### PR TITLE
chore: cargo fmt --all (close chronic risk-report fmt drift)

### DIFF
--- a/crates/ga-chatbot/src/algebra.rs
+++ b/crates/ga-chatbot/src/algebra.rs
@@ -1,4 +1,6 @@
-use ix_bracelet::{bracelet_prime_form, forte_number, grothendieck_delta, icv, z_related_pairs, PcSet};
+use ix_bracelet::{
+    bracelet_prime_form, forte_number, grothendieck_delta, icv, z_related_pairs, PcSet,
+};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -29,7 +31,10 @@ pub fn answer_query(query: &str, source: &str, revision: &str) -> Option<Algebra
 
     let normalized = query.to_lowercase();
 
-    if normalized.contains("z-related") || normalized.contains("z relation") || normalized.contains("z-pair") {
+    if normalized.contains("z-related")
+        || normalized.contains("z relation")
+        || normalized.contains("z-pair")
+    {
         return Some(answer_z_relation(&sets, source, revision));
     }
 
@@ -37,7 +42,11 @@ pub fn answer_query(query: &str, source: &str, revision: &str) -> Option<Algebra
         return Some(answer_prime_form(sets[0], source, revision));
     }
 
-    if normalized.contains("interval-class vector") || normalized.contains("interval class vector") || normalized.contains(" icv") || normalized.ends_with("icv") {
+    if normalized.contains("interval-class vector")
+        || normalized.contains("interval class vector")
+        || normalized.contains(" icv")
+        || normalized.ends_with("icv")
+    {
         return Some(answer_interval_class_vector(sets[0], source, revision));
     }
 
@@ -64,7 +73,11 @@ fn answer_prime_form(set: PcSet, source: &str, revision: &str) -> AlgebraRespons
     ]);
 
     AlgebraResponse {
-        natural_language_answer: format!("The prime form of {} is {}.", format_set(set), format_set(prime)),
+        natural_language_answer: format!(
+            "The prime form of {} is {}.",
+            format_set(set),
+            format_set(prime)
+        ),
         query_type: "prime-form".to_string(),
         facts,
         source: source.to_string(),
@@ -81,7 +94,11 @@ fn answer_interval_class_vector(set: PcSet, source: &str, revision: &str) -> Alg
     ]);
 
     AlgebraResponse {
-        natural_language_answer: format!("The interval-class vector for {} is {}.", format_set(set), formatted),
+        natural_language_answer: format!(
+            "The interval-class vector for {} is {}.",
+            format_set(set),
+            formatted
+        ),
         query_type: "interval-class-vector".to_string(),
         facts,
         source: source.to_string(),
@@ -91,7 +108,9 @@ fn answer_interval_class_vector(set: PcSet, source: &str, revision: &str) -> Alg
 
 fn answer_forte(set: PcSet, source: &str, revision: &str) -> AlgebraResponse {
     let prime = bracelet_prime_form(set);
-    let forte = forte_number(set).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
+    let forte = forte_number(set)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
     let facts = BTreeMap::from([
         ("input".to_string(), format_set(set)),
         ("primeForm".to_string(), format_set(prime)),
@@ -99,7 +118,10 @@ fn answer_forte(set: PcSet, source: &str, revision: &str) -> AlgebraResponse {
     ]);
 
     let natural_language_answer = if forte == "unavailable" {
-        format!("I could compute the prime form for {}, but no Forte label was available.", format_set(set))
+        format!(
+            "I could compute the prime form for {}, but no Forte label was available.",
+            format_set(set)
+        )
     } else {
         format!("The Forte label for {} is {}.", format_set(set), forte)
     };
@@ -116,7 +138,9 @@ fn answer_forte(set: PcSet, source: &str, revision: &str) -> AlgebraResponse {
 fn answer_set_class_summary(set: PcSet, source: &str, revision: &str) -> AlgebraResponse {
     let prime = bracelet_prime_form(set);
     let vector = icv(set);
-    let forte = forte_number(set).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
+    let forte = forte_number(set)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
     let formatted_icv = format_icv(vector.data);
     let facts = BTreeMap::from([
         ("input".to_string(), format_set(set)),
@@ -131,7 +155,8 @@ fn answer_set_class_summary(set: PcSet, source: &str, revision: &str) -> Algebra
             format_set(set),
             format_set(prime),
             formatted_icv,
-            forte),
+            forte
+        ),
         query_type: "set-class-summary".to_string(),
         facts,
         source: source.to_string(),
@@ -146,8 +171,12 @@ fn answer_z_relation(sets: &[PcSet], source: &str, revision: &str) -> AlgebraRes
         let left_icv = icv(left);
         let right_icv = icv(right);
         let is_z_related = left != right && left_icv == right_icv;
-        let left_forte = forte_number(left).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
-        let right_forte = forte_number(right).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
+        let left_forte = forte_number(left)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unavailable".to_string());
+        let right_forte = forte_number(right)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unavailable".to_string());
         let facts = BTreeMap::from([
             ("left".to_string(), format_set(left)),
             ("right".to_string(), format_set(right)),
@@ -167,7 +196,11 @@ fn answer_z_relation(sets: &[PcSet], source: &str, revision: &str) -> AlgebraRes
                 right_forte,
                 format_icv(left_icv.data))
         } else {
-            format!("{} and {} are not Z-related.", format_set(left), format_set(right))
+            format!(
+                "{} and {} are not Z-related.",
+                format_set(left),
+                format_set(right)
+            )
         };
 
         return AlgebraResponse {
@@ -190,7 +223,9 @@ fn answer_z_relation(sets: &[PcSet], source: &str, revision: &str) -> AlgebraRes
         }
     });
     let vector = icv(set);
-    let forte = forte_number(set).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
+    let forte = forte_number(set)
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "unavailable".to_string());
     let mut facts = BTreeMap::from([
         ("input".to_string(), format_set(set)),
         ("forte".to_string(), forte),
@@ -199,7 +234,9 @@ fn answer_z_relation(sets: &[PcSet], source: &str, revision: &str) -> AlgebraRes
     ]);
 
     let natural_language_answer = if let Some(partner) = partner {
-        let partner_forte = forte_number(partner).map(|value| value.to_string()).unwrap_or_else(|| "unavailable".to_string());
+        let partner_forte = forte_number(partner)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "unavailable".to_string());
         facts.insert("partner".to_string(), format_set(partner));
         facts.insert("partnerForte".to_string(), partner_forte.clone());
         format!(
@@ -207,7 +244,8 @@ fn answer_z_relation(sets: &[PcSet], source: &str, revision: &str) -> AlgebraRes
             format_set(set),
             format_set(partner),
             partner_forte,
-            format_icv(vector.data))
+            format_icv(vector.data)
+        )
     } else {
         format!("{} is not Z-related.", format_set(set))
     };
@@ -240,7 +278,8 @@ fn answer_distance(left: PcSet, right: PcSet, source: &str, revision: &str) -> A
             format_set(left),
             format_set(right),
             format_delta(delta.data),
-            delta.l1_norm()),
+            delta.l1_norm()
+        ),
         query_type: "distance".to_string(),
         facts,
         source: source.to_string(),
