### PR TITLE
feat(stable-surface): enforce Stable-tier API contract in CI

### DIFF
--- a/.github/workflows/stable-surface.yml
+++ b/.github/workflows/stable-surface.yml
@@ -1,0 +1,209 @@
+name: Stable Surface Guard
+
+# Enforces the maturity-tier "Stable" contract: any change to the public API
+# of a Stable-tier crate must be accompanied by either (a) a demotion in
+# `crate-maturity.toml` or (b) a major version bump on the crate.
+#
+# Source of truth: `crate-maturity.toml` (workspace root).
+# Implementation: `ix stable-surface --format=json` (in crates/ix-skill).
+# Policy doc: README.md "Stability contract" section.
+
+on:
+  pull_request:
+    branches: [main]
+    # Trigger on any change — we always want to know if a Stable API moved.
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  diff:
+    name: diff Stable public-API hashes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: pr
+
+      - name: Checkout base (main)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          submodules: recursive
+          path: base
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            pr
+            base
+
+      - name: Build ix-skill on PR
+        working-directory: pr
+        run: cargo build -p ix-skill --bin ix --release
+
+      - name: Build ix-skill on base
+        working-directory: base
+        # Tolerate base lacking the verb (first introduction); fall back to
+        # the PR binary running against the base workspace tree.
+        run: cargo build -p ix-skill --bin ix --release || echo "base has no ix-skill stable-surface verb yet — will use PR binary"
+
+      - name: Capture PR report
+        working-directory: pr
+        run: ./target/release/ix stable-surface --format=json > ../pr-report.json
+
+      - name: Capture base report
+        # Prefer the base's own binary; if missing, run the PR binary against
+        # the base workspace. Either way, we get a comparable report.
+        run: |
+          set -euo pipefail
+          if [ -x base/target/release/ix ]; then
+            (cd base && ./target/release/ix stable-surface --format=json) > base-report.json
+          else
+            echo "Using PR binary against base tree (first-run bootstrap)."
+            IX_ROOT="$PWD/base" pr/target/release/ix stable-surface --format=json > base-report.json
+          fi
+
+      - name: Diff & enforce
+        id: diff
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Build a name -> {tier, hash} map for each side via jq.
+          jq -r '.crates[] | "\(.name)\t\(.tier)\t\(.api_hash)"' base-report.json | sort > base.tsv
+          jq -r '.crates[] | "\(.name)\t\(.tier)\t\(.api_hash)"' pr-report.json   | sort > pr.tsv
+
+          echo "::group::Base report"
+          cat base.tsv
+          echo "::endgroup::"
+          echo "::group::PR report"
+          cat pr.tsv
+          echo "::endgroup::"
+
+          declare -A BASE_TIER BASE_HASH PR_TIER PR_HASH
+
+          while IFS=$'\t' read -r name tier hash; do
+            [ -n "$name" ] || continue
+            BASE_TIER["$name"]="$tier"
+            BASE_HASH["$name"]="$hash"
+          done < base.tsv
+
+          while IFS=$'\t' read -r name tier hash; do
+            [ -n "$name" ] || continue
+            PR_TIER["$name"]="$tier"
+            PR_HASH["$name"]="$hash"
+          done < pr.tsv
+
+          STABLE_CHANGED=()
+          OTHER_CHANGED=()
+          ADDED=()
+          REMOVED=()
+
+          # All crate names across both sides.
+          ALL_NAMES=$(printf "%s\n" "${!BASE_HASH[@]}" "${!PR_HASH[@]}" | sort -u)
+          while IFS= read -r name; do
+            [ -n "$name" ] || continue
+            b_h="${BASE_HASH[$name]:-}"
+            p_h="${PR_HASH[$name]:-}"
+            b_t="${BASE_TIER[$name]:-}"
+            p_t="${PR_TIER[$name]:-}"
+            if [ -z "$b_h" ]; then
+              ADDED+=("$name (tier=$p_t)")
+              continue
+            fi
+            if [ -z "$p_h" ]; then
+              REMOVED+=("$name (was tier=$b_t)")
+              continue
+            fi
+            if [ "$b_h" != "$p_h" ]; then
+              if [ "$b_t" = "stable" ] || [ "$p_t" = "stable" ]; then
+                STABLE_CHANGED+=("$name | tier: $b_t->$p_t | hash: ${b_h}->${p_h}")
+              else
+                OTHER_CHANGED+=("$name | tier: $b_t->$p_t | hash: ${b_h}->${p_h}")
+              fi
+            fi
+          done <<< "$ALL_NAMES"
+
+          echo ""
+          echo "## Stable Surface Diff"
+          echo ""
+          if [ "${#STABLE_CHANGED[@]}" -gt 0 ]; then
+            echo "::error::Stable-tier public API change(s) detected:"
+            for c in "${STABLE_CHANGED[@]}"; do
+              echo "::error::  $c"
+            done
+          fi
+          if [ "${#OTHER_CHANGED[@]}" -gt 0 ]; then
+            echo "Non-stable hash changes (warn only):"
+            for c in "${OTHER_CHANGED[@]}"; do
+              echo "::warning::  $c"
+            done
+          fi
+          if [ "${#ADDED[@]}" -gt 0 ]; then
+            echo "New crates in maturity table:"
+            for c in "${ADDED[@]}"; do
+              echo "  + $c"
+            done
+          fi
+          if [ "${#REMOVED[@]}" -gt 0 ]; then
+            echo "Crates removed from maturity table:"
+            for c in "${REMOVED[@]}"; do
+              echo "  - $c"
+            done
+          fi
+
+          # Persist outputs for the summary step.
+          {
+            echo "stable_count=${#STABLE_CHANGED[@]}"
+            echo "other_count=${#OTHER_CHANGED[@]}"
+            echo "added_count=${#ADDED[@]}"
+            echo "removed_count=${#REMOVED[@]}"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "${#STABLE_CHANGED[@]}" -gt 0 ]; then
+            echo ""
+            echo "Public API of one or more Stable-tier crates changed."
+            echo ""
+            echo "Required action — either:"
+            echo "  (a) Demote the affected crate to 'beta' in crate-maturity.toml IN THIS SAME PR, or"
+            echo "  (b) Bump the crate's MAJOR version in its Cargo.toml."
+            echo ""
+            echo "See README.md \"Stability contract\" for the full policy."
+            exit 1
+          fi
+
+      - name: Job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "# Stable Surface Guard"
+            echo ""
+            echo "| Category | Count |"
+            echo "|---|---|"
+            echo "| Stable-tier changed (fails CI) | ${{ steps.diff.outputs.stable_count }} |"
+            echo "| Non-stable changed (warn only) | ${{ steps.diff.outputs.other_count }} |"
+            echo "| Crates added | ${{ steps.diff.outputs.added_count }} |"
+            echo "| Crates removed | ${{ steps.diff.outputs.removed_count }} |"
+            echo ""
+            echo "## Stable subset hashes (PR branch)"
+            echo ""
+            echo '```'
+            jq -r '.crates[] | select(.tier == "stable") | "\(.name)\t\(.api_hash)\t(\(.decl_count) pub decls)"' pr-report.json
+            echo '```'
+            echo ""
+            echo "See \`crate-maturity.toml\` for the source of truth."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/stable-surface.yml
+++ b/.github/workflows/stable-surface.yml
@@ -65,14 +65,26 @@ jobs:
         run: ./target/release/ix stable-surface --format=json > ../pr-report.json
 
       - name: Capture base report
