### PR TITLE
feat(quality): schema-pin sidecar for state/quality/** + quality-snapshots

### DIFF
--- a/state/quality/_schema.json
+++ b/state/quality/_schema.json
@@ -1,0 +1,16 @@
+{
+  "$comment": "Schema pin declaration for state/quality/** and state/quality-snapshots/** artifacts in ix. Phase 0 deliverable #5 of ga/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md.",
+  "schema_version": 1,
+  "applies_to_path": "state/quality/**",
+  "pins": {
+    "OPTIC-K": "v1.8",
+    "rust": "1.80+",
+    "ix_optick_sae_artifact_schema": "ga/docs/contracts/optick-sae-artifact.schema.json (vendored upstream)",
+    "qa_verdict_schema": "ga/docs/contracts/qa-verdict.schema.json (vendored upstream)"
+  },
+  "policy": {
+    "scope": "Quality artifacts produced AFTER this file's git introduction are considered pinned to these versions. Dated daily snapshots under state/quality-snapshots/ pre-dating this file are implicitly draft/v0.",
+    "bump_rule": "On OPTIC-K version bump (e.g. v1.8 -> v1.9), this file MUST be updated before consumers (ga RAG layer, Demerzel tribunal) re-tune against new artifacts. Cascade invalidation via per-domain .lock + manual rebaselining.",
+    "owner": "ix maintainer + cross-repo coordinator (Demerzel tribunal)"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 deliverable #5 of [ga v2 plan](https://github.com/GuitarAlchemist/ga/blob/main/docs/plans/2026-05-14-arch-cherny-adoption-and-tribunal-ci-plan-v2.md). Closes silent-baseline-invalidation gap from the 2026-05-14 octo brainstorm.

## What ships

One file: `state/quality/_schema.json` pinning:

| Pin | Value |
|---|---|
| OPTIC-K | v1.8 — ix is the **canonical OPTIC-K producer**; bumping invalidates baselines in ga / Demerzel / tars |
| rust | 1.80+ (MSRV — wgpu 28) |
| ix_optick_sae_artifact_schema | vendored from ga/docs/contracts/ |
| qa_verdict_schema | vendored from ga/docs/contracts/ |

## Why sidecar (not per-file)

`state/quality-snapshots/chatbot-qa/` accumulates daily snapshots (28+ files since 2026-04-12). Editing each would be churn-heavy and unnecessary — sidecar applies the pin set to everything in the tree.

## Companion PRs

- [ga#212](https://github.com/GuitarAlchemist/ga/pull/212)
- Demerzel — sidecar at `state/quality-trend/_schema.json` (canonical coordinator role)
- tars — sidecar at `v2/baselines/_schema.json` (per-model overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)