### PR TITLE
chore(federation): register hari MCP peer

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -23,6 +23,11 @@
     "sentrux": {
       "command": "C:/Users/spare/bin/sentrux.exe",
       "args": ["mcp"]
+    },
+    "hari": {
+      "command": "C:/Users/spare/source/repos/hari/target/release/hari-mcp.exe",
+      "args": [],
+      "env": { "HARI_STATE_DIR": "C:/Users/spare/source/repos/hari/state/harness" }
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ MSRV: Rust 1.80+ (due to wgpu 28).
 
 ## MCP Federation
 
-MCP peers in `.mcp.json`: **ix** (Rust, algorithms + governance), **tars** (F#, grammar + metacognition), **ga** (C#, music theory), **sentrux** (Rust, realtime structural-quality sensor). Capability registry: `governance/demerzel/schemas/capability-registry.json`.
+MCP peers in `.mcp.json`: **ix** (Rust, algorithms + governance), **tars** (F#, grammar + metacognition), **ga** (C#, music theory), **sentrux** (Rust, realtime structural-quality sensor), **hari** (Rust, belief-state substrate — batch tools `hari_query_belief` / `hari_snapshot` / `hari_diff` / `hari_record_observation` / `hari_consensus` plus live Phase-6 multiplexer `hari_session_open` / `hari_session_event` / `hari_session_close`). Capability registry: `governance/demerzel/schemas/capability-registry.json`.
 
 **Realtime vs offline code analysis boundary.** Sentrux owns *realtime* structural quality (live treemap, regression gate, file-watcher feedback for in-progress agent edits). The `ix-code-*` crates own *offline* catalog work (large-corpus AST analysis, code-smell mining, code catalog snapshots that feed governance reports). When in doubt: if it's "what changed in the last 30 seconds," call sentrux; if it's "snapshot the whole codebase for the daily quality trend," use `ix-code-analyze`.
 


### PR DESCRIPTION
## Summary

Adds the **hari** MCP server to ix's `.mcp.json` federation, alongside ix / tars / ga / sentrux.

Hari ships 8 tools over stdio JSON-RPC 2.0:
- **Batch:** `hari_query_belief`, `hari_snapshot`, `hari_diff`, `hari_record_observation`, `hari_consensus`
- **Live (Phase-6 multiplexer):** `hari_session_open`, `hari_session_event`, `hari_session_close`

The corresponding binary ships in [GuitarAlchemist/hari PR #1](https://github.com/GuitarAlchemist/hari/pull/1) (\`feat/hari-extractor-mercury-2026-05-13\`). Pattern doc: [`docs/loops/hari-federation.md`](https://github.com/GuitarAlchemist/hari/blob/feat/hari-extractor-mercury-2026-05-13/docs/loops/hari-federation.md) in that repo.

The federation entry uses a Windows-specific path matching the existing convention for `ix`, `sentrux`, `ga` etc. in the same file. The `HARI_STATE_DIR` env var points at the harness state directory so any federation peer reads/writes the same belief state as offline batch runs.

## Test plan

- [ ] hari PR #1 is built locally: `cargo build -p hari-mcp --release` from the hari workspace
- [ ] Restart Claude Code and confirm `hari_*` tools appear in `tools/list`
- [ ] Call `hari_snapshot` from any federation peer to confirm the wire works

🤖 Generated with [Claude Code](https://claude.com/claude-code)