-        # Prefer the base's own binary; if missing, run the PR binary against
-        # the base workspace. Either way, we get a comparable report.
+        # Prefer the base's own binary; if it lacks the subcommand (first-run
+        # bootstrap: this PR is what introduces the verb), fall back to the
+        # PR binary run against the base workspace tree.
         run: |
           set -euo pipefail
+          base_has_verb=0
           if [ -x base/target/release/ix ]; then
+            if base/target/release/ix stable-surface --help >/dev/null 2>&1; then
+              base_has_verb=1
+            fi
+          fi
+          if [ "$base_has_verb" = "1" ]; then
             (cd base && ./target/release/ix stable-surface --format=json) > base-report.json
           else
-            echo "Using PR binary against base tree (first-run bootstrap)."
+            echo "Base binary lacks 'stable-surface' subcommand — running PR binary against base tree (first-run bootstrap)."
+            # crate-maturity.toml might not exist on base either; copy it from
+            # the PR tree so the PR binary can locate it under IX_ROOT=base.
+            if [ ! -f base/crate-maturity.toml ]; then
+              cp pr/crate-maturity.toml base/crate-maturity.toml
+            fi
             IX_ROOT="$PWD/base" pr/target/release/ix stable-surface --format=json > base-report.json
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ this project uses workspace-unified semver (all crates share one version).
 
 ## [Unreleased]
 
+### Added — Stable Surface guard (2026-05-17)
+
+- `crate-maturity.toml` workspace-root file: single source of truth mapping
+  every crate to one of `stable` / `beta` / `experimental` / `internal`.
+- `ix stable-surface` CLI subcommand: prints each Stable crate's public-API
+  hash (BLAKE3 over sorted `pub` declarations). `--all-tiers` includes the
+  rest. JSON output is the wire format for CI.
+- `.github/workflows/stable-surface.yml`: diffs the report between `main`
+  and the PR. Stable hash changes → fail. Non-stable hash changes → warn.
+- README "Stability contract" section documenting the demotion escape
+  hatch.
+- Unit tests in `ix-skill::verbs::stable_surface::tests` cover pub-line
+  extraction, internal-vs-external change detection, and the diff
+  partitioning across tiers (4 tests, all green).
+
 ### Added — Phase 1 delivery (Weeks 1–8)
 
 **New foundation crates**

