### PR TITLE
test(ix-optick-sae): partition contract test against canonical baseline

### DIFF
--- a/crates/ix-optick-sae/tests/fixtures/canonical-partitions.json
+++ b/crates/ix-optick-sae/tests/fixtures/canonical-partitions.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Canonical Phase 1 partition snapshot, mirrored from GA's state/quality/optick-sae/<date>/optick-sae-artifact.json (latest dated directory). This is a deliberate point-in-time snapshot, NOT a live mirror — the contract test asserts ix-optick-sae's PHASE1_PARTITIONS matches this list. When this list legitimately needs to change, coordinate the producer constant + this fixture + GA's canonical artifact in one PR. Refusing to update both producer and fixture is the bug class PR #82 + ix #29 hit.",
+  "_source": "ga/state/quality/optick-sae/<date>/optick-sae-artifact.json",
+  "_optick_k_schema_version": "OPTIC-K-v1.8",
+  "partitions_used": ["STRUCTURE", "MORPHOLOGY", "CONTEXT", "SYMBOLIC", "MODAL", "ROOT"],
+  "compact_training_dim": 124
+}

--- a/crates/ix-optick-sae/tests/partition_contract.rs
+++ b/crates/ix-optick-sae/tests/partition_contract.rs
@@ -1,0 +1,86 @@
+//! Producer/consumer schema-contract test for the OPTIC-K Phase 1 partition list.
+//!
+//! Background: PR #82 (GA) shipped an SAE artifact whose `partitions_used` was
+//! missing the ROOT partition. ix #29 then nearly repeated the same omission
+//! in the Rust producer. Same bug class, two occurrences in one week. The
+//! prevention prose lives at
+//! `ga/docs/solutions/integration-issues/optick-sae-phase1-partition-and-python-bin-2026-05-05.md` —
+//! this file is the actual mechanical guard.
+//!
+//! When this test fails, treat it as a one-way-door alarm: the producer's
+//! `PHASE1_PARTITIONS` constant has drifted from the canonical baseline. Either
+//! the constant is wrong (most common — fix the constant) or the canonical
+//! baseline legitimately changed (rare — coordinate the change with GA's
+//! `state/quality/optick-sae/<date>/optick-sae-artifact.json` and refresh the
+//! `tests/fixtures/canonical-partitions.json` snapshot in the SAME PR).
+//!
+//! The fixture is a deliberately tiny mirror of GA's canonical artifact, not
+//! the whole thing — the test only needs the partition list and the compact
+//! training dim to fail loud on drift. Vendoring is preferred over fetching
+//! from GA at test time so this test runs offline and on every CI runner.
+
+use ix_optick_sae::PHASE1_PARTITIONS;
+use serde::Deserialize;
+
+/// Slimmed mirror of the consumer-side artifact contract.
+#[derive(Deserialize)]
+struct CanonicalSnapshot {
+    partitions_used: Vec<String>,
+    compact_training_dim: u32,
+}
+
+const CANONICAL_FIXTURE: &str = include_str!("fixtures/canonical-partitions.json");
+
+#[test]
+fn phase1_partitions_match_canonical_baseline() {
+    let canonical: CanonicalSnapshot = serde_json::from_str(CANONICAL_FIXTURE)
+        .expect("canonical-partitions.json failed to parse — the fixture is corrupt");
+
+    let producer: Vec<String> = PHASE1_PARTITIONS.iter().map(|s| s.to_string()).collect();
+
+    assert_eq!(
+        producer, canonical.partitions_used,
+        "\n\
+         PHASE1_PARTITIONS in src/lib.rs has drifted from the canonical baseline.\n\
+         \n\
+           producer (src/lib.rs):  {:?}\n\
+           canonical (fixture):    {:?}\n\
+         \n\
+         If the producer is wrong, fix the constant.\n\
+         If the canonical baseline legitimately changed (rare — re-indexing cost is high),\n\
+         coordinate the change with GA's state/quality/optick-sae/<date>/optick-sae-artifact.json\n\
+         AND refresh tests/fixtures/canonical-partitions.json in the same PR.\n\
+         \n\
+         This drift is the bug class PR #82 (GA) and ix #29 hit (ROOT missed twice).\n",
+        producer, canonical.partitions_used,
+    );
+}
+
+#[test]
+fn compact_training_dim_matches_canonical_baseline() {
+    let canonical: CanonicalSnapshot = serde_json::from_str(CANONICAL_FIXTURE)
+        .expect("canonical-partitions.json failed to parse");
+
+    // The OPTIC-K v1.8 partition widths (from
+    // ga/Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs SimilarityPartitions):
+    //   STRUCTURE   = 24
+    //   MORPHOLOGY  = 24
+    //   CONTEXT     = 12
+    //   SYMBOLIC    = 12
+    //   MODAL       = 40
+    //   ROOT        = 12
+    // Sum = 124.
+    //
+    // We don't have the widths as constants in this crate yet (they live in the
+    // Python trainer + GA C# schema). Hardcoding the canonical sum here and
+    // asserting against the fixture catches a drift in either direction —
+    // partition list shrinks/grows OR the canonical fixture forgets to update.
+    const EXPECTED_COMPACT_DIM: u32 = 124;
+    assert_eq!(
+        canonical.compact_training_dim, EXPECTED_COMPACT_DIM,
+        "Canonical fixture's compact_training_dim ({}) drifted from the OPTIC-K v1.8 \
+         similarity-partition sum ({}). If partition widths legitimately changed, update \
+         this constant AND ga's EmbeddingSchema.cs in the same PR.",
+        canonical.compact_training_dim, EXPECTED_COMPACT_DIM,
+    );
+}


