### PR TITLE
ci: add Agent Blackbox risk report

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -1,0 +1,97 @@
+name: Agent Blackbox
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  checks: write
+
+env:
+  VERIFY_COMMAND: "cargo test --workspace"
+
+jobs:
+  risk-report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Checkout Agent Blackbox
+        uses: actions/checkout@v4
+        with:
+          repository: GuitarAlchemist/agent-blackbox
+          path: .agent-blackbox
+          token: ${{ secrets.AGENT_BLACKBOX_TOKEN || github.token }}
+
+      - name: Collect PR evidence
+        shell: bash
+        run: |
+          mkdir -p dist
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/changed-files.txt
+          git diff "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > dist/diff.patch
+          set +e
+          bash -lc "$VERIFY_COMMAND" > dist/test-output.txt 2>&1
+          verify_exit=$?
+          set -e
+          echo "verify_exit=$verify_exit" >> "$GITHUB_ENV"
+          echo "verify command exited with code $verify_exit" >> dist/test-output.txt
+          cat dist/test-output.txt
+
+      - name: Generate risk report
+        shell: bash
+        run: |
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox analyze \
+            --policy agent-blackbox.policy.json \
+            --changed-files dist/changed-files.txt \
+            --diff dist/diff.patch \
+            --test-output dist/test-output.txt \
+            --out-dir dist
+
+      - name: Comment risk report
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- agent-blackbox-risk-report -->';
+            const body = marker + '\n' + fs.readFileSync('dist/risk-report.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.data.find(comment =>
+              comment.user.type === 'Bot' && comment.body && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Upload risk artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-blackbox-risk-report
+          path: dist/
+
+      - name: Enforce verdict
+        shell: bash
+        env:
+          AGENT_BLACKBOX_REVIEWED: ${{ contains(github.event.pull_request.labels.*.name, 'agent-blackbox-reviewed') }}
+        run: |
+          if [ "$AGENT_BLACKBOX_REVIEWED" = "true" ]; then
+            echo "Agent Blackbox human-review override label present; skipping hard enforcement."
+            exit 0
+          fi
+          PYTHONPATH=.agent-blackbox python -m cli.agent_blackbox enforce --report dist/risk-report.json

--- a/agent-blackbox.policy.json
+++ b/agent-blackbox.policy.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.1.0",
+  "risk_thresholds": {
+    "pass": 0.25,
+    "warn": 0.6
+  },
+  "blocked_paths": [
+    ".github/workflows/**",
+    "infra/production/**",
+    "billing/**",
+    "legal/**",
+    "security/**",
+    "Cargo.lock",
+    "rust-toolchain.toml"
+  ],
+  "one_way_door_paths": [
+    "schemas/**",
+    "contracts/**",
+    "migrations/**",
+    "Cargo.toml",
+    "**/build.rs"
+  ],
+  "required_evidence": [
+    "changed_files",
+    "test_output",
+    "risk_report"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Agent Blackbox PR risk-report workflow
- add IX Rust policy with workflow and lockfile guarded paths
- run cargo test --workspace as the verification evidence command

## Verification
- git diff --cached --check
- local Agent Blackbox smoke test rendered risk-report.json and risk-report.md with PR Review Summary

Note: this bootstrap PR intentionally changes .github/workflows/**, so Agent Blackbox should report a fail verdict until the agent-blackbox-reviewed override label is applied after report review.