--- a/README.md
+++ b/README.md
@@ -52,6 +52,43 @@ cargo run -p ix-agent
 | ix-game | Stable | Nash, Shapley, auctions, mechanism design — promoted 2026-05-02 |
 | ix-rl | Stable | Bandits (EpsilonGreedy, UCB1, Thompson), Q-learning — promoted 2026-05-02 |
 
+### Stability contract
+
+"Stable" is not just documentation — **CI prevents silent breakage**. The
+[`stable-surface.yml`](.github/workflows/stable-surface.yml) workflow runs on
+every PR: it hashes the public-API surface of each Stable-tier crate on
+`main`, then again on the PR branch, and **fails** the check if any hash
+changed. Non-stable crates produce a warning only.
+
+Source of truth: [`crate-maturity.toml`](crate-maturity.toml) at the workspace
+root. The CLI subcommand `ix stable-surface` is the reference implementation
+used by CI and is runnable locally:
+
+```bash
+cargo run -p ix-skill -- stable-surface --format=json
+```
+
+The hash is a BLAKE3 over the sorted, deduplicated set of `pub` declarations
+discovered in each crate's `src/**.rs`. It catches **added / removed /
+renamed exported symbols** — enough to stop accidental breaks. It does NOT
+catch finer-grained changes (function signature edits, trait-bound
+additions, variance shifts). Those are out of scope for v1; revisit with
+`cargo public-api` integration when a real break slips through.
+
+**To intentionally break a Stable API**, do one of the following in the
+SAME PR that introduces the change:
+
+1. **Demote the crate** to `beta` in `crate-maturity.toml`. The guard then
+   downgrades the diff to a warning. Document the demotion in the PR body.
+2. **Bump the crate's major version** in its `Cargo.toml`. (v1 of this
+   guard still flags the hash change — bumping the major version is the
+   semver-correct signal to downstream consumers, but the guard does not
+   yet auto-detect it. Use the demotion path for the CI to go green, then
+   restore the tier in a follow-up release PR.)
+
+The current 12 Stable crates (see table above) cover the safe-to-consume
+subset for `ga`, `tars`, `Demerzel`, and `agent-blackbox`.
+
 ### Beta Crates
 
 | Crate | Tier | Notes |

--- a/crate-maturity.toml
+++ b/crate-maturity.toml
@@ -1,0 +1,91 @@
+# Crate maturity source of truth for the ix workspace.
+#
+# Tiers (see README.md "Crate Maturity & Stability" for full definitions):
+#   - "stable"        — API commitments, CI prevents silent breakage
+#   - "beta"          — Feature-complete, API may change between minor versions
+#   - "experimental"  — Research-grade, no stability guarantees
+#   - "internal"      — Tooling/infra, not intended for direct external use
+#
+# Adding a new crate: add it here. CI's `stable-surface` check reads this file
+# to know which crates are guarded.
+#
+# Demoting a crate from "stable" requires updating this file in the SAME PR
+# that breaks the public API. See README.md "Stability contract" for the flow.
+
+[crates]
+# --- Stable tier (12 crates, guarded by CI) -----------------------------
+ix-math          = "stable"
+ix-optimize      = "stable"
+ix-supervised    = "stable"
+ix-ensemble      = "stable"
+ix-unsupervised  = "stable"
+ix-search        = "stable"
+ix-graph         = "stable"
+ix-signal        = "stable"
+ix-cache         = "stable"
+ix-probabilistic = "stable"
+ix-game          = "stable"
+ix-rl            = "stable"
+
+# --- Beta tier ----------------------------------------------------------
+ix-nn          = "beta"
+ix-pipeline    = "beta"
+ix-agent       = "beta"
+ix-governance  = "beta"
+ix-io          = "beta"
+ix-grammar     = "beta"
+ix-catalog-core = "beta"
+ix-net         = "beta"
+
+# --- Experimental tier --------------------------------------------------
+ix-evolution      = "experimental"
+ix-chaos          = "experimental"
+ix-adversarial    = "experimental"
+ix-dynamics       = "experimental"
+ix-topo           = "experimental"
+ix-ktheory        = "experimental"
+ix-category       = "experimental"
+ix-rotation       = "experimental"
+ix-sedenion       = "experimental"
+ix-fractal        = "experimental"
+ix-number-theory  = "experimental"
+ix-gpu            = "experimental"
+memristive-markov = "experimental"
+
+# --- Internal tier ------------------------------------------------------
+ix-skill                  = "internal"
+ix-skill-macros           = "internal"
+ix-demo                   = "internal"
+ix-dashboard              = "internal"
+ix-registry               = "internal"
+ix-code                   = "internal"
+ix-types                  = "internal"
+ix-agent-core             = "internal"
+ix-approval               = "internal"
+ix-autograd               = "internal"
+ix-context                = "internal"
+ix-fuzzy                  = "internal"
+ix-harness-cargo          = "internal"
+ix-harness-clippy         = "internal"
+ix-harness-ga             = "internal"
+ix-harness-github-actions = "internal"
+ix-harness-signing        = "internal"
+ix-harness-tars           = "internal"
+ix-loop-detect            = "internal"
+ix-memory                 = "internal"
+ix-registry-check         = "internal"
+ix-sentinel               = "internal"
+ix-session                = "internal"
+ix-manifold               = "internal"
+ix-sanitize               = "internal"
+ix-voicings               = "internal"
+ix-optick                 = "internal"
+ix-optick-invariants      = "internal"
+ix-optick-sae             = "internal"
+ix-embedding-diagnostics  = "internal"
+ix-quality-trend          = "internal"
+ix-invariant-coverage     = "internal"
+ix-bracelet               = "internal"
+ga-chatbot                = "internal"
+ix-autoresearch           = "internal"
+ix-blast-radius           = "internal"