### PR DESCRIPTION
## Summary

Turns the prevention prose from yesterday's learning doc into actual test code. Closes the bug class that hit twice in one week.

## The bug class

- **GA PR #82** shipped an SAE artifact whose `partitions_used` was missing the ROOT partition (the v1.8 one-way-door addition that closes the T-invariance gap)
- **ix #29** then nearly repeated the same omission in the Rust producer; caught and fixed pre-merge

Both shipped past local `cargo test` because the existing 7 unit tests only validated structural shape — they never asserted the producer constant equals the canonical baseline.

## What this PR adds

- `tests/fixtures/canonical-partitions.json` — slimmed mirror of GA's canonical artifact (just `partitions_used` + `compact_training_dim`), vendored so the test runs offline on every CI runner without a cross-repo fetch
- `tests/partition_contract.rs` — two assertions:
  1. `PHASE1_PARTITIONS` in `src/lib.rs` matches the canonical 6-entry list `[STRUCTURE, MORPHOLOGY, CONTEXT, SYMBOLIC, MODAL, ROOT]`
  2. `compact_training_dim` equals 124 (sum of OPTIC-K v1.8 similarity-partition widths)

When a drift is detected, the assert message names the recurrence pattern (PR #82, ix #29 — ROOT missed twice) and instructs to coordinate a producer + fixture + GA artifact change in the same PR.

## Why this is the right test

The existing 7 unit tests are structural shape checks (does it serialize, do guardrails fire, etc.). None assert the actual VALUE of the partition list. This PR adds the missing equality check — the simplest possible mechanical guard against silent schema drift.

The fixture is intentionally tiny (2 fields). It is **not** the whole artifact — it's the minimum that has to stay in sync with GA. Vendoring beats fetching: the test runs offline, every machine sees the same canonical, and a change to the canonical artifact requires an explicit PR-side update to both repos.

## Test plan

- [x] 2/2 new tests pass locally
- [x] Full ix-optick-sae suite: 9/9 pass (7 existing + 2 new)
- [x] \`cargo clippy -p ix-optick-sae --tests -- -D warnings\` clean
- [ ] CI confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)