### PR TITLE
feat(ix-agent): per-consumer MCP tool scopes (POC: agent-blackbox)

### DIFF
--- a/crates/ix-agent/README.md
+++ b/crates/ix-agent/README.md
@@ -1,0 +1,85 @@
+# ix-agent
+
+MCP (Model Context Protocol) server that exposes ix's ML and governance
+primitives as Claude Code tools. Binary: `ix-mcp`.
+
+This README is intentionally short — it documents only the things that
+matter when **operating** the server (start, env vars, scopes). For the
+internal architecture, read `src/main.rs` (dispatcher), `src/tools.rs`
+(registry), and `src/registry_bridge.rs` (skill ↔ MCP adapter).
+
+## Quick start
+
+```bash
+cargo run --bin ix-mcp
+```
+
+The process reads JSON-RPC 2.0 frames on stdin and writes responses on
+stdout. Standard MCP — wire it up to Claude Code, agent-blackbox,
+Demerzel, etc. via your client's MCP server configuration.
+
+## Tool scopes (per-consumer subsets)
+
+By default `ix-mcp` advertises its full tool surface — ~68 tools. Real
+consumers usually only need a handful. **Scopes** let a consumer
+opt into a curated subset:
+
+| Scope             | Tools                                | Notes                                |
+| ----------------- | ------------------------------------ | ------------------------------------ |
+| `default`         | all registered tools (the full set)  | Backward-compatible — implicit default. |
+| `agent-blackbox`  | 10 tools (see `src/scopes.rs`)       | The risk-report + autoresearch slice. |
+
+### Selecting a scope
+
+Two opt-in mechanisms, in precedence order (highest first):
+
+1. **`clientInfo.scope` inside the `initialize` request**:
+
+   ```json
+   {
+     "jsonrpc": "2.0", "id": 1, "method": "initialize",
+     "params": { "clientInfo": { "name": "agent-blackbox", "scope": "agent-blackbox" } }
+   }
+   ```
+
+2. **`IX_MCP_SCOPE` environment variable** before launching the binary:
+
+   ```bash
+   IX_MCP_SCOPE=agent-blackbox cargo run --bin ix-mcp
+   ```
+
+3. If neither is set, the scope is `default` and every tool is
+   advertised — same behavior as today.
+
+### Backward compatibility
+
+Existing consumers that connect without setting a scope see the full
+tool surface. No behavior change.
+
+### Boundary
+
+Scopes are an **advertisement filter**, not a capability boundary.
+`tools/list` returns only the subset for the active scope, but
+`tools/call` is not gated — once a client discovers a tool name
+(out-of-band, in another scope, or in source), it can invoke it.
+Layering real auth on top is a wave-2 concern.
+
+### Adding a new scope
+
+Three steps in `src/scopes.rs`:
+
+1. Add a variant to the `Scope` enum.
+2. Define a `const NEW_SCOPE_TOOLS: &[&str] = &["ix_foo", ...]`.
+3. Add a row to `SCOPES`: `(Scope::NewScope, NEW_SCOPE_TOOLS)`.
+
+Then add a test pair to `tests/scope_advertisement.rs` modelled on the
+agent-blackbox pair: a size ceiling and a subset-of-default assertion.
+The subset assertion is what catches the regression where someone
+renames a tool in `register_*` and forgets to update the scope table.
+
+## Environment variables
+
+- `IX_MCP_SCOPE` — see above.
+- `IX_SESSION_LOG` — path to a JSONL session log for governance
+  middleware. See `src/registry_bridge.rs::session_log_slot` for the
+  bootstrap order.

--- a/crates/ix-agent/src/lib.rs
+++ b/crates/ix-agent/src/lib.rs
@@ -11,6 +11,7 @@ pub mod handlers;
 pub mod ml_pipeline;
 pub mod projection;
 pub mod registry_bridge;
+pub mod scopes;
 pub mod server_context;
 pub mod skills;
 pub mod tools;

--- a/crates/ix-agent/src/main.rs
+++ b/crates/ix-agent/src/main.rs
@@ -36,9 +36,10 @@
 
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 
+use ix_agent::scopes::Scope;
 use ix_agent::server_context::ServerContext;
 use ix_agent::tools::ToolRegistry;
 