--- a/crates/ix-skill/Cargo.toml
+++ b/crates/ix-skill/Cargo.toml
@@ -43,6 +43,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 
+# stable-surface verb: parse crate-maturity.toml and hash the public API.
+toml = "0.8"
+blake3 = { workspace = true }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"
+tempfile = { workspace = true }

--- a/crates/ix-skill/src/main.rs
+++ b/crates/ix-skill/src/main.rs
@@ -97,6 +97,18 @@ enum Verb {
         #[command(subcommand)]
         noun: ServeNoun,
     },
+
+    /// Print the maturity-tier "Stable" crates with a public-API hash each.
+    ///
+    /// CI uses this on `main` and on PR branches and fails the PR if a
+    /// Stable crate's hash changed without an explicit demotion. See
+    /// `crate-maturity.toml` for the source of truth and the README's
+    /// "Stability contract" section for the policy.
+    StableSurface {
+        /// Include non-Stable crates in the report (default: Stable only).
+        #[arg(long)]
+        all_tiers: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -329,6 +341,8 @@ fn dispatch(cli: Cli) -> i32 {
             eprintln!("{msg}");
             exit::UNKNOWN
         }
+
+        Verb::StableSurface { all_tiers } => try_or(verbs::stable_surface::run(fmt, all_tiers)),
     }
 }
 

--- a/crates/ix-skill/src/verbs/mod.rs
+++ b/crates/ix-skill/src/verbs/mod.rs
@@ -7,3 +7,4 @@ pub mod describe;
 pub mod list;
 pub mod pipeline;
 pub mod run;
+pub mod stable_surface;