@@ -327,16 +366,26 @@ fn normalize_token(token: &str) -> String {
 }
 
 fn format_set(set: PcSet) -> String {
-    let pcs = set.iter_pcs().map(|pc| pc.to_string()).collect::<Vec<_>>().join(",");
+    let pcs = set
+        .iter_pcs()
+        .map(|pc| pc.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
     format!("[{pcs}]")
 }
 
 fn format_icv(data: [u32; 6]) -> String {
-    format!("[{}, {}, {}, {}, {}, {}]", data[0], data[1], data[2], data[3], data[4], data[5])
+    format!(
+        "[{}, {}, {}, {}, {}, {}]",
+        data[0], data[1], data[2], data[3], data[4], data[5]
+    )
 }
 
 fn format_delta(data: [i32; 6]) -> String {
-    format!("[{}, {}, {}, {}, {}, {}]", data[0], data[1], data[2], data[3], data[4], data[5])
+    format!(
+        "[{}, {}, {}, {}, {}, {}]",
+        data[0], data[1], data[2], data[3], data[4], data[5]
+    )
 }
 
 fn bracketed_set_regex() -> &'static Regex {
@@ -360,18 +409,26 @@ mod tests {
 
     #[test]
     fn answers_prime_form_query() {
-        let response = answer_query("What is the prime form of [0,1,4,6]?", "ix", "7b02a56").expect("answer");
+        let response =
+            answer_query("What is the prime form of [0,1,4,6]?", "ix", "7b02a56").expect("answer");
         assert_eq!(response.query_type, "prime-form");
-        assert_eq!(response.facts.get("primeForm").map(String::as_str), Some("[0,1,4,6]"));
+        assert_eq!(
+            response.facts.get("primeForm").map(String::as_str),
+            Some("[0,1,4,6]")
+        );
         assert_eq!(response.source, "ix");
         assert_eq!(response.revision, "7b02a56");
     }
 
     #[test]
     fn answers_z_relation_query() {
-        let response = answer_query("Are 0146 and 0137 z-related?", "ix", "7b02a56").expect("answer");
+        let response =
+            answer_query("Are 0146 and 0137 z-related?", "ix", "7b02a56").expect("answer");
         assert_eq!(response.query_type, "z-relation");
-        assert_eq!(response.facts.get("zRelated").map(String::as_str), Some("true"));
+        assert_eq!(
+            response.facts.get("zRelated").map(String::as_str),
+            Some("true")
+        );
         assert!(response.natural_language_answer.contains("share ICV"));
     }
 
@@ -380,8 +437,13 @@ mod tests {
         let response = answer_query(
             "What is the harmonic distance between [0,4,8] and [0,3,6]?",
             "ix",
-            "7b02a56").expect("answer");
+            "7b02a56",
+        )
+        .expect("answer");
         assert_eq!(response.query_type, "distance");
-        assert_eq!(response.facts.get("l1Distance").map(String::as_str), Some("6"));
+        assert_eq!(
+            response.facts.get("l1Distance").map(String::as_str),
+            Some("6")
+        );
     }
 }