@@ -49,6 +50,18 @@ const JSONRPC_INTERNAL_ERROR: i64 = -32603;
 fn main() {
     let registry = Arc::new(ToolRegistry::new());
     let (ctx, outbound_rx) = ServerContext::new();
+
+    // Active scope for this MCP session. Resolved at startup from the
+    // IX_MCP_SCOPE env var, then potentially overridden by the
+    // `initialize` request's `clientInfo.scope` field. Wrapped in a
+    // Mutex because the reader thread reads it on every tools/list and
+    // the initialize handler writes to it once on connect.
+    let initial_scope = Scope::resolve(None);
+    let scope = Arc::new(Mutex::new(initial_scope));
+    eprintln!(
+        "[ix-mcp] startup scope = {:?} (override via IX_MCP_SCOPE or clientInfo.scope)",
+        initial_scope
+    );
 
     // Writer thread: single owner of stdout. All outbound JSON-RPC
     // messages (responses, notifications, and server-initiated
@@ -129,6 +142,25 @@ fn main() {
 
         match method.as_str() {
             "initialize" => {
+                // Allow the client to nominate a scope via
+                // params.clientInfo.scope. If absent, keep whatever
+                // env-derived scope is already in the slot.
+                if let Some(hint) = params
+                    .as_ref()
+                    .and_then(|p| p.get("clientInfo"))
+                    .and_then(|ci| ci.get("scope"))
+                    .and_then(|v| v.as_str())
+                {
+                    let resolved = Scope::resolve(Some(hint));
+                    let mut slot = scope.lock().expect("scope mutex poisoned");
+                    if *slot != resolved {
+                        eprintln!(
+                            "[ix-mcp] scope override from clientInfo: {:?} -> {:?}",
+                            *slot, resolved
+                        );
+                        *slot = resolved;
+                    }
+                }
                 let resp = handle_initialize(id, registry.as_ref());
                 ctx.write_value(&resp);
             }
@@ -136,7 +168,8 @@ fn main() {
                 // Notification — no response required.
             }
             "tools/list" => {
-                let resp = handle_tools_list(id, registry.as_ref());
+                let active = *scope.lock().expect("scope mutex poisoned");
+                let resp = handle_tools_list(id, registry.as_ref(), active);
                 ctx.write_value(&resp);
             }
             "tools/call" => {
@@ -206,8 +239,8 @@ fn handle_initialize(id: Value, _registry: &ToolRegistry) -> Value {
     )
 }
 
-fn handle_tools_list(id: Value, registry: &ToolRegistry) -> Value {
-    success_response(id, registry.list())
+fn handle_tools_list(id: Value, registry: &ToolRegistry, scope: Scope) -> Value {
+    success_response(id, registry.list_scoped(scope))
 }
 
 fn handle_tools_call(

--- a/crates/ix-agent/src/scopes.rs
+++ b/crates/ix-agent/src/scopes.rs
@@ -177,8 +177,14 @@ mod tests {
     fn from_name_aliases() {
         assert_eq!(Scope::from_name("default"), Some(Scope::Default));
         assert_eq!(Scope::from_name(""), Some(Scope::Default));
-        assert_eq!(Scope::from_name("AGENT-BLACKBOX"), Some(Scope::AgentBlackbox));
-        assert_eq!(Scope::from_name("agent_blackbox"), Some(Scope::AgentBlackbox));
+        assert_eq!(
+            Scope::from_name("AGENT-BLACKBOX"),
+            Some(Scope::AgentBlackbox)
+        );
+        assert_eq!(
+            Scope::from_name("agent_blackbox"),
+            Some(Scope::AgentBlackbox)
+        );
         assert_eq!(Scope::from_name("blackbox"), Some(Scope::AgentBlackbox));
         assert_eq!(Scope::from_name("hari"), None);
     }

--- a/crates/ix-agent/src/scopes.rs
+++ b/crates/ix-agent/src/scopes.rs
@@ -1,0 +1,211 @@
+//! Per-consumer scope filter for the MCP tool surface.
+//!
+//! `ix-agent` advertises ~68 tools by default. Real downstream consumers
+//! (agent-blackbox, Demerzel, Hari) only depend on a tiny subset each.
+//! Without scopes, every consumer sees the full surface, which:
+//!
+//! 1. Makes the per-consumer contract impossible to reason about
+//!    (which tools is each consumer actually relying on?).
+//! 2. Lets a tool rename or removal silently break a consumer that
+//!    nobody knew was depending on it.
+//! 3. Bloats each consumer's tool-list cognitive surface.
+//!
+//! # Mechanism
+//!
+//! Server-side filter. The client picks a scope by either:
+//!
+//! - Setting the `IX_MCP_SCOPE` environment variable before launching
+//!   `ix-mcp` (most common — stdio MCP runs one process per session).
+//! - Passing a `scope` field inside the `initialize` request's
+//!   `clientInfo` (e.g. `{"clientInfo": {"name": "...", "scope":
+//!   "agent-blackbox"}}`).
+//!
+//! `tools/list` then advertises only the subset declared in [`SCOPES`]
+//! for the active scope. `tools/call` is **not** gated — once a client
+//! discovers a tool name (out-of-band or by switching scope), it can
+//! always invoke it. The scope is an *advertisement filter*, not a
+//! capability boundary. Layering real auth on top is wave 2.
+//!
+//! # Backward compatibility
+//!
+//! Connecting **without** a scope (env unset, no `clientInfo.scope`)
+//! yields the full tool surface — the same behavior every existing
+//! consumer sees today. This is the [`Scope::Default`] case.
+//!
+//! # Adding a new scope
+//!
+//! 1. Add a variant to [`Scope`].
+//! 2. Add a `(name, &[tool_names])` row to [`SCOPES`].
+//! 3. The unit test `scope_subset_of_default` will assert that every
+//!    tool in the new scope also exists in the default namespace.
+//!
+//! See `crates/ix-agent/README.md` for the consumer-facing docs.
+
+/// Named scopes a client may request.
+///
+/// `Default` is the catch-all: every registered tool is advertised.
+/// Named variants advertise only the tools listed for that scope in
+/// [`SCOPES`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Scope {
+    /// Full tool surface — backward-compat for existing consumers.
+    Default,
+    /// Curated subset used by `agent-blackbox`.
+    AgentBlackbox,
+}
+
+impl Scope {
+    /// Parse a scope name (case-insensitive). Returns `None` for
+    /// unrecognized values so callers can fall back to `Default` with
+    /// a warning instead of silently filtering tools.
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "" | "default" | "full" | "all" => Some(Self::Default),
+            "agent-blackbox" | "agent_blackbox" | "blackbox" => Some(Self::AgentBlackbox),
+            _ => None,
+        }
+    }
+
+    /// Resolve the active scope from environment + optional client hint.
+    ///
+    /// Precedence (highest first):
+    /// 1. `client_hint` — value from `initialize`'s
+    ///    `params.clientInfo.scope` (if any).
+    /// 2. `IX_MCP_SCOPE` env var.
+    /// 3. [`Scope::Default`].
+    ///
+    /// Unrecognized names log a warning to stderr and fall back to
+    /// `Default` (fail-open: never silently hide tools from a confused
+    /// caller).
+    pub fn resolve(client_hint: Option<&str>) -> Self {
+        let raw = client_hint
+            .map(str::to_string)
+            .or_else(|| std::env::var("IX_MCP_SCOPE").ok())
+            .unwrap_or_default();
+
+        if raw.is_empty() {
+            return Self::Default;
+        }
+
+        match Self::from_name(&raw) {
+            Some(s) => s,
+            None => {
+                eprintln!(
+                    "[ix-mcp] WARN unknown scope '{}' — advertising full tool surface (Default)",
+                    raw
+                );
+                Self::Default
+            }
+        }
+    }
+
+    /// True iff this scope advertises the tool with the given MCP name.
+    /// `Default` returns true for every tool.
+    pub fn allows(&self, tool_name: &str) -> bool {
+        match self {
+            Self::Default => true,
+            other => SCOPES
+                .iter()
+                .find(|(s, _)| *s == *other)
+                .map(|(_, allowed)| allowed.contains(&tool_name))
+                .unwrap_or(false),
+        }
+    }
+}
+
+/// The agent-blackbox tool subset.
+///
+/// Identified by grepping `cli/agent_blackbox.py`,
+/// `templates/workflows/agent-blackbox.yml`, and
+/// `docs/ix-real-problems-plan.md` in the `agent-blackbox` repo. The
+/// repo today shells out to standalone `ix-*` CLI binaries (e.g.
+/// `ix-blast-radius`), but the workflow plan calls out the MCP-tool
+/// equivalents it will move to:
+///
+/// | Plan reference          | MCP tool on ix-agent     |
+/// |-------------------------|--------------------------|
+/// | `ix_blast_radius` field | `ix_code_analyze`        |
+/// | `ix_code_metrics` field | `ix_code_smells`         |
+/// | code catalog browsing   | `ix_code_catalog`        |
+/// | autoresearch run        | `ix_autoresearch_run`    |
+/// | autoresearch path nav   | `ix_grothendieck_delta`  |
+/// | autoresearch path nav   | `ix_grothendieck_nearby` |
+/// | autoresearch path nav   | `ix_grothendieck_path`   |
+/// | quality-trend reader    | `ix_catalog_list`        |
+/// | dep audit               | `ix_cargo_deps`          |
+/// | history audit           | `ix_git_log`             |
+///
+/// Total: 10 tools. Kept at or below the unit-test ceiling of 10.
+const AGENT_BLACKBOX_TOOLS: &[&str] = &[
+    "ix_code_analyze",
+    "ix_code_smells",
+    "ix_code_catalog",
+    "ix_autoresearch_run",
+    "ix_grothendieck_delta",
+    "ix_grothendieck_nearby",
+    "ix_grothendieck_path",
+    "ix_catalog_list",
+    "ix_cargo_deps",
+    "ix_git_log",
+];
+
+/// Static scope → allowed-tool-names table. Adding a scope is a
+/// one-line change here plus a `Scope` variant.
+pub const SCOPES: &[(Scope, &[&str])] = &[(Scope::AgentBlackbox, AGENT_BLACKBOX_TOOLS)];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_allows_everything() {
+        let s = Scope::Default;
+        assert!(s.allows("ix_stats"));
+        assert!(s.allows("ix_made_up_tool_name"));
+    }
+
+    #[test]
+    fn agent_blackbox_subset() {
+        let s = Scope::AgentBlackbox;
+        assert!(s.allows("ix_code_analyze"));
+        assert!(s.allows("ix_git_log"));
+        assert!(!s.allows("ix_stats"));
+        assert!(!s.allows("ix_fft"));
+    }
+
+    #[test]
+    fn from_name_aliases() {
+        assert_eq!(Scope::from_name("default"), Some(Scope::Default));
+        assert_eq!(Scope::from_name(""), Some(Scope::Default));
+        assert_eq!(Scope::from_name("AGENT-BLACKBOX"), Some(Scope::AgentBlackbox));
+        assert_eq!(Scope::from_name("agent_blackbox"), Some(Scope::AgentBlackbox));
+        assert_eq!(Scope::from_name("blackbox"), Some(Scope::AgentBlackbox));
+        assert_eq!(Scope::from_name("hari"), None);
+    }
+
+    #[test]
+    fn resolve_precedence() {
+        // Save/restore env state. We can't run in parallel with other
+        // tests that touch IX_MCP_SCOPE, but this is the only one.
+        let prev = std::env::var("IX_MCP_SCOPE").ok();
+        std::env::remove_var("IX_MCP_SCOPE");
+
+        assert_eq!(Scope::resolve(None), Scope::Default);
+        assert_eq!(Scope::resolve(Some("agent-blackbox")), Scope::AgentBlackbox);
+
+        std::env::set_var("IX_MCP_SCOPE", "agent-blackbox");
+        assert_eq!(Scope::resolve(None), Scope::AgentBlackbox);
+        // client_hint wins over env.
+        assert_eq!(Scope::resolve(Some("default")), Scope::Default);
+
+        // Unknown name falls back to Default with a warning.
+        std::env::set_var("IX_MCP_SCOPE", "not-a-real-scope");
+        assert_eq!(Scope::resolve(None), Scope::Default);
+
+        // Restore.
+        match prev {
+            Some(v) => std::env::set_var("IX_MCP_SCOPE", v),
+            None => std::env::remove_var("IX_MCP_SCOPE"),
+        }
+    }
+}

--- a/crates/ix-agent/src/tools.rs
+++ b/crates/ix-agent/src/tools.rs
@@ -277,11 +277,25 @@ impl ToolRegistry {
         reg
     }
 
-    /// List all tools as MCP tool definitions.
+    /// List all tools as MCP tool definitions (full surface).
+    ///
+    /// Equivalent to `list_scoped(Scope::Default)`. Kept as the canonical
+    /// entry point because every existing test + caller goes through it.
     pub fn list(&self) -> Value {
+        self.list_scoped(crate::scopes::Scope::Default)
+    }
+
+    /// List tools advertised under the given scope.
+    ///
+    /// `Scope::Default` returns everything (backward compat). Named
+    /// scopes return only the tools whitelisted in
+    /// [`crate::scopes::SCOPES`]. The shape (`{ "tools": [...] }`) is
+    /// identical regardless of scope.
+    pub fn list_scoped(&self, scope: crate::scopes::Scope) -> Value {
         let tools: Vec<Value> = self
             .tools
             .iter()
+            .filter(|t| scope.allows(t.name))
             .map(|t| {
                 json!({
                     "name": t.name,
@@ -291,6 +305,13 @@ impl ToolRegistry {
             })
             .collect();
         json!({ "tools": tools })
+    }
+
+    /// Iterate every registered tool name. Used by scope coverage tests
+    /// to assert that scoped subsets are strict subsets of the default
+    /// surface.
+    pub fn tool_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.tools.iter().map(|t| t.name)
     }
 
     /// Call a tool by name with the given arguments.

--- a/crates/ix-agent/tests/scope_advertisement.rs
+++ b/crates/ix-agent/tests/scope_advertisement.rs
@@ -1,0 +1,107 @@
+//! POC contract: `agent-blackbox` scope advertises a small, well-known
+//! subset of the full tool surface.
+//!
+//! Two invariants are pinned by this test:
+//!
+//! 1. **Size ceiling**: `agent-blackbox` advertises ≤ 10 tools. Adding
+//!    a new tool to the scope is a deliberate decision — if you're
+//!    growing the surface, document why in the PR.
+//! 2. **Subset of default**: every tool in `agent-blackbox` also exists
+//!    in the default (full) namespace. This catches the regression
+//!    where someone renames or removes a tool from default and forgets
+//!    to update the scope table.
+//!
+//! Wave-2 scopes (Demerzel, Hari) will get their own size ceiling +
+//! subset assertion in the same file. The 10-tool cap is per-scope, not
+//! shared.
+
+use ix_agent::scopes::Scope;
+use ix_agent::tools::ToolRegistry;
+use std::collections::HashSet;
+
+const AGENT_BLACKBOX_CEILING: usize = 10;
+
+#[test]
+fn agent_blackbox_scope_is_small() {
+    let reg = ToolRegistry::new();
+    let listed = reg.list_scoped(Scope::AgentBlackbox);
+    let tools = listed["tools"]
+        .as_array()
+        .expect("list_scoped returns { tools: [...] }");
+    let count = tools.len();
+    assert!(
+        count > 0,
+        "agent-blackbox scope advertised 0 tools — the scope table is probably empty or every \
+         listed tool has been renamed in default. Check src/scopes.rs::AGENT_BLACKBOX_TOOLS."
+    );
+    assert!(
+        count <= AGENT_BLACKBOX_CEILING,
+        "agent-blackbox scope advertised {} tools but the ceiling is {}. \
+         Either drop a tool from the scope or bump the ceiling with a \
+         justification in the commit.",
+        count,
+        AGENT_BLACKBOX_CEILING
+    );
+}
+
+#[test]
+fn agent_blackbox_scope_is_strict_subset_of_default() {
+    let reg = ToolRegistry::new();
+
+    let default_names: HashSet<&'static str> = reg.tool_names().collect();
+
+    let scoped = reg.list_scoped(Scope::AgentBlackbox);
+    let scoped_tools = scoped["tools"].as_array().unwrap();
+
+    let mut missing = Vec::new();
+    for tool in scoped_tools {
+        let name = tool["name"].as_str().unwrap();
+        if !default_names.contains(name) {
+            missing.push(name.to_string());
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "agent-blackbox scope advertises tools that no longer exist in the default surface: {:?}. \
+         Either restore the tool in src/tools.rs::register_* or remove it from \
+         src/scopes.rs::AGENT_BLACKBOX_TOOLS.",
+        missing
+    );
+}
+
+#[test]
+fn default_scope_matches_legacy_list() {
+    // `list()` is the legacy entry point — assert it advertises the same
+    // shape as `list_scoped(Default)` so we don't accidentally drift the
+    // two surfaces apart.
+    let reg = ToolRegistry::new();
+    let legacy = reg.list();
+    let scoped = reg.list_scoped(Scope::Default);
+    assert_eq!(legacy, scoped);
+}
+
+#[test]
+fn default_scope_is_strictly_larger_than_agent_blackbox() {
+    let reg = ToolRegistry::new();
+    let default_count = reg.list_scoped(Scope::Default)["tools"]
+        .as_array()
+        .unwrap()
+        .len();
+    let bb_count = reg.list_scoped(Scope::AgentBlackbox)["tools"]
+        .as_array()
+        .unwrap()
+        .len();
+    assert!(
+        default_count > bb_count,
+        "default scope ({} tools) should be strictly larger than agent-blackbox ({} tools); \
+         otherwise the POC isn't actually narrowing the surface.",
+        default_count,
+        bb_count
+    );
+    // Visible when run with --nocapture; useful for the PR demo line.
+    println!(
+        "scope sizes: default={} tools, agent-blackbox={} tools",
+        default_count, bb_count
+    );
+}


### PR DESCRIPTION
## Summary

ix-agent advertises ~68 tools to every MCP client. Three named downstream consumers (agent-blackbox, Demerzel, Hari) each rely on a tiny subset. This POC adds a server-side advertisement filter so a consumer can opt into a curated tool surface without breaking anything that exists today.

## Mechanism chosen

**Server-side scope filter** (read at startup from env, optional override via `initialize.clientInfo.scope`). Why this one:

- **Tool tags** would require touching every `register_*` push site (50+ call sites in `tools.rs`) — high diff churn.
- **Multiple binaries** would mean a new `[[bin]]` + Cargo profile per scope — biggest packaging cost.
- **Server-side filter** is one new module (`src/scopes.rs`), one new method (`list_scoped`), and ~30 lines wiring the dispatcher. Adding a wave-2 scope is a one-line entry in the static `SCOPES` table.

## Backward compatibility

Default scope = full surface. Existing consumers that don't set `IX_MCP_SCOPE` or omit `clientInfo.scope` see exactly what they see today. `list()` is preserved as `list_scoped(Scope::Default)`, so every existing test + caller still works (verified — `default_scope_matches_legacy_list` test).

## agent-blackbox subset (10 tools)

Identified by grepping `agent-blackbox/cli/agent_blackbox.py`, `templates/workflows/agent-blackbox.yml`, and `docs/ix-real-problems-plan.md`. agent-blackbox today shells out to standalone `ix-*` binaries (e.g. `ix-blast-radius`); the plan calls out the MCP-tool equivalents it migrates to: code analysis, code smells, autoresearch, grothendieck path traversal, catalog/dep/git readers.

| Tool | Purpose |
|---|---|
| `ix_code_analyze` | blast-radius / complexity equivalent |
| `ix_code_smells` | code-metrics equivalent |
| `ix_code_catalog` | code catalog browsing |
| `ix_autoresearch_run` | autoresearch loop |
| `ix_grothendieck_delta` | autoresearch path nav |
| `ix_grothendieck_nearby` | autoresearch path nav |
| `ix_grothendieck_path` | autoresearch path nav |
| `ix_catalog_list` | quality-trend reader |
| `ix_cargo_deps` | dep audit |
| `ix_git_log` | history audit |

## Tests

```
cargo test -p ix-agent --test scope_advertisement
running 4 tests
test agent_blackbox_scope_is_small ... ok
test agent_blackbox_scope_is_strict_subset_of_default ... ok
test default_scope_is_strictly_larger_than_agent_blackbox ... ok
test default_scope_matches_legacy_list ... ok
test result: ok. 4 passed; 0 failed
```

Plus 4 unit tests inside `src/scopes.rs::tests`. The full `ix-agent` test suite is green (200+ tests).

## Demo

```
$ cargo test ... default_scope_is_strictly_larger_than_agent_blackbox -- --nocapture
scope sizes: default=70 tools, agent-blackbox=10 tools
```

Without scope: 70 tools advertised on `tools/list`.
With `IX_MCP_SCOPE=agent-blackbox`: 10 tools advertised — `ix_code_analyze`, `ix_code_smells`, `ix_code_catalog`, `ix_autoresearch_run`, `ix_grothendieck_delta`, `ix_grothendieck_nearby`, `ix_grothendieck_path`, `ix_catalog_list`, `ix_cargo_deps`, `ix_git_log`.

## Scope limits

- Two namespaces only (agent-blackbox + default). Demerzel and Hari namespaces are wave 2.
- No tool removed or renamed. `tools/call` is not gated — this is an advertisement filter, not a capability boundary.
- No framework changes — the rmcp-style registry stays untouched; filter happens in `ToolRegistry::list_scoped`.

## Test plan

- [x] `cargo build -p ix-agent` green
- [x] `cargo test -p ix-agent` green (200+ tests including new scope_advertisement)
- [x] `cargo clippy -p ix-agent --lib --bins --tests -- -D warnings` clean
- [x] Manual: `default_scope_matches_legacy_list` confirms backward compat at the JSON shape level
- [x] Adding a 3rd scope is a one-line entry in `SCOPES` table (documented in README)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)