--- a/crates/ix-skill/src/verbs/stable_surface.rs
+++ b/crates/ix-skill/src/verbs/stable_surface.rs
@@ -1,0 +1,437 @@
+//! `ix stable-surface` — print the maturity-tier Stable crates and a
+//! deterministic hash of each crate's public API surface.
+//!
+//! ## Source of truth
+//!
+//! Crate maturity is read from `crate-maturity.toml` at the workspace root.
+//! Locate the workspace by walking up from `IX_ROOT` (or CWD) until we find
+//! that file.
+//!
+//! ## API hash
+//!
+//! We hash the **sorted, deduplicated set of public declarations** found by
+//! scanning all `.rs` files under `crates/<crate>/src/`. A "public
+//! declaration" is a non-blank, non-comment line whose first non-whitespace
+//! token starts with `pub ` or `pub(crate)` (the latter is intentionally
+//! excluded — only true `pub` items, plus `pub use` re-exports, count).
+//!
+//! This is intentionally simple: it catches added / removed / renamed
+//! exported symbols, which is exactly the scope this guard cares about
+//! (per the PR brief). It does NOT catch:
+//!   - changes to function signatures (param types, return type)
+//!   - changes to struct field types
+//!   - trait bound additions / removals
+//!   - variance changes
+//!
+//! Those finer-grained checks are out of scope for v1. The escape hatch
+//! when a real breaking change ships is: demote the crate to "beta" in
+//! `crate-maturity.toml` in the same PR (which silences the warn-only
+//! guard for that crate).
+//!
+//! ## Determinism
+//!
+//! We sort the per-file lines, deduplicate them, then hash with BLAKE3.
+//! Whitespace inside each captured line is preserved verbatim (renaming a
+//! function changes the line). Comments and blank lines are skipped.
+
+use crate::output::{self, Format};
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Locate the workspace root by walking up from `start` until we find a
+/// directory containing `crate-maturity.toml`.
+pub fn locate_workspace_root() -> Result<PathBuf, String> {
+    if let Ok(env_root) = std::env::var("IX_ROOT") {
+        let p = PathBuf::from(env_root);
+        if p.join("crate-maturity.toml").is_file() {
+            return Ok(p);
+        }
+    }
+    let mut cur = std::env::current_dir().map_err(|e| format!("cwd: {e}"))?;
+    loop {
+        if cur.join("crate-maturity.toml").is_file() {
+            return Ok(cur);
+        }
+        if !cur.pop() {
+            return Err("crate-maturity.toml not found in any parent directory".into());
+        }
+    }
+}
+
+/// Parse `crate-maturity.toml` into a name→tier map.
+pub fn load_maturity(root: &Path) -> Result<BTreeMap<String, String>, String> {
+    let path = root.join("crate-maturity.toml");
+    let body = fs::read_to_string(&path)
+        .map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let parsed: toml::Value = toml::from_str(&body)
+        .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    let crates = parsed
+        .get("crates")
+        .and_then(|v| v.as_table())
+        .ok_or_else(|| "missing [crates] table".to_string())?;
+    let mut out = BTreeMap::new();
+    for (k, v) in crates {
+        let tier = v
+            .as_str()
+            .ok_or_else(|| format!("crate `{k}` tier must be a string"))?;
+        out.insert(k.clone(), tier.to_string());
+    }
+    Ok(out)
+}
+
+/// Extract the set of public-API declarations from a single `.rs` file.
+///
+/// A "public declaration" is a line whose first non-whitespace token starts
+/// with `pub ` or `pub(`-something-other-than-`crate`/`super`/`self`. We
+/// preserve the line verbatim so renaming a function changes the captured
+/// string. Doc-comments and `//` comments are skipped.
+fn extract_pub_lines(source: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for raw in source.lines() {
+        let trimmed = raw.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with("//") {
+            continue;
+        }
+        // Match `pub ` and `pub(<vis>) ` where <vis> != crate|super|self.
+        // Strip any leading attribute marker `#[...]` continuation by just
+        // requiring the line itself to start with `pub`.
+        if let Some(rest) = trimmed.strip_prefix("pub") {
+            // Next character determines whether this is a public item.
+            let c = rest.chars().next();
+            match c {
+                Some(' ') | Some('\t') => out.push(trimmed.to_string()),
+                Some('(') => {
+                    // pub(crate), pub(super), pub(self) → not public surface.
+                    // pub(in path) → also not the unqualified public surface.
+                    // The only "true" public form with parens is pub itself,
+                    // which never has parens. So skip all `pub(...)` forms.
+                    let after = &rest[1..];
+                    let restricted = after.starts_with("crate")
+                        || after.starts_with("super")
+                        || after.starts_with("self")
+                        || after.starts_with("in ");
+                    if !restricted {
+                        // Unknown form — be conservative and include it.
+                        out.push(trimmed.to_string());
+                    }
+                }
+                _ => {} // e.g. `pubfn` (identifier collision) — ignore
+            }
+        }
+    }
+    out
+}
+
+/// Walk a `crates/<name>/src/` tree, collecting all unique public-decl lines.
+fn collect_pub_decls(crate_src: &Path) -> Result<BTreeSet<String>, String> {
+    let mut decls = BTreeSet::new();
+    let mut stack = vec![crate_src.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = fs::read_dir(&dir)
+            .map_err(|e| format!("reading {}: {e}", dir.display()))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("entry in {}: {e}", dir.display()))?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .map_err(|e| format!("file_type of {}: {e}", path.display()))?;
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file()
+                && path.extension().and_then(|s| s.to_str()) == Some("rs")
+            {
+                let body = fs::read_to_string(&path)
+                    .map_err(|e| format!("reading {}: {e}", path.display()))?;
+                for line in extract_pub_lines(&body) {
+                    decls.insert(line);
+                }
+            }
+        }
+    }
+    Ok(decls)
+}
+
+/// Compute the BLAKE3 hash (hex, first 16 chars) of a crate's public surface.
+///
+/// Returns `(hash, decl_count)`. If the crate src dir is missing, returns
+/// `("missing", 0)` rather than failing — that's a real-world signal worth
+/// surfacing in the report instead of crashing.
+pub fn compute_api_hash(workspace_root: &Path, crate_name: &str) -> (String, usize) {
+    let src = workspace_root.join("crates").join(crate_name).join("src");
+    if !src.is_dir() {
+        return ("missing".into(), 0);
+    }
+    let decls = match collect_pub_decls(&src) {
+        Ok(d) => d,
+        Err(_) => return ("error".into(), 0),
+    };
+    let mut hasher = blake3::Hasher::new();
+    for line in &decls {
+        hasher.update(line.as_bytes());
+        hasher.update(b"\n");
+    }
+    let hash = hasher.finalize().to_hex();
+    // First 16 hex chars = 64 bits — plenty for change detection.
+    (hash.as_str()[..16].to_string(), decls.len())
+}
+
+/// Top-level entry point for the `stable-surface` subcommand.
+///
+/// Emits a JSON-or-table report:
+/// ```text
+/// {
+///   "schema_version": 1,
+///   "workspace_root": "<abs path>",
+///   "crates": [
+///     { "name": "ix-math", "tier": "stable", "api_hash": "deadbeef...", "decl_count": 123 },
+///     ...
+///   ]
+/// }
+/// ```
+pub fn run(format: Format, all_tiers: bool) -> Result<(), String> {
+    let root = locate_workspace_root()?;
+    let maturity = load_maturity(&root)?;
+
+    let mut rows: Vec<Value> = Vec::new();
+    for (name, tier) in &maturity {
+        if !all_tiers && tier != "stable" {
+            continue;
+        }
+        let (hash, count) = compute_api_hash(&root, name);
+        rows.push(json!({
+            "name": name,
+            "tier": tier,
+            "api_hash": hash,
+            "decl_count": count,
+        }));
+    }
+    rows.sort_by(|a, b| {
+        let an = a.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let bn = b.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        an.cmp(bn)
+    });
+
+    let payload = json!({
+        "schema_version": 1,
+        "workspace_root": root.to_string_lossy(),
+        "crates": rows,
+    });
+    output::emit(&payload, format).map_err(|e| format!("writing output: {e}"))?;
+    Ok(())
+}
+
+/// Diff two stable-surface reports. Used by the CI guard and by tests.
+///
+/// Returns a structured `DiffResult` listing crates whose hash changed,
+/// crates added, and crates removed — partitioned by tier (stable vs other).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffResult {
+    /// Stable-tier crates whose hash changed (these FAIL CI).
+    pub stable_changed: Vec<HashChange>,
+    /// Non-stable crates whose hash changed (these WARN only).
+    pub other_changed: Vec<HashChange>,
+    /// Crates present on PR but not on base.
+    pub added: Vec<String>,
+    /// Crates present on base but not on PR.
+    pub removed: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HashChange {
+    pub name: String,
+    pub tier_before: String,
+    pub tier_after: String,
+    pub hash_before: String,
+    pub hash_after: String,
+}
+
+/// Parse a JSON document produced by `ix stable-surface --format=json` into
+/// a name → (tier, hash) map.
+fn parse_report(doc: &Value) -> BTreeMap<String, (String, String)> {
+    let mut out = BTreeMap::new();
+    if let Some(arr) = doc.get("crates").and_then(|v| v.as_array()) {
+        for item in arr {
+            let name = item
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let tier = item
+                .get("tier")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let hash = item
+                .get("api_hash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if !name.is_empty() {
+                out.insert(name, (tier, hash));
+            }
+        }
+    }
+    out
+}
+
+/// Compute the diff between two stable-surface reports.
+///
+/// `base` is the report from `main`; `head` is the report from the PR.
+/// A crate is "stable_changed" if it is tier=stable in EITHER report and the
+/// hash differs.
+pub fn diff_reports(base: &Value, head: &Value) -> DiffResult {
+    let base_map = parse_report(base);
+    let head_map = parse_report(head);
+
+    let mut stable_changed = Vec::new();
+    let mut other_changed = Vec::new();
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+
+    let all_names: BTreeSet<&String> = base_map.keys().chain(head_map.keys()).collect();
+    for name in all_names {
+        match (base_map.get(name), head_map.get(name)) {
+            (None, Some(_)) => added.push(name.clone()),
+            (Some(_), None) => removed.push(name.clone()),
+            (Some((tb, hb)), Some((ta, ha))) => {
+                if hb != ha {
+                    let change = HashChange {
+                        name: name.clone(),
+                        tier_before: tb.clone(),
+                        tier_after: ta.clone(),
+                        hash_before: hb.clone(),
+                        hash_after: ha.clone(),
+                    };
+                    if tb == "stable" || ta == "stable" {
+                        stable_changed.push(change);
+                    } else {
+                        other_changed.push(change);
+                    }
+                }
+            }
+            (None, None) => unreachable!(),
+        }
+    }
+
+    DiffResult {
+        stable_changed,
+        other_changed,
+        added,
+        removed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_pub_lines_basic() {
+        let src = r#"
+//! doc comment
+// regular comment
+use std::collections::HashMap;
+
+pub fn foo() {}
+pub(crate) fn hidden() {}
+pub(super) fn also_hidden() {}
+pub struct Bar { pub field: u32, pub(crate) inner: u32 }
+pub use crate::baz::Quux;
+
+fn private() {}
+"#;
+        let lines = extract_pub_lines(src);
+        // Should capture: pub fn foo(), pub struct Bar..., pub use ...
+        // The pub field inside the struct is on the same line as `pub struct`
+        // so it's only captured once via the struct line.
+        assert!(lines.iter().any(|l| l.starts_with("pub fn foo")));
+        assert!(lines.iter().any(|l| l.starts_with("pub struct Bar")));
+        assert!(lines.iter().any(|l| l.starts_with("pub use crate::baz")));
+        assert!(!lines.iter().any(|l| l.starts_with("pub(crate) fn hidden")));
+        assert!(!lines.iter().any(|l| l.starts_with("pub(super) fn also_hidden")));
+        assert!(!lines.iter().any(|l| l.starts_with("fn private")));
+    }
+
+    #[test]
+    fn hash_changes_when_pub_added() {
+        // Build two fake crate directories on the fly and check hashes differ.
+        use std::fs;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let crate_src = root.join("crates").join("fake-crate").join("src");
+        fs::create_dir_all(&crate_src).expect("mkdir");
+        fs::write(crate_src.join("lib.rs"), "pub fn alpha() {}\n").expect("write 1");
+        let (h1, n1) = compute_api_hash(root, "fake-crate");
+        assert_eq!(n1, 1);
+
+        // Add a new pub fn — hash MUST change.
+        fs::write(
+            crate_src.join("lib.rs"),
+            "pub fn alpha() {}\npub fn beta() {}\n",
+        )
+        .expect("write 2");
+        let (h2, n2) = compute_api_hash(root, "fake-crate");
+        assert_eq!(n2, 2);
+        assert_ne!(h1, h2, "adding a pub fn must change the hash");
+
+        // Add an internal-only change — hash MUST NOT change.
+        fs::write(
+            crate_src.join("lib.rs"),
+            "pub fn alpha() {}\npub fn beta() {}\n\nfn internal() {}\n",
+        )
+        .expect("write 3");
+        let (h3, n3) = compute_api_hash(root, "fake-crate");
+        assert_eq!(n3, 2, "internal fn must not affect decl_count");
+        assert_eq!(h2, h3, "internal-only changes must not change the hash");
+    }
+
+    #[test]
+    fn diff_reports_flags_stable_break() {
+        let base = json!({
+            "crates": [
+                { "name": "ix-math", "tier": "stable", "api_hash": "aaaa", "decl_count": 10 },
+                { "name": "ix-evolution", "tier": "experimental", "api_hash": "bbbb", "decl_count": 5 },
+            ]
+        });
+        let head = json!({
+            "crates": [
+                // Pretend ix-math's API changed.
+                { "name": "ix-math", "tier": "stable", "api_hash": "cccc", "decl_count": 11 },
+                // Pretend ix-evolution also changed — should be warn-only.
+                { "name": "ix-evolution", "tier": "experimental", "api_hash": "dddd", "decl_count": 4 },
+            ]
+        });
+        let d = diff_reports(&base, &head);
+        assert_eq!(d.stable_changed.len(), 1);
+        assert_eq!(d.stable_changed[0].name, "ix-math");
+        assert_eq!(d.other_changed.len(), 1);
+        assert_eq!(d.other_changed[0].name, "ix-evolution");
+        assert!(d.added.is_empty());
+        assert!(d.removed.is_empty());
+    }
+
+    #[test]
+    fn diff_reports_handles_demotion_escape_hatch() {
+        // Stable break + simultaneous demotion to beta in the SAME PR is the
+        // documented escape hatch. The diff still reports it as
+        // stable_changed (CI will then look at the head tier to decide).
+        // For this v1 we simply flag it; CI fails. Future: allow the
+        // override via PR label or commit trailer.
+        let base = json!({
+            "crates": [
+                { "name": "ix-game", "tier": "stable", "api_hash": "aa", "decl_count": 8 }
+            ]
+        });
+        let head = json!({
+            "crates": [
+                { "name": "ix-game", "tier": "beta", "api_hash": "bb", "decl_count": 7 }
+            ]
+        });
+        let d = diff_reports(&base, &head);
+        assert_eq!(d.stable_changed.len(), 1);
+        assert_eq!(d.stable_changed[0].tier_before, "stable");
+        assert_eq!(d.stable_changed[0].tier_after, "beta");
+    }
+}

--- a/crates/ix-skill/src/verbs/stable_surface.rs
+++ b/crates/ix-skill/src/verbs/stable_surface.rs
@@ -63,10 +63,9 @@ pub fn locate_workspace_root() -> Result<PathBuf, String> {
 /// Parse `crate-maturity.toml` into a name→tier map.
 pub fn load_maturity(root: &Path) -> Result<BTreeMap<String, String>, String> {
     let path = root.join("crate-maturity.toml");
-    let body = fs::read_to_string(&path)
-        .map_err(|e| format!("reading {}: {e}", path.display()))?;
-    let parsed: toml::Value = toml::from_str(&body)
-        .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+    let body = fs::read_to_string(&path).map_err(|e| format!("reading {}: {e}", path.display()))?;
+    let parsed: toml::Value =
+        toml::from_str(&body).map_err(|e| format!("parsing {}: {e}", path.display()))?;
     let crates = parsed
         .get("crates")
         .and_then(|v| v.as_table())
@@ -129,8 +128,7 @@ fn collect_pub_decls(crate_src: &Path) -> Result<BTreeSet<String>, String> {
     let mut decls = BTreeSet::new();
     let mut stack = vec![crate_src.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let entries = fs::read_dir(&dir)
-            .map_err(|e| format!("reading {}: {e}", dir.display()))?;
+        let entries = fs::read_dir(&dir).map_err(|e| format!("reading {}: {e}", dir.display()))?;
         for entry in entries {
             let entry = entry.map_err(|e| format!("entry in {}: {e}", dir.display()))?;
             let path = entry.path();
@@ -139,8 +137,7 @@ fn collect_pub_decls(crate_src: &Path) -> Result<BTreeSet<String>, String> {
                 .map_err(|e| format!("file_type of {}: {e}", path.display()))?;
             if file_type.is_dir() {
                 stack.push(path);
-            } else if file_type.is_file()
-                && path.extension().and_then(|s| s.to_str()) == Some("rs")
+            } else if file_type.is_file() && path.extension().and_then(|s| s.to_str()) == Some("rs")
             {
                 let body = fs::read_to_string(&path)
                     .map_err(|e| format!("reading {}: {e}", path.display()))?;
@@ -350,7 +347,9 @@ fn private() {}
         assert!(lines.iter().any(|l| l.starts_with("pub struct Bar")));
         assert!(lines.iter().any(|l| l.starts_with("pub use crate::baz")));
         assert!(!lines.iter().any(|l| l.starts_with("pub(crate) fn hidden")));
-        assert!(!lines.iter().any(|l| l.starts_with("pub(super) fn also_hidden")));
+        assert!(!lines
+            .iter()
+            .any(|l| l.starts_with("pub(super) fn also_hidden")));
         assert!(!lines.iter().any(|l| l.starts_with("fn private")));
     }
 


### PR DESCRIPTION
## Summary

Promote IX's maturity table from documentation to a CI-gated contract. Today a Stable crate can break its public API silently and downstream consumers (`ga`, `tars`, `Demerzel`, `agent-blackbox`) discover the breakage days later as failing tests. This PR makes the break show up on the offending IX PR.

- **Source of truth**: workspace-root `crate-maturity.toml` mapping every crate to one of `stable` / `beta` / `experimental` / `internal`. 12 Stable crates (matches today's README).
- **CLI**: `cargo run -p ix-skill -- stable-surface [--all-tiers] [--format=json]` prints a JSON report with a BLAKE3 hash per crate. The hash is over the sorted, deduplicated set of `pub` declarations under `crates/<name>/src/**.rs`.
- **CI**: `.github/workflows/stable-surface.yml` runs the report on `main` and on the PR, diffs the two, **fails** if any Stable crate's hash changed (with a remediation message), and **warns only** for non-Stable changes.
- **Docs**: new README "Stability contract" section explains the demotion escape hatch.
- **Tests**: 4 unit tests in `ix-skill::verbs::stable_surface::tests` cover pub-line extraction, internal-vs-external change detection, and the diff partitioning across tiers.

No tier changes for any crate in this PR — only the guard is new.

## Baseline hashes (12 Stable crates, current `main` content)

```
ix-cache         147b0616bfe61a97   ( 98 pub decls)
ix-ensemble      40f62a95b4c84cc3   ( 18 pub decls)
ix-game          0ba400ba7b975f36   ( 82 pub decls)
ix-graph         1e2f9a7b4085d6b0   ( 71 pub decls)
ix-math          bb46464aae7899a7   (213 pub decls)
ix-optimize      b2d93181a2455efd   ( 54 pub decls)
ix-probabilistic 73a9c95dc7d6ea5a   ( 34 pub decls)
ix-rl            5885112db232491f   ( 44 pub decls)
ix-search        895db0c1b3d4f10c   ( 68 pub decls)
ix-signal        bc195894a00c7467   (124 pub decls)
ix-supervised    9fc8f10836998e5b   (107 pub decls)
ix-unsupervised  9d4b9a17d253eb66   ( 80 pub decls)
```

## Out of scope (intentionally, per the brief)

- Finer-grained API checks (function signature edits, trait-bound additions, variance shifts). Line-level public-decl diffing catches add / remove / rename, which is the v1 scope. Wire `cargo public-api` in a follow-up.
- No promotion or demotion of any crate's tier.

## Test plan

- [x] `cargo build -p ix-skill` (Windows, local) — green
- [x] `cargo test -p ix-skill` — 9/9 pass (4 new + 5 existing pipeline tests)
- [x] `cargo clippy -p ix-skill --all-targets -- -D warnings` — green
- [x] `cargo run -p ix-skill -- stable-surface --format=json` emits a valid JSON report with all 12 Stable crates
- [ ] CI's new `stable-surface` check passes on this intro PR (nothing's actually breaking)
- [ ] Existing `CI` check stays green

The first-run bootstrap (PR adds the verb that doesn't exist on `main`) is handled in the workflow: if base's binary lacks the subcommand, the workflow runs the PR's binary against the base tree to get a comparable baseline.