--- a/crates/ga-chatbot/src/coverage.rs
+++ b/crates/ga-chatbot/src/coverage.rs
@@ -104,23 +104,8 @@ const FAMOUS_REFERENCES: &[&str] = &[
 
 /// Style/genre keywords. Lowercase substring match.
 const STYLE_KEYWORDS: &[&str] = &[
-    "jazz",
-    "blues",
-    "rock",
-    "metal",
-    "funk",
-    "bossa",
-    "samba",
-    "swing",
-    "bebop",
-    "fusion",
-    "gospel",
-    "country",
-    "folk",
-    "gypsy",
-    "reggae",
-    "latin",
-    "comping",
+    "jazz", "blues", "rock", "metal", "funk", "bossa", "samba", "swing", "bebop", "fusion",
+    "gospel", "country", "folk", "gypsy", "reggae", "latin", "comping",
 ];
 
 /// Mood/affect adjectives. Picked for low overlap with voice-leading
@@ -171,14 +156,7 @@ pub fn classify_intent(entry: &TelemetryEntry) -> IntentLabel {
         return IntentLabel::StyleQuery;
     }
     let instruments = [
-        "bass",
-        "ukulele",
-        "mandolin",
-        "banjo",
-        "baritone",
-        "7-string",
-        "8-string",
-        "fretless",
+        "bass", "ukulele", "mandolin", "banjo", "baritone", "7-string", "8-string", "fretless",
     ];
     if instruments.iter().any(|k| q.contains(k)) {
         return IntentLabel::InstrumentSpecific;
@@ -508,10 +486,18 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
         let mut f = std::fs::File::create(&path).unwrap();
-        writeln!(f, r#"{{"ts":"2026-05-04T00:00:00Z","q":"Cmaj7","results":3}}"#).unwrap();
+        writeln!(
+            f,
+            r#"{{"ts":"2026-05-04T00:00:00Z","q":"Cmaj7","results":3}}"#
+        )
+        .unwrap();
         writeln!(f, "this is not json").unwrap();
         writeln!(f).unwrap();
-        writeln!(f, r#"{{"ts":"2026-05-04T00:01:00Z","q":"Dm7","results":3}}"#).unwrap();
+        writeln!(
+            f,
+            r#"{{"ts":"2026-05-04T00:01:00Z","q":"Dm7","results":3}}"#
+        )
+        .unwrap();
         let entries = load_telemetry(dir.path());
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].q, "Cmaj7");

--- a/crates/ga-chatbot/src/main.rs
+++ b/crates/ga-chatbot/src/main.rs
@@ -298,10 +298,7 @@ fn run_coverage(
         }
     };
     if let Err(e) = std::fs::write(output_path, &json) {
-        eprintln!(
-            "[coverage] write {} failed: {e}",
-            output_path.display()
-        );
+        eprintln!("[coverage] write {} failed: {e}", output_path.display());
         return 2;
     }
     eprintln!(

--- a/crates/ga-chatbot/tests/algebra_fixtures_match_bracelet.rs
+++ b/crates/ga-chatbot/tests/algebra_fixtures_match_bracelet.rs
@@ -43,7 +43,10 @@ fn algebra_001_major_minor_triads_share_set_class() {
     assert_eq!(icv(c_maj), icv(c_min));
 
     let resp = fixture_for("are c major and c minor triads in the same set class");
-    assert!(resp.answer.contains("3-11"), "answer should cite Forte 3-11");
+    assert!(
+        resp.answer.contains("3-11"),
+        "answer should cite Forte 3-11"
+    );
     assert!(
         resp.answer.contains("[0, 0, 1, 1, 1, 0]"),
         "answer should cite the ICV [0, 0, 1, 1, 1, 0]"
@@ -90,7 +93,10 @@ fn algebra_004_g7_db7_tritone_substitution() {
     assert!(grothendieck_delta(g7, db7).is_zero());
 
     let resp = fixture_for("is db7 a valid substitution for g7");
-    assert!(resp.answer.contains("4-27"), "answer should cite Forte 4-27");
+    assert!(
+        resp.answer.contains("4-27"),
+        "answer should cite Forte 4-27"
+    );
     assert!(
         resp.answer.contains("[0, 1, 2, 1, 1, 1]"),
         "answer should cite the dominant-7th ICV"
@@ -131,9 +137,8 @@ fn algebra_006_aug_dim_distance_is_l1_6() {
     assert_eq!(delta.data, [0, 0, 2, -3, 0, 1]);
     assert_eq!(delta.l1_norm(), 6);
 
-    let resp = fixture_for(
-        "what is the harmonic distance between c augmented and c diminished triads",
-    );
+    let resp =
+        fixture_for("what is the harmonic distance between c augmented and c diminished triads");
     assert!(resp.answer.contains("[0, 0, 0, 3, 0, 0]"));
     assert!(resp.answer.contains("[0, 0, 2, 0, 0, 1]"));
     assert!(

--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -309,18 +309,12 @@ pub fn tsne(params: Value) -> Result<Value, String> {
         .get("perplexity")
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
-    let n_iter = params
-        .get("n_iter")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(500) as usize;
+    let n_iter = params.get("n_iter").and_then(|v| v.as_u64()).unwrap_or(500) as usize;
     let target_dim = params
         .get("target_dim")
         .and_then(|v| v.as_u64())
         .unwrap_or(2) as usize;
-    let seed = params
-        .get("seed")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(0);
+    let seed = params.get("seed").and_then(|v| v.as_u64()).unwrap_or(0);
 
     let data = vecs_to_array2(&data_rows)?;
     let n = data.nrows();
@@ -5043,7 +5037,9 @@ fn parse_pc_set(params: &Value, field: &str) -> Result<ix_bracelet::PcSet, Strin
     let arr = params
         .get(field)
         .and_then(|v| v.as_array())
-        .ok_or_else(|| format!("Missing or invalid field '{field}' (expected array of pitch classes)"))?;
+        .ok_or_else(|| {
+            format!("Missing or invalid field '{field}' (expected array of pitch classes)")
+        })?;
     let mut pcs: Vec<u8> = Vec::with_capacity(arr.len());
     for v in arr {
         let n = v
@@ -5089,8 +5085,9 @@ pub fn grothendieck_nearby(params: Value) -> Result<Value, String> {
     let max_l1 = params
         .get("max_l1")
         .and_then(|v| v.as_u64())
-        .ok_or_else(|| "Missing or invalid field 'max_l1' (expected non-negative integer)".to_string())?
-        as u32;
+        .ok_or_else(|| {
+            "Missing or invalid field 'max_l1' (expected non-negative integer)".to_string()
+        })? as u32;
     let limit = params
         .get("limit")
         .and_then(|v| v.as_u64())
@@ -5156,9 +5153,7 @@ pub fn grothendieck_path(params: Value) -> Result<Value, String> {
 // MCP_ITERATION_CAP` (10_000). CLI is unconstrained.
 
 pub fn autoresearch_run(params: Value) -> Result<Value, String> {
-    use ix_autoresearch::{
-        run_experiment, GrammarTarget, Strategy, TimeBudget, MCP_ITERATION_CAP,
-    };
+    use ix_autoresearch::{run_experiment, GrammarTarget, Strategy, TimeBudget, MCP_ITERATION_CAP};
 
     let target = params
         .get("target")
@@ -5193,9 +5188,7 @@ pub fn autoresearch_run(params: Value) -> Result<Value, String> {
         "greedy" => Strategy::Greedy,
         "random" | "random_search" => Strategy::RandomSearch,
         "sa" | "simulated_annealing" => {
-            let initial_temperature = params
-                .get("initial_temperature")
-                .and_then(|v| v.as_f64());
+            let initial_temperature = params.get("initial_temperature").and_then(|v| v.as_f64());
             let cooling_rate = params
                 .get("cooling_rate")
                 .and_then(|v| v.as_f64())
@@ -5205,7 +5198,11 @@ pub fn autoresearch_run(params: Value) -> Result<Value, String> {
                 cooling_rate,
             }
         }
-        other => return Err(format!("unknown strategy '{other}'; expected 'greedy' | 'sa' | 'random'")),
+        other => {
+            return Err(format!(
+                "unknown strategy '{other}'; expected 'greedy' | 'sa' | 'random'"
+            ))
+        }
     };
 
     let soft_seconds = params
@@ -5225,10 +5222,7 @@ pub fn autoresearch_run(params: Value) -> Result<Value, String> {
         Some(h) => return Err(format!("'hard_seconds' must be > 0, got {h}")),
     };
 
-    let seed = params
-        .get("seed")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(42);
+    let seed = params.get("seed").and_then(|v| v.as_u64()).unwrap_or(42);
 
     let state_dir = params
         .get("state_dir")
@@ -5272,11 +5266,7 @@ pub fn voicings_payload(params: Value) -> Result<Value, String> {
     let scene_offset = params
         .get("scene_offset")
         .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_f64())
-                .collect::<Vec<f64>>()
-        })
+        .map(|arr| arr.iter().filter_map(|v| v.as_f64()).collect::<Vec<f64>>())
         .filter(|v| v.len() == 3)
         .unwrap_or_else(|| vec![200.0, 0.0, 0.0]);
 
@@ -5316,8 +5306,14 @@ mod voicings_payload_tests {
         let out = voicings_payload(json!({})).expect("ok");
         assert_eq!(out["schema"], "voicings.payload.v1");
         assert_eq!(out["format"], "binary-positions+meta");
-        assert_eq!(out["positions_url"], "http://127.0.0.1:8765/data/voicing-positions.bin");
-        assert_eq!(out["meta_url"], "http://127.0.0.1:8765/data/voicing-positions.meta.json");
+        assert_eq!(
+            out["positions_url"],
+            "http://127.0.0.1:8765/data/voicing-positions.bin"
+        );
+        assert_eq!(
+            out["meta_url"],
+            "http://127.0.0.1:8765/data/voicing-positions.meta.json"
+        );
         assert_eq!(out["scene_offset"], json!([200.0, 0.0, 0.0]));
         assert_eq!(out["default_spread"], 1.5);
         assert_eq!(out["default_point_size"], 0.3);
@@ -5330,12 +5326,16 @@ mod voicings_payload_tests {
             "default_spread": 0.0,
             "default_point_size": 1.2,
             "serve_url": "http://demo.local:9000/",
-        })).expect("ok");
+        }))
+        .expect("ok");
         assert_eq!(out["scene_offset"], json!([0.0, 0.0, 50.0]));
         assert_eq!(out["default_spread"], 0.0);
         assert_eq!(out["default_point_size"], 1.2);
         // Trailing slash gets stripped.
-        assert_eq!(out["positions_url"], "http://demo.local:9000/data/voicing-positions.bin");
+        assert_eq!(
+            out["positions_url"],
+            "http://demo.local:9000/data/voicing-positions.bin"
+        );
     }
 
     #[test]

--- a/crates/ix-agent/tests/autoresearch_smoke.rs
+++ b/crates/ix-agent/tests/autoresearch_smoke.rs
@@ -111,10 +111,7 @@ fn ix_autoresearch_run_sa_with_calibration_runs_to_completion() {
 fn ix_autoresearch_run_rejects_zero_iterations() {
     let reg = ToolRegistry::new();
     let err = reg
-        .call(
-            "ix_autoresearch_run",
-            json!({ "iterations": 0 }),
-        )
+        .call("ix_autoresearch_run", json!({ "iterations": 0 }))
         .expect_err("expected zero-iterations error");
     assert!(err.contains("≥ 1"), "got: {err}");
 }

--- a/crates/ix-agent/tests/grothendieck_smoke.rs
+++ b/crates/ix-agent/tests/grothendieck_smoke.rs
@@ -138,5 +138,8 @@ fn ix_grothendieck_delta_rejects_non_array_source() {
             }),
         )
         .expect_err("expected an error for non-array source");
-    assert!(err.contains("source"), "error should mention 'source': {err}");
+    assert!(
+        err.contains("source"),
+        "error should mention 'source': {err}"
+    );
 }

--- a/crates/ix-agent/tests/voicings_payload_contract.rs
+++ b/crates/ix-agent/tests/voicings_payload_contract.rs
@@ -46,15 +46,24 @@ fn payload_handler_matches_voicings_payload_v1_schema() {
         let url = payload[url_field]
             .as_str()
             .unwrap_or_else(|| panic!("{url_field} must be a string"));
-        assert!(url.starts_with("http"), "{url_field} should be an http URL, got {url}");
-        assert!(!url.ends_with('/'), "{url_field} should not end with a slash");
+        assert!(
+            url.starts_with("http"),
+            "{url_field} should be an http URL, got {url}"
+        );
+        assert!(
+            !url.ends_with('/'),
+            "{url_field} should not end with a slash"
+        );
     }
 
     let offset = payload["scene_offset"]
         .as_array()
         .expect("scene_offset is an array");
     assert_eq!(offset.len(), 3, "scene_offset must be [x,y,z]");
-    assert_eq!(offset[0], 200.0, "default x offset clears the governance graph");
+    assert_eq!(
+        offset[0], 200.0,
+        "default x offset clears the governance graph"
+    );
 
     assert!(
         payload["default_spread"].as_f64().unwrap() >= 0.0,
@@ -80,7 +89,10 @@ fn corpus_lazy_lookup_resolves_when_present() {
     }
     let bytes = std::fs::read(&bass_corpus).expect("read bass corpus");
     let entries: Vec<Value> = serde_json::from_slice(&bytes).expect("parse bass corpus");
-    assert!(!entries.is_empty(), "corpus should have at least one voicing");
+    assert!(
+        !entries.is_empty(),
+        "corpus should have at least one voicing"
+    );
     let first = &entries[0];
     assert!(
         first.get("instrument").and_then(|v| v.as_str()) == Some("bass"),
@@ -101,7 +113,9 @@ fn binary_buffer_layout_matches_meta_when_present() {
     let meta_path = project_root().join("state/viz/voicing-positions.meta.json");
 
     if !bin_path.exists() || !meta_path.exists() {
-        eprintln!("skipping: voicing-positions.{{bin,meta.json}} not present (run serve_viz first)");
+        eprintln!(
+            "skipping: voicing-positions.{{bin,meta.json}} not present (run serve_viz first)"
+        );
         return;
     }
 
@@ -109,9 +123,7 @@ fn binary_buffer_layout_matches_meta_when_present() {
     let meta: Value = serde_json::from_slice(&meta_bytes).expect("meta is JSON");
     let total = meta["total"].as_u64().expect("meta.total is integer") as usize;
 
-    let bin_size = std::fs::metadata(&bin_path)
-        .expect("stat bin")
-        .len() as usize;
+    let bin_size = std::fs::metadata(&bin_path).expect("stat bin").len() as usize;
     let expected = total * 3 * 4;
     assert_eq!(
         bin_size, expected,
@@ -131,5 +143,8 @@ fn binary_buffer_layout_matches_meta_when_present() {
         );
         running += count;
     }
-    assert_eq!(running, total, "sum of per-instrument counts ({running}) must equal total ({total})");
+    assert_eq!(
+        running, total,
+        "sum of per-instrument counts ({running}) must equal total ({total})"
+    );
 }

--- a/crates/ix-autoresearch/examples/phase6_demo.rs
+++ b/crates/ix-autoresearch/examples/phase6_demo.rs
@@ -202,7 +202,10 @@ fn main() {
     println!("  GA CLI:      {}", args.ga_cli.display());
     println!("  iterations:  {}", args.iterations);
     println!("  seed:        {}", args.seed);
-    println!("  --export-max {} per iter (small for demo speed)", EXPORT_MAX);
+    println!(
+        "  --export-max {} per iter (small for demo speed)",
+        EXPORT_MAX
+    );
     println!("  workdir:     {}", workdir.path().display());
     println!();
 
@@ -230,11 +233,7 @@ fn main() {
     println!();
     println!("=== Summary ===");
     let accepted: Vec<&IterResult> = results.iter().filter(|r| r.accepted).collect();
-    println!(
-        "  accepted: {}/{}",
-        accepted.len(),
-        results.len()
-    );
+    println!("  accepted: {}/{}", accepted.len(), results.len());
     if let Some(min_bytes) = accepted.iter().map(|r| r.index_bytes).min() {
         println!("  smallest index: {} bytes", min_bytes);
     }
@@ -256,7 +255,10 @@ fn main() {
     {
         println!();
         println!("=== Lex-best (smallest bytes, fastest tiebreak) ===");
-        println!("  bytes={}  elapsed={}ms", best.index_bytes, best.elapsed_ms);
+        println!(
+            "  bytes={}  elapsed={}ms",
+            best.index_bytes, best.elapsed_ms
+        );
         println!("  cfg: {}", fmt_cfg(&best.cfg));
     }
 }

--- a/crates/ix-autoresearch/examples/phase7_validate.rs
+++ b/crates/ix-autoresearch/examples/phase7_validate.rs
@@ -83,13 +83,18 @@ fn parse_args() -> Args {
             "--seeds" => seeds = argv.next().and_then(|s| s.parse().ok()).unwrap_or(3),
             "--export-max" => export_max = argv.next().and_then(|s| s.parse().ok()).unwrap_or(2000),
             "--base-seed" => {
-                base_seed = argv.next().and_then(|s| s.parse().ok()).unwrap_or(base_seed)
+                base_seed = argv
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(base_seed)
             }
             "--baseline" => {
                 baseline = match argv.next().as_deref() {
                     Some("production") => Baseline::Production,
                     Some("uniform") => Baseline::Uniform,
-                    Some(other) => panic!("--baseline must be 'production' or 'uniform'; got '{other}'"),
+                    Some(other) => {
+                        panic!("--baseline must be 'production' or 'uniform'; got '{other}'")
+                    }
                     None => panic!("--baseline requires an argument"),
                 }
             }

--- a/crates/ix-autoresearch/src/bin/ix-autoresearch.rs
+++ b/crates/ix-autoresearch/src/bin/ix-autoresearch.rs
@@ -175,9 +175,9 @@ fn main() -> ExitCode {
     let result: Result<(), String> = match cli.verb {
         Verb::Run(args) => verb_run(&runs_root, args, cli.quiet),
         Verb::Resume(args) => verb_resume(args, cli.quiet),
-        Verb::List {
-            include_milestones,
-        } => verb_list(&runs_root, &milestones_root, include_milestones),
+        Verb::List { include_milestones } => {
+            verb_list(&runs_root, &milestones_root, include_milestones)
+        }
         Verb::Promote(args) => verb_promote(&runs_root, &milestones_root, args, cli.quiet),
         Verb::Revert(args) => verb_revert(&runs_root, args),
     };
@@ -212,8 +212,15 @@ fn verb_run(runs_root: &std::path::Path, args: RunArgs, quiet: bool) -> Result<(
             )
             .map_err(|e| format!("run failed: {e}"))?;
             if !quiet {
-                print_outcome("grammar", &outcome.run_id, &outcome.log_path, outcome.iterations,
-                              outcome.accepted, outcome.best_reward, outcome.aborted_kills);
+                print_outcome(
+                    "grammar",
+                    &outcome.run_id,
+                    &outcome.log_path,
+                    outcome.iterations,
+                    outcome.accepted,
+                    outcome.best_reward,
+                    outcome.aborted_kills,
+                );
             }
         }
     }
@@ -234,8 +241,15 @@ fn verb_resume(args: ResumeArgs, quiet: bool) -> Result<(), String> {
             )
             .map_err(|e| format!("resume failed: {e}"))?;
             if !quiet {
-                print_outcome("grammar", &outcome.run_id, &outcome.log_path, outcome.iterations,
-                              outcome.accepted, outcome.best_reward, outcome.aborted_kills);
+                print_outcome(
+                    "grammar",
+                    &outcome.run_id,
+                    &outcome.log_path,
+                    outcome.iterations,
+                    outcome.accepted,
+                    outcome.best_reward,
+                    outcome.aborted_kills,
+                );
             }
         }
     }
@@ -313,8 +327,14 @@ fn verb_promote(
     args: PromoteArgs,
     quiet: bool,
 ) -> Result<(), String> {
-    let dst = promote_run(runs_root, milestones_root, &args.run_id, &args.note, args.force)
-        .map_err(|e| format!("promote failed: {e}"))?;
+    let dst = promote_run(
+        runs_root,
+        milestones_root,
+        &args.run_id,
+        &args.note,
+        args.force,
+    )
+    .map_err(|e| format!("promote failed: {e}"))?;
     if !quiet {
         println!("promoted: {}", dst.display());
     }

--- a/crates/ix-autoresearch/src/cache.rs
+++ b/crates/ix-autoresearch/src/cache.rs
@@ -66,7 +66,9 @@ impl CacheBridge {
     /// Compute the cache key for a config. Returns `None` when caching
     /// is disabled. Hash is `blake3(serde_json(config) || salt)`.
     pub fn key_for<C: Serialize>(&self, config: &C) -> Result<Option<String>, AutoresearchError> {
-        let Some(salt) = &self.salt else { return Ok(None) };
+        let Some(salt) = &self.salt else {
+            return Ok(None);
+        };
         let mut buf = serde_json::to_vec(config)?;
         buf.extend_from_slice(salt.as_bytes());
         let hash = blake3::hash(&buf);
@@ -80,7 +82,9 @@ impl CacheBridge {
         C: Serialize,
         S: DeserializeOwned,
     {
-        let Some(key) = self.key_for(config)? else { return Ok(None) };
+        let Some(key) = self.key_for(config)? else {
+            return Ok(None);
+        };
         Ok(global_cache().get::<S>(&key))
     }
 
@@ -90,7 +94,9 @@ impl CacheBridge {
         C: Serialize,
         S: Serialize,
     {
-        let Some(key) = self.key_for(config)? else { return Ok(()) };
+        let Some(key) = self.key_for(config)? else {
+            return Ok(());
+        };
         global_cache().set_with_ttl(&key, score, self.ttl);
         Ok(())
     }

--- a/crates/ix-autoresearch/src/lib.rs
+++ b/crates/ix-autoresearch/src/lib.rs
@@ -69,9 +69,7 @@ pub use policy::{
 };
 pub use target_chatbot::{ChatbotConfig, ChatbotScore, ChatbotTarget};
 pub use target_grammar::{GrammarConfig, GrammarScore, GrammarTarget};
-pub use target_optick::{
-    CIReducedConfig, OpticKConfig, OpticKScore, OpticKTarget, RebuildMode,
-};
+pub use target_optick::{CIReducedConfig, OpticKConfig, OpticKScore, OpticKTarget, RebuildMode};
 pub use time_budget::TimeBudget;
 
 use std::path::{Path, PathBuf};
@@ -110,8 +108,8 @@ impl RunId {
     /// [`validate_run_id`].
     pub fn parse(s: &str) -> Result<Self, AutoresearchError> {
         let canonical = validate_run_id(s)?;
-        let parsed = uuid::Uuid::parse_str(&canonical)
-            .expect("validate_run_id returned non-UUID string");
+        let parsed =
+            uuid::Uuid::parse_str(&canonical).expect("validate_run_id returned non-UUID string");
         Ok(Self(parsed))
     }
 
@@ -641,8 +639,7 @@ fn resolve_sa_calibration<E: Experiment>(
             initial_temperature: None,
             cooling_rate,
         } => {
-            let baseline_score = experiment
-                .evaluate(baseline, budget.soft_deadline_from_now())?;
+            let baseline_score = experiment.evaluate(baseline, budget.soft_deadline_from_now())?;
             let baseline_reward = experiment.score_to_reward(&baseline_score);
             // Distinct seed for calibration so it doesn't deplete the main loop's RNG stream.
             let mut calib_rng = ChaCha8Rng::seed_from_u64(seed.wrapping_add(0xCA1B_EAFE));
@@ -664,10 +661,7 @@ fn resolve_sa_calibration<E: Experiment>(
 
 /// Compute the cache key + a "config hash" string for log entries.
 /// When caching is disabled we still produce a hash for log uniqueness.
-fn config_hash<C: Serialize>(
-    cache: &CacheBridge,
-    config: &C,
-) -> Result<String, AutoresearchError> {
+fn config_hash<C: Serialize>(cache: &CacheBridge, config: &C) -> Result<String, AutoresearchError> {
     if let Some(k) = cache.key_for(config)? {
         return Ok(k);
     }
@@ -684,7 +678,10 @@ fn best_effort_git_sha() -> (Option<String>, Option<String>) {
     match output {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8_lossy(&o.stdout).trim().to_string();
-            if s.len() == 40 && s.chars().all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()) {
+            if s.len() == 40
+                && s.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+            {
                 (Some(s), None)
             } else {
                 (None, Some("malformed sha".to_string()))
@@ -765,9 +762,8 @@ where
         }
     }
 
-    let run_id = run_id.ok_or_else(|| {
-        AutoresearchError::InvalidRunId("log has no RunStart event".to_string())
-    })?;
+    let run_id = run_id
+        .ok_or_else(|| AutoresearchError::InvalidRunId("log has no RunStart event".to_string()))?;
     let baseline = baseline.ok_or_else(|| {
         AutoresearchError::InvalidRunId("log has no baseline_config in RunStart".to_string())
     })?;

--- a/crates/ix-autoresearch/src/log.rs
+++ b/crates/ix-autoresearch/src/log.rs
@@ -168,10 +168,7 @@ impl JsonlLog {
     /// already exist; this fails fast on missing parent or unwritable target.
     pub fn open(path: impl Into<PathBuf>, policy: FsyncPolicy) -> Result<Self, AutoresearchError> {
         let path = path.into();
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)?;
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
         Ok(Self {
             file,
             path,
@@ -236,9 +233,7 @@ where
 {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
-    let lines: Vec<String> = reader
-        .lines()
-        .collect::<std::io::Result<Vec<_>>>()?;
+    let lines: Vec<String> = reader.lines().collect::<std::io::Result<Vec<_>>>()?;
 
     let mut out: Vec<LogEvent<C, S>> = Vec::with_capacity(lines.len());
     let total = lines.len();

--- a/crates/ix-autoresearch/src/milestones.rs
+++ b/crates/ix-autoresearch/src/milestones.rs
@@ -25,13 +25,13 @@ const MAX_SLUG_TAIL: usize = 63;
 /// Patterns that indicate a leak in promote sanitization. Adding to this
 /// list does NOT bump the schema; it strengthens the safety net.
 const REDACTION_PATTERNS: &[&str] = &[
-    "sk-ant-",          // Anthropic API key prefix
-    "Bearer ",          // Generic OAuth bearer
-    "AKIA",             // AWS access key prefix
-    "ghp_",             // GitHub personal access token
-    "ghs_",             // GitHub server token
-    "github_pat_",      // GitHub fine-grained token prefix
-    "AIza",             // Google API key prefix
+    "sk-ant-",     // Anthropic API key prefix
+    "Bearer ",     // Generic OAuth bearer
+    "AKIA",        // AWS access key prefix
+    "ghp_",        // GitHub personal access token
+    "ghs_",        // GitHub server token
+    "github_pat_", // GitHub fine-grained token prefix
+    "AIza",        // Google API key prefix
 ];
 
 /// Validate a milestone slug. Slugs must:

--- a/crates/ix-autoresearch/src/policy.rs
+++ b/crates/ix-autoresearch/src/policy.rs
@@ -98,9 +98,9 @@ impl Strategy {
                 })
             }
             Self::RandomSearch => Box::new(RandomSearchPolicy),
-            Self::Custom => panic!(
-                "Strategy::Custom is reserved for v1.5+; cannot construct a policy in v1"
-            ),
+            Self::Custom => {
+                panic!("Strategy::Custom is reserved for v1.5+; cannot construct a policy in v1")
+            }
         }
     }
 
@@ -301,7 +301,10 @@ mod tests {
             })
             .count();
         let rate = downhill_accepts as f64 / trials as f64;
-        assert!(rate > 0.5, "high-T SA should accept most downhill moves; rate={rate}");
+        assert!(
+            rate > 0.5,
+            "high-T SA should accept most downhill moves; rate={rate}"
+        );
     }
 
     #[test]

--- a/crates/ix-autoresearch/src/target_chatbot.rs
+++ b/crates/ix-autoresearch/src/target_chatbot.rs
@@ -170,7 +170,14 @@ impl Experiment for ChatbotTarget {
         let mut cmd = Command::new(&self.chatbot_bin);
         cmd.env_clear();
         // Allow-list only what the subprocess truly needs.
-        for var in &["PATH", "SystemRoot", "USERPROFILE", "TEMP", "TMP", "RUST_BACKTRACE"] {
+        for var in &[
+            "PATH",
+            "SystemRoot",
+            "USERPROFILE",
+            "TEMP",
+            "TMP",
+            "RUST_BACKTRACE",
+        ] {
             if let Ok(v) = std::env::var(var) {
                 cmd.env(var, v);
             }
@@ -226,10 +233,7 @@ impl Experiment for ChatbotTarget {
                     reason: "summary.json missing match_rate".to_string(),
                 })
             })?;
-        let total = summary
-            .get("total")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(1) as f64;
+        let total = summary.get("total").and_then(|v| v.as_u64()).unwrap_or(1) as f64;
 
         // Compute FP / FN from the mismatches array.
         let mismatches = summary

--- a/crates/ix-autoresearch/src/target_grammar.rs
+++ b/crates/ix-autoresearch/src/target_grammar.rs
@@ -334,7 +334,10 @@ mod tests {
         let mut t = GrammarTarget::default_smoke();
         let baseline = t.baseline();
         let score = t
-            .evaluate(&baseline, Instant::now() + std::time::Duration::from_secs(1))
+            .evaluate(
+                &baseline,
+                Instant::now() + std::time::Duration::from_secs(1),
+            )
             .unwrap();
         assert!(
             (score.parse_success_rate - 1.0 / 6.0).abs() < 1e-12,

--- a/crates/ix-autoresearch/src/target_optick.rs
+++ b/crates/ix-autoresearch/src/target_optick.rs
@@ -344,7 +344,11 @@ impl Experiment for OpticKTarget {
                 reason: format!("weights must sum to ≈ 1.0; got sum = {s:.6}"),
             }));
         }
-        if config.as_array().iter().any(|w| !w.is_finite() || *w < -1e-12) {
+        if config
+            .as_array()
+            .iter()
+            .any(|w| !w.is_finite() || *w < -1e-12)
+        {
             return Err(AutoresearchError::EvalFailed(EvalCategory::InvalidConfig {
                 reason: "weights must be non-negative and finite".to_string(),
             }));
@@ -482,15 +486,9 @@ impl OpticKTarget {
             .map_err(|e| internal(format!("create diag dir: {e}")))?;
         let mut diag_args: Vec<String> = vec![
             "--index".into(),
-            index_path
-                .to_str()
-                .ok_or_else(non_utf8_path)?
-                .to_string(),
+            index_path.to_str().ok_or_else(non_utf8_path)?.to_string(),
             "--out-dir".into(),
-            diag_dir
-                .to_str()
-                .ok_or_else(non_utf8_path)?
-                .to_string(),
+            diag_dir.to_str().ok_or_else(non_utf8_path)?.to_string(),
             "--n-trees".into(),
             cfg.n_trees.to_string(),
             "--tree-depth".into(),
@@ -549,12 +547,11 @@ impl OpticKTarget {
     /// values purely from the config's distance to true_optimum.
     fn synthetic_score(&self, config: &OpticKConfig) -> OpticKScore {
         let l1 = self.l1_to_optimum(config); // ∈ [0, 2]
-        // Linear scale: l1=0 → leak=0; l1=2 → leak=1.
+                                             // Linear scale: l1=0 → leak=0; l1=2 → leak=1.
         let structure_leak_pct = (l1 / 2.0).clamp(0.0, 1.0);
         // Inverse of leak with a tiny "structural prior" so retrieval
         // doesn't track leak exactly. v1: retrieval = 1 − leak² (concave).
-        let retrieval_match_pct =
-            (1.0 - structure_leak_pct.powi(2)).clamp(0.0, 1.0);
+        let retrieval_match_pct = (1.0 - structure_leak_pct.powi(2)).clamp(0.0, 1.0);
         // Synthetic invariant pass rates: smoothly decay with leak.
         let inv_25_pass_rate = (1.0 - structure_leak_pct).clamp(0.0, 1.0);
         let inv_32_pass_rate = (1.0 - structure_leak_pct).clamp(0.0, 1.0);
@@ -571,10 +568,7 @@ impl OpticKTarget {
 
 // ─── Live evaluator helpers ─────────────────────────────────────────────
 
-fn write_weights_json(
-    config: &OpticKConfig,
-    path: &Path,
-) -> Result<(), AutoresearchError> {
+fn write_weights_json(config: &OpticKConfig, path: &Path) -> Result<(), AutoresearchError> {
     let payload = serde_json::json!({
         "schema_version":   1,
         "structure_weight":  config.structure_weight,
@@ -663,9 +657,7 @@ fn parse_invariant_pass_rates(stderr: &str) -> (f64, f64, f64) {
 
 /// Locate `embedding-diagnostics-*.json` inside `diag_dir` (date-stamped
 /// filename) and parse it as a generic JSON value.
-fn find_and_parse_diag_report(
-    diag_dir: &Path,
-) -> Result<serde_json::Value, AutoresearchError> {
+fn find_and_parse_diag_report(diag_dir: &Path) -> Result<serde_json::Value, AutoresearchError> {
     let entries =
         std::fs::read_dir(diag_dir).map_err(|e| internal(format!("read diag_dir: {e}")))?;
     let mut report_path: Option<PathBuf> = None;
@@ -808,7 +800,10 @@ mod tests {
         let mut t = make_target();
         let baseline = t.baseline();
         let score = t
-            .evaluate(&baseline, Instant::now() + std::time::Duration::from_secs(1))
+            .evaluate(
+                &baseline,
+                Instant::now() + std::time::Duration::from_secs(1),
+            )
             .unwrap();
         assert!(score.structure_leak_pct > 0.0);
         assert!(score.structure_leak_pct < 1.0);

--- a/crates/ix-autoresearch/tests/grammar_e2e.rs
+++ b/crates/ix-autoresearch/tests/grammar_e2e.rs
@@ -11,9 +11,7 @@ use std::time::{Duration, Instant};
 
 use tempfile::TempDir;
 
-use ix_autoresearch::{
-    run_experiment, Experiment, GrammarTarget, LogEvent, Strategy, TimeBudget,
-};
+use ix_autoresearch::{run_experiment, Experiment, GrammarTarget, LogEvent, Strategy, TimeBudget};
 
 #[test]
 fn sa_finds_improvement_over_uniform_baseline_on_skewed_held_out() {
@@ -25,10 +23,7 @@ fn sa_finds_improvement_over_uniform_baseline_on_skewed_held_out() {
 
     // Compute baseline reward (deterministic, no eval cost — just calls evaluate once).
     let baseline_score = target
-        .evaluate(
-            &target.baseline(),
-            Instant::now() + Duration::from_secs(1),
-        )
+        .evaluate(&target.baseline(), Instant::now() + Duration::from_secs(1))
         .unwrap();
     let baseline_reward = target.score_to_reward(&baseline_score);
     // Sanity: 1/6 + 0.1 * ess_stability_at_uniform.

--- a/crates/ix-autoresearch/tests/jsonl_contract.rs
+++ b/crates/ix-autoresearch/tests/jsonl_contract.rs
@@ -88,9 +88,19 @@ fn every_line_validates_against_pinned_schema() {
         match event {
             "run_start" => {
                 assert!(!seen_run_start, "duplicate run_start at line {i}");
-                assert!(!seen_run_complete, "run_start after run_complete at line {i}");
+                assert!(
+                    !seen_run_complete,
+                    "run_start after run_complete at line {i}"
+                );
                 assert_eq!(i, 0, "run_start must be the first line");
-                for req in ["run_id", "timestamp", "target", "strategy", "seed", "baseline_config"] {
+                for req in [
+                    "run_id",
+                    "timestamp",
+                    "target",
+                    "strategy",
+                    "seed",
+                    "baseline_config",
+                ] {
                     assert!(
                         v.get(req).is_some(),
                         "run_start line {i} missing required field `{req}`"
@@ -100,7 +110,10 @@ fn every_line_validates_against_pinned_schema() {
             }
             "iteration" => {
                 assert!(seen_run_start, "iteration before run_start at line {i}");
-                assert!(!seen_run_complete, "iteration after run_complete at line {i}");
+                assert!(
+                    !seen_run_complete,
+                    "iteration after run_complete at line {i}"
+                );
                 for req in [
                     "iteration",
                     "timestamp",
@@ -200,7 +213,10 @@ fn deterministic_replay_same_seed_produces_same_config_hash_sequence() {
 
     let a = extract(&path_a);
     let b = extract(&path_b);
-    assert_eq!(a, b, "same-seed runs must produce identical config_hash sequence");
+    assert_eq!(
+        a, b,
+        "same-seed runs must produce identical config_hash sequence"
+    );
 }
 
 /// Derived semantic event view (per SCHEMA.md "Layer 2"). Produced by
@@ -414,12 +430,19 @@ fn contradictory_findings_preserved_in_derived_view() {
 
 #[test]
 fn json_schema_file_is_present_and_well_formed() {
-    let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("jsonl-event.schema.json");
+    let schema_path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("jsonl-event.schema.json");
     let raw = std::fs::read_to_string(&schema_path)
         .unwrap_or_else(|e| panic!("missing {}: {e}", schema_path.display()));
     let parsed: Value = serde_json::from_str(&raw).expect("schema is valid JSON");
-    assert_eq!(parsed.get("$schema").and_then(Value::as_str).unwrap_or(""),
-               "https://json-schema.org/draft/2020-12/schema");
+    assert_eq!(
+        parsed.get("$schema").and_then(Value::as_str).unwrap_or(""),
+        "https://json-schema.org/draft/2020-12/schema"
+    );
     let one_of = parsed.get("oneOf").and_then(Value::as_array).unwrap();
-    assert_eq!(one_of.len(), 3, "schema must define run_start, iteration, run_complete");
+    assert_eq!(
+        one_of.len(),
+        3,
+        "schema must define run_start, iteration, run_complete"
+    );
 }

--- a/crates/ix-autoresearch/tests/kernel.rs
+++ b/crates/ix-autoresearch/tests/kernel.rs
@@ -14,8 +14,8 @@ use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 
 use ix_autoresearch::{
-    promote_run, resume_experiment, run_experiment, sanitize_text, validate_run_id,
-    validate_slug, AutoresearchError, EvalCategory, Experiment, LogEvent, Strategy, TimeBudget,
+    promote_run, resume_experiment, run_experiment, sanitize_text, validate_run_id, validate_slug,
+    AutoresearchError, EvalCategory, Experiment, LogEvent, Strategy, TimeBudget,
     HARD_KILL_CASCADE_THRESHOLD, MCP_ITERATION_CAP,
 };
 
@@ -332,7 +332,10 @@ fn three_consecutive_hard_kills_aborts_run() {
         ..
     } = last
     {
-        assert_eq!(*consecutive_kills_at_abort, Some(HARD_KILL_CASCADE_THRESHOLD));
+        assert_eq!(
+            *consecutive_kills_at_abort,
+            Some(HARD_KILL_CASCADE_THRESHOLD)
+        );
     } else {
         panic!("last event should be RunComplete");
     }
@@ -385,7 +388,12 @@ fn slug_regex_rejects_path_traversal_and_unsafe_chars() {
             "should have rejected slug {bad:?}"
         );
     }
-    for good in &["ok", "1", "first-overnight-tune", "2026-04-26-grammar-smoke"] {
+    for good in &[
+        "ok",
+        "1",
+        "first-overnight-tune",
+        "2026-04-26-grammar-smoke",
+    ] {
         assert!(
             validate_slug(good).is_ok(),
             "should have accepted slug {good:?}"

--- a/crates/ix-blast-radius/src/lib.rs
+++ b/crates/ix-blast-radius/src/lib.rs
@@ -206,11 +206,7 @@ pub fn one_way_doors_in(paths: &[String]) -> Vec<String> {
 /// changes have the widest blast radius; one-way doors gate merge so
 /// they push hard; component count breadth contributes a small bump
 /// past five touched components.
-pub fn score_blast(
-    layers: &[Layer],
-    one_way_doors: &[String],
-    components: &[String],
-) -> f64 {
+pub fn score_blast(layers: &[Layer], one_way_doors: &[String], components: &[String]) -> f64 {
     let mut score: f64 = 0.0;
     score += (layers.len() as f64 * 0.10).min(0.40);
     score += (one_way_doors.len() as f64 * 0.15).min(0.50);
@@ -307,8 +303,7 @@ mod tests {
 
     #[test]
     fn schema_change_recorded_as_one_way_door() {
-        let doors =
-            one_way_doors_in(&["docs/contracts/some-thing.schema.json".into()]);
+        let doors = one_way_doors_in(&["docs/contracts/some-thing.schema.json".into()]);
         assert_eq!(doors.len(), 1);
         assert!(doors[0].starts_with("contract:"));
     }

--- a/crates/ix-blast-radius/src/main.rs
+++ b/crates/ix-blast-radius/src/main.rs
@@ -33,10 +33,7 @@ fn main() {
 
     let raw = match cli.paths_file {
         Some(path) => std::fs::read_to_string(&path).unwrap_or_else(|e| {
-            eprintln!(
-                "[ix-blast-radius] cannot read {}: {e}",
-                path.display()
-            );
+            eprintln!("[ix-blast-radius] cannot read {}: {e}", path.display());
             std::process::exit(2);
         }),
         None => {
@@ -70,4 +67,3 @@ fn main() {
     });
     println!("{out}");
 }
-

--- a/crates/ix-bracelet/src/grothendieck.rs
+++ b/crates/ix-bracelet/src/grothendieck.rs
@@ -445,9 +445,9 @@ mod tests {
         // At cost 0, we get the entire orbit of src (all sets with the same ICV
         // *via the major-triad orbit*; Z-relations would not appear here since
         // they are different orbit reps).
-        assert!(near.iter().any(|(s, d, c)| {
-            *s == src && d.is_zero() && *c == 0
-        }));
+        assert!(near
+            .iter()
+            .any(|(s, d, c)| { *s == src && d.is_zero() && *c == 0 }));
     }
 
     #[test]
@@ -516,7 +516,10 @@ mod tests {
     fn z_related_pairs_have_identical_icvs() {
         // Definitional check: every pair returned must share an ICV.
         let pairs = z_related_pairs();
-        assert!(!pairs.is_empty(), "12-TET has known Z-pairs at cardinalities 4-8");
+        assert!(
+            !pairs.is_empty(),
+            "12-TET has known Z-pairs at cardinalities 4-8"
+        );
         for (a, b) in &pairs {
             assert_eq!(
                 icv(*a),
@@ -584,7 +587,10 @@ mod tests {
         let c_maj_scale = pcset(&[0, 2, 4, 5, 7, 9, 11]);
         let g_maj_scale = pcset(&[0, 2, 4, 6, 7, 9, 11]); // C major + F♯ instead of F
         let path = find_shortest_path(c_maj_scale, g_maj_scale, 8);
-        assert!(!path.is_empty(), "expected a path between adjacent diatonic scales");
+        assert!(
+            !path.is_empty(),
+            "expected a path between adjacent diatonic scales"
+        );
         assert_eq!(*path.first().unwrap(), c_maj_scale);
         assert_eq!(*path.last().unwrap(), g_maj_scale);
     }

--- a/crates/ix-manifold/src/lib.rs
+++ b/crates/ix-manifold/src/lib.rs
@@ -112,10 +112,7 @@ impl Tsne {
     /// low-dim embedding (rows = samples, cols = `target_dim`).
     pub fn fit_transform(&self, x: ArrayView2<f64>) -> Array2<f64> {
         let n = x.nrows();
-        assert!(
-            n >= 2,
-            "t-SNE needs ≥ 2 samples; got {n}"
-        );
+        assert!(n >= 2, "t-SNE needs ≥ 2 samples; got {n}");
         assert!(
             self.perplexity < ((n - 1) as f64) / 3.0,
             "perplexity {} too large for {} samples (must be < (n-1)/3 = {})",
@@ -133,9 +130,8 @@ impl Tsne {
 
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let normal = Normal::new(0.0, 1e-4_f64.sqrt()).unwrap();
-        let mut y: Array2<f64> = Array2::from_shape_fn((n, self.target_dim), |_| {
-            normal.sample(&mut rng)
-        });
+        let mut y: Array2<f64> =
+            Array2::from_shape_fn((n, self.target_dim), |_| normal.sample(&mut rng));
         let mut y_prev = y.clone();
         let mut p_eff = p.clone();
         p_eff *= self.early_exaggeration;
@@ -176,10 +172,7 @@ fn pairwise_sq_dist(x: ArrayView2<f64>) -> Array2<f64> {
 
 #[inline]
 fn sq_dist(a: ArrayView1<f64>, b: ArrayView1<f64>) -> f64 {
-    a.iter()
-        .zip(b.iter())
-        .map(|(x, y)| (x - y).powi(2))
-        .sum()
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum()
 }
 
 /// Compute the conditional probability matrix P with per-row σ_i
@@ -266,7 +259,11 @@ fn compute_gradient(y: &Array2<f64>, p: &Array2<f64>) -> Array2<f64> {
     let mut num = Array2::<f64>::zeros((n, n));
     for i in 0..n {
         for j in 0..n {
-            num[[i, j]] = if i == j { 0.0 } else { 1.0 / (1.0 + dist_sq[[i, j]]) };
+            num[[i, j]] = if i == j {
+                0.0
+            } else {
+                1.0 / (1.0 + dist_sq[[i, j]])
+            };
         }
     }
     let z: f64 = num.sum();
@@ -437,7 +434,10 @@ mod tests {
     #[test]
     fn deterministic_with_same_seed() {
         let x = Array2::<f64>::from_shape_fn((30, 5), |(i, j)| ((i + j) as f64).sin());
-        let cfg = Tsne::new().with_n_iter(100).with_perplexity(5.0).with_seed(42);
+        let cfg = Tsne::new()
+            .with_n_iter(100)
+            .with_perplexity(5.0)
+            .with_seed(42);
         let a = cfg.clone().fit_transform(x.view());
         let b = cfg.fit_transform(x.view());
         for (av, bv) in a.iter().zip(b.iter()) {
@@ -515,9 +515,7 @@ mod tests {
     fn perplexity_too_large_panics() {
         // n=10, perplexity=30 → (n-1)/3 = 3, so 30 is invalid.
         let x = Array2::<f64>::eye(10);
-        let _ = Tsne::new()
-            .with_perplexity(30.0)
-            .fit_transform(x.view());
+        let _ = Tsne::new().with_perplexity(30.0).fit_transform(x.view());
     }
 
     #[test]

--- a/crates/ix-optick-invariants/src/main.rs
+++ b/crates/ix-optick-invariants/src/main.rs
@@ -165,9 +165,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Exit non-zero if any invariant failed — lets CI gate on regressions.
-    let any_failed = (tested25 - passed25) > 0
-        || (tested32 - passed32) > 0
-        || (tested36 - passed36) > 0;
+    let any_failed =
+        (tested25 - passed25) > 0 || (tested32 - passed32) > 0 || (tested36 - passed36) > 0;
     if any_failed {
         std::process::exit(1);
     }
@@ -204,11 +203,7 @@ fn check_invariant_36_z_pair_separation(
             .into_iter()
             .find_map(|s| by_pcs_all.get(&s.raw()).and_then(|vs| vs.first().copied()));
 
-        let exemplar_id = format!(
-            "z-pair-0x{:03X}-0x{:03X}",
-            rep_a.raw(),
-            rep_b.raw()
-        );
+        let exemplar_id = format!("z-pair-0x{:03X}-0x{:03X}", rep_a.raw(), rep_b.raw());
         let card = rep_a.cardinality();
         let description = format!(
             "Z-pair card={} {{ {} }} ↔ {{ {} }}",
@@ -231,8 +226,12 @@ fn check_invariant_36_z_pair_separation(
             kind: "embedding-invariant".to_string(),
         });
 
-        let Some(vec_a) = index.vector(vidx_a) else { continue };
-        let Some(vec_b) = index.vector(vidx_b) else { continue };
+        let Some(vec_a) = index.vector(vidx_a) else {
+            continue;
+        };
+        let Some(vec_b) = index.vector(vidx_b) else {
+            continue;
+        };
         let slice_a = &vec_a[STRUCTURE_OFFSET..STRUCTURE_OFFSET + STRUCTURE_DIM];
         let slice_b = &vec_b[STRUCTURE_OFFSET..STRUCTURE_OFFSET + STRUCTURE_DIM];
         let cos = cosine(slice_a, slice_b);
@@ -335,10 +334,8 @@ fn check_invariant_32(
     by_pcs_all: &BTreeMap<u16, Vec<usize>>,
     cosine_tolerance: f32,
 ) -> (Vec<Exemplar>, BTreeSet<String>, Vec<String>) {
-    let multi_voicing: Vec<(&u16, &Vec<usize>)> = by_pcs_all
-        .iter()
-        .filter(|(_, vs)| vs.len() >= 2)
-        .collect();
+    let multi_voicing: Vec<(&u16, &Vec<usize>)> =
+        by_pcs_all.iter().filter(|(_, vs)| vs.len() >= 2).collect();
 
     let mut exemplars = Vec::new();
     let mut fired = BTreeSet::new();

--- a/crates/ix-optick-sae/src/bin/ix-optick-sae.rs
+++ b/crates/ix-optick-sae/src/bin/ix-optick-sae.rs
@@ -11,8 +11,7 @@ use ix_optick_sae::trainer::{
 use ix_optick_sae::{validate_artifact, SaeArtifact, DEAD_FEATURES_PCT_GUARDRAIL};
 
 // Resolved at compile time so the binary always knows where its Python trainer lives.
-const DEFAULT_PYTHON_SCRIPT: &str =
-    concat!(env!("CARGO_MANIFEST_DIR"), "/python/train.py");
+const DEFAULT_PYTHON_SCRIPT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/python/train.py");
 
 #[derive(Parser)]
 #[command(
@@ -167,8 +166,8 @@ fn finish(output_dir: PathBuf, artifact_id: &str) -> Result<(), Box<dyn std::err
     let json = fs::read_to_string(&artifact_path)
         .map_err(|e| format!("cannot read artifact at {}: {e}", artifact_path.display()))?;
 
-    let artifact: SaeArtifact = serde_json::from_str(&json)
-        .map_err(|e| format!("artifact JSON is malformed: {e}"))?;
+    let artifact: SaeArtifact =
+        serde_json::from_str(&json).map_err(|e| format!("artifact JSON is malformed: {e}"))?;
 
     validate_artifact(&artifact).map_err(|e| format!("artifact validation failed: {e}"))?;
 

--- a/crates/ix-optick-sae/src/lib.rs
+++ b/crates/ix-optick-sae/src/lib.rs
@@ -12,7 +12,12 @@ pub const DEAD_FEATURES_PCT_GUARDRAIL: f64 = 30.0;
 // carries chord-root identity which is critical for similarity comparisons.
 // Source: state/quality/optick-sae/2026-05-04/optick-sae-artifact.json (canonical baseline).
 pub const PHASE1_PARTITIONS: &[&str] = &[
-    "STRUCTURE", "MORPHOLOGY", "CONTEXT", "SYMBOLIC", "MODAL", "ROOT",
+    "STRUCTURE",
+    "MORPHOLOGY",
+    "CONTEXT",
+    "SYMBOLIC",
+    "MODAL",
+    "ROOT",
 ];
 
 // ── Artifact JSON shape (mirrors optick-sae-artifact.schema.json v0.1) ─────────
@@ -110,14 +115,10 @@ pub enum ValidationError {
     #[error("schema_version must be {expected}, got {got}")]
     WrongSchemaVersion { expected: u32, got: u32 },
 
-    #[error(
-        "artifact_id '{id}' is not filename-safe (must not contain ':' or '/')"
-    )]
+    #[error("artifact_id '{id}' is not filename-safe (must not contain ':' or '/')")]
     InvalidArtifactId { id: String },
 
-    #[error(
-        "reconstruction_mse {mse:.8} exceeds guardrail {guardrail:.2} — artifact not emitted"
-    )]
+    #[error("reconstruction_mse {mse:.8} exceeds guardrail {guardrail:.2} — artifact not emitted")]
     ReconstructionMseTooHigh { mse: f64, guardrail: f64 },
 
     #[error(
@@ -246,7 +247,10 @@ mod tests {
     #[test]
     fn mse_above_guardrail_fails() {
         let err = validate_artifact(&stub_artifact(0.051, 10.0)).unwrap_err();
-        assert!(matches!(err, ValidationError::ReconstructionMseTooHigh { .. }));
+        assert!(matches!(
+            err,
+            ValidationError::ReconstructionMseTooHigh { .. }
+        ));
     }
 
     #[test]

--- a/crates/ix-optick-sae/src/trainer.rs
+++ b/crates/ix-optick-sae/src/trainer.rs
@@ -104,7 +104,9 @@ pub fn run_python_trainer(
     match status.code() {
         Some(0) => Ok(()),
         Some(EXIT_MSE_FAIL) => Err(TrainerError::MseGuardrailExceeded),
-        Some(EXIT_DEAD_FEATURES) => Err(TrainerError::UnexpectedExitCode { code: EXIT_DEAD_FEATURES }),
+        Some(EXIT_DEAD_FEATURES) => Err(TrainerError::UnexpectedExitCode {
+            code: EXIT_DEAD_FEATURES,
+        }),
         Some(code) => Err(TrainerError::UnexpectedExitCode { code }),
         None => Err(TrainerError::KilledBySignal),
     }

--- a/crates/ix-optick-sae/tests/partition_contract.rs
+++ b/crates/ix-optick-sae/tests/partition_contract.rs
@@ -58,8 +58,8 @@ fn phase1_partitions_match_canonical_baseline() {
 
 #[test]
 fn compact_training_dim_matches_canonical_baseline() {
-    let canonical: CanonicalSnapshot = serde_json::from_str(CANONICAL_FIXTURE)
-        .expect("canonical-partitions.json failed to parse");
+    let canonical: CanonicalSnapshot =
+        serde_json::from_str(CANONICAL_FIXTURE).expect("canonical-partitions.json failed to parse");
 
     // The OPTIC-K v1.8 partition widths (from
     // ga/Common/GA.Business.ML/Embeddings/EmbeddingSchema.cs SimilarityPartitions):


### PR DESCRIPTION
## Why

`risk-report` has been failing as an advisory red on every new PR to `GuitarAlchemist/ix` due to chronic format drift accumulated on `main`. Tonight's wave-1 agent sweep flagged this independently three times — the drift originated in PR #43 (`ga-chatbot/src/algebra.rs` and `ix-agent/src/handlers.rs`) but has since spread.

## What

Pure `cargo fmt --all`. 31 files reformatted, 384 insertions / 267 deletions — all whitespace and line-wrapping. **No semantic changes.** Verified by eyeballing the diff (long argument lists wrapped, `use` imports split across lines, multi-line `format!` calls).

## Verification

- `cargo fmt --all` clean (this PR is the result)
- Sampled diffs in `ga-chatbot/src/algebra.rs` and `ix-agent/src/handlers.rs` confirmed whitespace-only
- Expected effect: `risk-report` advisory goes green on next PR

## Risk

Zero behavioral risk. Pure formatting.