### PR TITLE
docs: add CONTEXT.md (2) and CONTRACTS.md (12) for stable-tier crates

### DIFF
--- a/crates/ix-autoresearch/CONTEXT.md
+++ b/crates/ix-autoresearch/CONTEXT.md
@@ -1,0 +1,57 @@
+# ix-autoresearch Context
+
+> Fresh-session orientation for this crate. Read BEFORE touching it.
+
+## What this crate is
+
+Karpathy-style edit-eval-iterate kernel. Drives autonomous experiment loops over IX subsystems: perturb a config, evaluate (with deadline), accept/reject via a `Strategy`, append a JSONL `LogEvent`, update best-so-far on `(reward: f64, iteration: usize)`, repeat. Three target adapters ship today: `target_grammar` (sub-second smoke), `target_chatbot` (~30s/iter QA threshold tuning), `target_optick` (~140s/iter cross-language OPTIC-K self-tune). Per-run state is written under `state/autoresearch/runs/<uuidv7>/log.jsonl`; promotion to `state/autoresearch/milestones/<slug>/` is a separate sanitizing step.
+
+## Key invariants (DO NOT VIOLATE)
+
+- `Experiment::Config` MUST serialize deterministically — no `HashMap`; use `BTreeMap` or plain structs.
+- Best-so-far is keyed on scalar `(reward: f64, iteration)`, NOT on `Score: PartialOrd` (PartialOrd is partial; would corrupt tie-breaks). Score is returned alongside but never compared.
+- `HARD_KILL_CASCADE_THRESHOLD = 3`: after 3 consecutive `HardKilled` errors the kernel aborts the run. Do not raise this without a plan revision.
+- `MCP_ITERATION_CAP = 10_000`: MCP handler rejects `iterations > cap`. CLI is unconstrained.
+- `eval_inputs_hash()` MUST be a content hash, never a path hash — path hashes leak `C:\Users\<name>\…` into committed milestones (caught in security review).
+- The per-run leaf dir is created with `create_dir` (not `create_dir_all`); if it exists we fail rather than overwrite — UUIDv7 pre-creation defense.
+- Promote-time sanitization scrubs `sk-ant-`, `Bearer `, AWS/GitHub/Google API keys, absolute Windows + Unix paths. Add new patterns to `milestones::sanitize_text`, not callers.
+- Schema-tolerant logs: every `LogEvent` carries `schema_version: u32` (currently `SCHEMA_VERSION`). Bump on breaking changes; readers tolerate older versions.
+- `Strategy::Parallel(n)` and `Strategy::Custom` (LLM-perturb) are RESERVED for v2 — do not add v2 variants in v1 code paths.
+
+## The 5-10 files that matter
+
+- `src/lib.rs` — kernel: `run_experiment`, `resume_experiment`, `Experiment` trait, `Outcome`, the inner loop and SA-T0 calibration.
+- `src/policy.rs` — `Strategy` enum + `AcceptancePolicy` impls (`GreedyPolicy`, `SimulatedAnnealingPolicy`, `RandomSearchPolicy`); Ben-Ameur T0 calibration.
+- `src/log.rs` — `JsonlLog`, `FsyncPolicy`, tagged `LogEvent<Config, Score>` enum, `CostLedger`, log replay.
+- `src/milestones.rs` — `promote_run`, slug/run-id validation, secret/path sanitization. The "publish" boundary.
+- `src/cache.rs` — `CacheBridge`: opt-in cache keyed by `blake3(serde_json(config) || salt)`. Returns `None` when `cache_salt()` is `None`.
+- `src/time_budget.rs` — `TimeBudget::soft` (deadline hint) vs `hard_timeout_per_iter` (shell-out kill).
+- `src/target_grammar.rs` / `src/target_chatbot.rs` / `src/target_optick.rs` — the three reference target adapters; read these before adding a new target.
+- `tests/kernel.rs` — Phase 1 acceptance suite (items a–r from the plan). Treat as the spec.
+- `docs/plans/2026-04-26-001-feat-ix-autoresearch-edit-eval-iterate-plan.md` (in repo root) — locked design decisions.
+
+## How to add a new target
+
+1. Define `Config` and `Score` structs. `Config: Clone + Debug + Serialize + DeserializeOwned` and serializes deterministically (no `HashMap`). `Score: Clone + Debug + Serialize + DeserializeOwned + PartialOrd`.
+2. Create `src/target_<name>.rs`. Implement `Experiment` with `baseline`, `perturb`, `evaluate`, `score_to_reward`.
+3. Pick a `cache_salt()`: stable string (e.g. `"v1"`) if the target is deterministic; `None` if not. Bumping the salt invalidates cached evals.
+4. If the target shells out, honor `soft_deadline` in `evaluate` AND enforce `TimeBudget::hard_timeout_per_iter` via process kill — return `AutoresearchError::HardKilled { detail }` so the cascade-abort counter trips.
+5. Add a `pub use` line in `lib.rs`.
+6. Add an integration test patterned on `tests/kernel.rs` (mock target with a known optimum). For shell-out targets, prefer the mocked-eval pattern in `tests/optick_mocked.rs`.
+
+## What NOT to do here
+
+- Don't add an `LLM-perturb` strategy to `Strategy` in v1. That's the reserved `Strategy::Custom` slot in v2; the plan explicitly defers it.
+- Don't parallelize the inner loop. `Strategy::Parallel(n)` is reserved; the sequential `for` keeps log ordering and acceptance state coherent.
+- Don't compare `E::Score` across iterations to update best. Use the scalar reward — `Score: PartialOrd` is intentionally insufficient.
+- Don't widen the hard-kill cascade threshold to "just keep going". Three consecutive `HardKilled` is almost always a systemic failure (mmap lock, OOM, GA bug), not a bad config.
+- Don't change the `<run-id>` directory format. Tools downstream (Demerzel governance ingest, milestone promote) parse the UUIDv7 path-traversal-safe stem.
+- Don't sanitize at the caller side — keep all scrubbers in `milestones::sanitize_text`. Drift between callers was a Phase-1 review finding.
+
+## Where to look for related context
+
+- Crate `README.md` — quickstart, resume semantics, governance link.
+- `docs/plans/2026-04-26-001-feat-ix-autoresearch-edit-eval-iterate-plan.md` — the source-of-truth design with locked decisions.
+- `governance/demerzel/personas/autoresearch-driver.persona.yaml` — Demerzel invariant #34 affordances/constraints.
+- `docs/MANUAL.md` — where autoresearch fits in the ix toolkit.
+- Downstream consumers: chatbot QA (ga), OPTIC-K (ga/ix-optick), grammar (ix-grammar).

--- a/crates/ix-cache/CONTRACTS.md
+++ b/crates/ix-cache/CONTRACTS.md
@@ -1,0 +1,40 @@
+# ix-cache Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `Cache::set` / `set_with_ttl` PANICS on serialization failure (`expect("Serialization failed")`). Non-Serialize-safe types must be filtered at the caller.
+- `Cache::get<V>` returns `None` if (a) key absent, (b) entry expired, OR (c) deserialization into `V` fails. Callers cannot distinguish "missing" from "wrong type" via `Option`.
+- TTL = `None` means "never expires" — `is_expired()` short-circuits to `false`. Default config has `default_ttl = None`.
+- `Cache::set` overwrites without a "set if absent" semantic. Use `incr`/`incr_by` for atomic counter semantics (single shard lock).
+- `CacheStats::hit_rate()` returns 0.0 (not NaN) when `hits + misses == 0`. Forward-compat contract for dashboards.
+- `Cache::keys(pattern)` matches GLOB style (`*`, `?`), NOT regex. Iteration order is NOT sorted — depends on shard count and `HashMap` iteration.
+- `Cache::flush_all` is atomic per-shard but NOT atomic across shards. A reader during flush may see a partial state.
+- `incr` / `incr_by` / `decr` on a key holding a non-integer value return the new value as if the prior was 0; they do NOT error. (Redis-compatible semantics: missing key = 0.)
+- `delete` returns `true` iff the key was present at the moment of delete. `expire` returns `true` iff the key exists at call time.
+- LRU eviction triggers ONLY when `max_capacity > 0` AND total entries would exceed it after insert. `max_capacity = 0` is "unlimited" (default = 100_000).
+- TTL expiration is LAZY by default — entries past `expires_at` remain in memory until next access or `evict_expired()` call. Stats `total_bytes` may include expired entries.
+
+## Concurrency contracts
+- `Cache` is `Send + Sync`. Sharded `RwLock`s (default 16 shards) — concurrent readers in different shards do not block each other.
+- Writes within a single shard serialize. Hot keys hashing to the same shard contend.
+- `pubsub()` returns `&PubSub`; subscriptions are independent of cache locks — publishing during cache mutation is supported but the publish itself happens AFTER the cache mutation visibility window.
+- `stats()` returns a CLONE of `CacheStats` under a read lock; not a live view.
+
+## Failure contracts
+- No `Result` return on the public surface. Serialization failures PANIC (treat as a contract violation by the caller).
+- `Cache::new(config)` with `num_shards = 0` is silently bumped to 1 (`max(1)`).
+- Persist/restore (`persist::*`) does return `io::Result`; that's the only place I/O failures surface.
+
+## Determinism contracts
+- Shard assignment uses `DefaultHasher` (FNV/SipHash) — NOT deterministic across Rust versions (DefaultHasher implementation may change). Cross-version persisted snapshots may rebalance shards on load.
+- TTL is `Instant::now() + duration` — wall-clock-free, but means snapshot/restore must adjust TTLs based on `ttl_ms` rather than `expires_at` (see `persist::SnapshotEntry`).
+- `keys(pattern)` order is NON-deterministic across runs even with identical insert order (HashMap iteration).
+
+## Memory contracts
+- Each entry stores serialized JSON bytes (`Vec<u8>`), not the original `V`. Memory cost = `key.len() + serde_json::to_vec(value).len() + ~64B entry overhead`.
+- LRU eviction triggers BEFORE insert when capacity would be exceeded; it does not "burst" then evict.
+- `flush_all` does not shrink shard `HashMap` capacity — memory is reclaimed on drop, not on flush. Long-lived caches with churn may exhibit elevated steady-state memory.
+- The `resp-server` feature pulls in a TCP listener; with the feature off, the cache is in-process only with zero network surface.

--- a/crates/ix-ensemble/CONTRACTS.md
+++ b/crates/ix-ensemble/CONTRACTS.md
@@ -1,0 +1,35 @@
+# ix-ensemble Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `RandomForest::fit` infers `n_classes` from `*y.iter().max() + 1`. Missing classes in training data still claim probability columns. Empty `y` panics.
+- `RandomForest::fit` default `max_features` is `ceil(sqrt(n_features))` clamped to `n_features`. Override via `with_max_features` is silently clamped to `n_features` — does not error.
+- `RandomForest::predict_proba` returns rows summing to 1.0 within f64 rounding; each entry is the fraction of trees voting that class.
+- `RandomForest::predict` breaks ties (equal vote counts) by LOWEST class index — deterministic but not configurable.
+- Bootstrap samples are drawn WITH replacement (`rng.random_range(0..n)` per row), n samples per tree. Out-of-bag indices are NOT exposed; OOB error is not computed.
+- `GradientBoostedClassifier::fit` initializes with class-prior log-odds (not zeros); the first tree fits residuals against that prior.
+- `GradientBoostedClassifier` uses softmax over accumulated scores. Multiclass treats it as one-vs-rest with shared residual update per round.
+- `EnsembleClassifier` trait (this crate's own trait) is NOT interchangeable with `ix_supervised::traits::Classifier` even though method signatures match — they are distinct trait identities.
+
+## Concurrency contracts
+- Trees are fitted SEQUENTIALLY inside `RandomForest::fit` — no internal rayon. Parallelizing must happen at the caller and requires per-tree RNG split.
+- Fitted ensembles are `Send + Sync`. `predict` is read-only and safe to share `&self`.
+
+## Failure contracts
+- `fit` panics on empty input, label-domain gaps that cause `Array1::from_iter` shape mismatches, or `max_features = 0`.
+- `predict` before `fit` panics — the trees `Vec` is empty and `unwrap` fires in `partial_cmp`.
+- No `Result` returns anywhere on this surface.
+
+## Determinism contracts
+- `RandomForest` is fully deterministic given `seed`. Default seed = 42. Identical seed + identical (x, y) produces bit-identical trees and predictions.
+- Feature subset selection uses Fisher-Yates partial shuffle; order of selected features is RNG-dependent but reproducible.
+- Bootstrap sample order is RNG-dependent but reproducible; trees built from `sample_indices` in row order.
+- `GradientBoostedClassifier` is deterministic (no random sub-sampling); pure function of (x, y, n_rounds, learning_rate, max_depth).
+
+## Memory contracts
+- Each tree stores `(DecisionTree, Vec<usize>)` — feature_indices vector is heap-allocated per tree. Memory = O(n_trees * max_features).
+- `fit` materializes a fresh `sub_x: Array2` of shape `(n, max_features)` per tree (no zero-copy view) — peak memory during fit is `O(n * max_features)` on top of the original `x`.
+- `predict_proba` allocates a fresh `Array2<f64>` per call.

--- a/crates/ix-game/CONTRACTS.md
+++ b/crates/ix-game/CONTRACTS.md
@@ -1,0 +1,40 @@
+# ix-game Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `BimatrixGame::new(a, b)` PANICS via `assert_eq!` on shape mismatch — it does NOT return Result. Callers must pre-check `payoff_a.shape() == payoff_b.shape()`.
+- `BimatrixGame::zero_sum(a)` constructs `payoff_b = -a` — the negation, not the transpose. For symmetric zero-sum, callers must construct B explicitly.
+- `best_response_a` / `best_response_b` use `1e-10` absolute tolerance for tie detection. Ties are split UNIFORMLY across all near-optimal strategies (mixed best response).
+- `is_nash_equilibrium(profile, tolerance)` checks whether NEITHER player can improve by deviation by more than `tolerance` — tolerance is in payoff units, not probability units.
+- `first_price_auction` ties broken by FIRST bidder in `bids` slice (lowest input index wins). Same for second_price.
+- `second_price_auction` with `bids.len() < 2` falls back to first-price (no separate error path). Empty bids returns `None`.
+- `second_price_auction` winner pays the second-HIGHEST bid (sorted descending, index 1). Vickrey-truthful only if all bidders bid their valuation.
+- `cooperative::shapley_value` requires the coalition value function to be MONOTONIC for the result to be meaningful, but the API does not validate this.
+- `evolutionary::replicator_dynamics` is discrete-time per-step update; small step sizes approximate continuous dynamics. Step size > 1.0 is mathematically defined but can produce non-stochastic strategy vectors (negative probabilities).
+- `mechanism::vcg_payment` returns each bidder's externality cost. Sum across bidders MAY exceed total welfare — that's the VCG revenue, not a bug.
+
+## Concurrency contracts
+- All game-theory types (`BimatrixGame`, `StrategyProfile`) are `Send + Sync` value types with `&self` query methods.
+- `evolutionary` simulators mutate `&mut self`; serialize across threads.
+- No internal RNG on the public Nash/auction surface — fully thread-safe for read.
+
+## Failure contracts
+- `BimatrixGame::new` panics on shape mismatch. No Result variant.
+- `first_price_auction` / `second_price_auction` return `Option<AuctionResult>` — `None` iff `bids.is_empty()`.
+- Internal `partial_cmp` on bid amounts uses `unwrap` — NaN bids panic. Caller MUST filter NaN.
+- `cooperative` algorithms over `n` players iterate `2^n` coalitions — silently exponential. No guard.
+
+## Determinism contracts
+- All Nash / auction / cooperative / mechanism functions are deterministic functions of input — no internal RNG.
+- `best_response_*` returns a mixed strategy that is a function of the f64 payoff matrix only — bit-identical across runs.
+- `evolutionary::replicator_dynamics` is deterministic given initial state + payoff matrix + step count.
+- Tie-breaks are stable: lowest-index wins for auctions; uniform-split for best response.
+
+## Memory contracts
+- `BimatrixGame` stores two owned `Array2<f64>` matrices — no shared references.
+- `best_response_*` allocates one `Vec<f64>` (size = num_strategies) and one `Array1<f64>` output per call.
+- `cooperative` Shapley-value computation allocates a coalition-value cache of size `2^n` — DO NOT call for n > ~20.
+- Auction `all_bids` field clones the input bid vector into the result (`bids.to_vec()`) — O(n) extra memory per auction call.

--- a/crates/ix-graph/CONTRACTS.md
+++ b/crates/ix-graph/CONTRACTS.md
@@ -1,0 +1,36 @@
+# ix-graph Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `MarkovChain::new(transition)` returns `Err(String)` (not a typed error) on: non-square matrix, any row not summing to 1.0 within `1e-6`. Negative entries are NOT rejected by `MarkovChain::new` but are by `HiddenMarkovModel::new`.
+- `HiddenMarkovModel::new` validates: square transition matching N, emission N rows, initial sums to 1.0 within `1e-6`, all probabilities non-negative, transition + emission rows sum to 1.0. ALL validation failures return `Err(String)` — error MESSAGES are not stable across versions, but their `is_err()` status is.
+- `MarkovChain::state_distribution(initial, steps)` allocates `Array1::clone(initial)` and right-multiplies `steps` times. `steps = 0` returns initial unchanged (no copy elision but mathematically identity).
+- `MarkovChain::stationary_distribution` uses power iteration; terminates EARLY when L1 delta < `tol`. May return a non-stationary distribution if `max_iter` is hit first — caller cannot distinguish convergence vs cutoff from the return value alone.
+- `MarkovChain::simulate` advances RNG `steps` times; identical seed + identical chain + identical start_state = identical trajectory.
+- `hmm::viterbi` returns the MOST-LIKELY hidden state sequence under the model. Tie-breaks (equal-probability paths) follow argmax-first-wins, which depends on state ordering.
+- `hmm::baum_welch` (forward-backward EM) MUTATES the HMM in place and returns the final log-likelihood. It does NOT guarantee monotonic improvement across iterations near convergence due to numerical underflow.
+- `SkillRouter::add_skill` does NOT validate that `skill.dependencies` reference registered skill IDs. Forward references must be resolved before calling `build_graph`, else edges silently drop.
+- `routing::SkillRouter::route` returns shortest dependency-respecting plan by total `token_cost`. Cycles produce undefined behavior (no cycle detection at route time).
+
+## Concurrency contracts
+- `MarkovChain` and `HiddenMarkovModel` are `Send + Sync` — pure data structures with `&self` methods only. Cloning is cheap (small matrices).
+- `SkillRouter` holds `HashMap`s and is `!Sync` for mutation; safe to share `&SkillRouter` across threads for read-only routing.
+
+## Failure contracts
+- `MarkovChain::new` and `HiddenMarkovModel::new` return `Result<Self, String>` — stringly-typed errors. This is the v1 surface; do not rely on parsing the error string.
+- Internal numerical methods (`viterbi`, `baum_welch`) do not return Result — they degrade gracefully (underflow → log-space) and may return finite-but-wrong values rather than panic.
+- `MarkovChain::simulate` with `steps = 0` returns `vec![start_state]` (length 1).
+
+## Determinism contracts
+- Every randomized method takes an explicit `seed: u64`. No `thread_rng()` use on public surface.
+- `viterbi` ties broken by lowest state index (stable across runs).
+- `SkillRouter::route` iterates skills in `HashMap` order INTERNALLY but exposes results sorted by topological order — output order is stable; intermediate computation is not.
+- `Markov::stationary_distribution` starts from uniform `1/n` distribution (not random) — fully deterministic for a given chain.
+
+## Memory contracts
+- HMM forward/backward allocate two `(T, N)` matrices where T = observation length, N = state count. Memory = O(T*N). Not streaming; full sequence must be in memory.
+- `MarkovChain::simulate` returns `Vec<usize>` of length `steps + 1` (start state included).
+- `SkillRouter` stores full skill objects (not references) in `HashMap<String, SkillNode>` and dual `id_to_index`/`index_to_id` maps — memory = 3x skill count.

--- a/crates/ix-math/CONTRACTS.md
+++ b/crates/ix-math/CONTRACTS.md
@@ -1,0 +1,38 @@
+# ix-math Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `distance::*` (euclidean, manhattan, minkowski, chebyshev, cosine_*) — returns `Err(MathError::DimensionMismatch)` on length mismatch BEFORE allocating, never panics on input shape.
+- `distance::cosine_similarity` — returns `Ok(0.0)` (not `Err`) when either vector has norm < 1e-12. Callers depending on "0 means undefined" rely on this.
+- `distance::minkowski` — returns `Err(MathError::InvalidParameter)` for `p < 1.0`; `p = 1` is L1, `p = 2` is L2 (verified against `euclidean`).
+- `distance::cosine_distance` returns `1.0 - cosine_similarity`, i.e. in `[0, 2]`, NOT in `[0, 1]`.
+- `stats::mean` / `variance` / `std_dev` / `median` / `min_max` — return `Err(MathError::EmptyInput)` on empty arrays, never `Ok(NaN)`.
+- `stats::sample_variance` requires n >= 2; returns `Err(InvalidParameter)` for n < 2 (Bessel correction would divide by zero).
+- `stats::variance` is POPULATION variance (divides by N), not sample (N-1). `sample_variance` is the N-1 form.
+- `stats::correlation_matrix` returns 0.0 (not NaN) for any pair whose covariance denominator is < 1e-12.
+- `linalg::matmul` / `matvec` — dimension check BEFORE delegating to ndarray; returns `Err(DimensionMismatch)` instead of letting ndarray panic.
+- `linalg::determinant` is recursive cofactor expansion — O(n!) — intended for small (n <= ~10) square matrices. Do NOT call on large matrices in a hot path.
+- `activation::sigmoid` returns finite values for any finite f64 (no overflow path); `sigmoid_derivative` recomputes sigmoid internally (not a cached pass-through).
+- `activation::relu(x)` for negative `x` returns exactly `0.0`, not `-0.0`.
+
+## Concurrency contracts
+- All functions are pure (`fn`, no shared state). Safe to call from multiple threads concurrently.
+- No types in this crate hold `Mutex`/`RwLock`. `BSPTree`, `KMeans`-style state structs are `Send + Sync` iff their generic parameters are.
+
+## Failure contracts
+- Errors flow through `MathError` (`thiserror`). Variants: `DimensionMismatch { expected, got }`, `EmptyInput`, `InvalidParameter(String)`, `NotSquare { rows, cols }`.
+- No public function panics on user input shape. Internal `unwrap()` only on infallible ndarray operations (e.g. `mean()` after explicit emptiness check).
+- `bsp::BSPTree::nearest_neighbor` returns `Option`, never panics on an empty tree — returns `None`.
+
+## Determinism contracts
+- All non-randomized functions are bit-deterministic across runs on the same platform/toolchain.
+- Functions taking `seed: u64` (`random::*`) produce identical output for identical seeds (uses `StdRng` / `ChaCha8Rng`).
+- `stats::correlation_matrix` iterates `(i, j)` in nested `for` loops — order is deterministic; output `Array2` is symmetric within f64 rounding.
+
+## Memory contracts
+- Distance and stats functions allocate only the output (typically scalar or `Array1` / `Array2` of declared dims). They do NOT allocate intermediate buffers proportional to input.
+- `transpose` clones to a new owned `Array2`; the input view is left untouched.
+- `Complex` (re-exported via `ix-signal::fft::Complex`) is `Copy`; no allocation for arithmetic ops.

--- a/crates/ix-optimize/CONTRACTS.md
+++ b/crates/ix-optimize/CONTRACTS.md
@@ -1,0 +1,32 @@
+# ix-optimize Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `ObjectiveFunction::gradient` default implementation calls `ix_math::calculus::numerical_gradient` with `eps = 1e-7`. Overriding with an analytic gradient must match within numerical tolerance or downstream `SGD` / `Adam` convergence claims silently break.
+- `ParticleSwarm::run` minimizes the objective. To maximize, negate the objective at the caller; do not assume the optimizer auto-detects direction.
+- `SimulatedAnnealing` accept probability is `exp(-ΔE / T)` for uphill moves; `ΔE <= 0` always accepts. `CoolingSchedule::Logarithmic` ignores the `alpha` field (uses `T0 / ln(1 + k)`).
+- `Optimizer::step` returns NEW params; it does not mutate the input slice. `Momentum`/`Adam` track internal velocity state across calls — instances are stateful and not interchangeable across optimization runs.
+- `OptimizeResult.converged = true` means convergence criterion was met BEFORE `max_iterations`; `false` means the loop hit `max_iterations`. It is NOT "best > some threshold".
+- `ClosureObjective::dim()` returns the caller-supplied `dimensions` field verbatim; the closure is never inspected.
+
+## Concurrency contracts
+- Optimizers (`SGD`, `Momentum`, `Adam`) are `!Sync` due to interior mutable velocity state; clone per thread.
+- `ParticleSwarm::run` is single-threaded by design (seeded RNG sequentially advanced). Parallelizing requires per-particle RNG split and is out of scope for the v1 stable surface.
+
+## Failure contracts
+- No optimizer returns `Result` — all infallible by signature. Pathological objectives returning NaN propagate NaN into `OptimizeResult.best_value`. Callers MUST check `.is_finite()`.
+- `ParticleSwarm` clamps positions to `bounds` on every step; particles outside bounds at init are silently clamped, not rejected.
+
+## Determinism contracts
+- `ParticleSwarm` is fully deterministic given `seed`; identical seeds + bounds + dims produce identical trajectories.
+- `SimulatedAnnealing` is deterministic given `seed`. Switching `CoolingSchedule` variants changes the random-walk acceptance pattern even with the same seed.
+- Gradient optimizers (`SGD`, `Momentum`, `Adam`) are deterministic given identical initial params + gradients.
+- Default seed for `ParticleSwarm` / `SimulatedAnnealing` is `42`; calling `.with_seed(42)` is a no-op but explicit.
+
+## Memory contracts
+- `Optimizer::step` allocates one new `Array1<f64>` per call (size = param dim). No buffer reuse.
+- `ParticleSwarm::run` allocates `num_particles` particles each holding two `Array1<f64>` (position + velocity); peak memory is `O(num_particles * dim)`.
+- `Momentum` and `Adam` lazily allocate velocity on first `step` call (not at construction).

--- a/crates/ix-probabilistic/CONTRACTS.md
+++ b/crates/ix-probabilistic/CONTRACTS.md
@@ -1,0 +1,39 @@
+# ix-probabilistic Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `BloomFilter::contains` returns `true` for "possibly in set" and `false` for "definitely not in set". FALSE POSITIVES are expected; FALSE NEGATIVES are a contract violation.
+- `BloomFilter::new(capacity, fp_rate)` sizes `bits` and `num_hashes` for the GIVEN capacity. Inserting more than `capacity` items inflates fp_rate beyond `fp_rate` silently — no warning, no error.
+- `BloomFilter::estimated_fp_rate()` is computed from observed fill ratio, not from the insert count. Two filters at the same fill report the same rate even if one has more inserts.
+- `BloomFilter::len()` is the count of `insert` calls, NOT unique items. Inserting the same item twice increments `count`.
+- `CountMinSketch::estimate` returns a value GREATER THAN OR EQUAL TO the true count — never underestimates (one-sided error).
+- `CountMinSketch::with_error(epsilon, delta)` ceils width to `e/epsilon` and depth to `ln(1/delta)`; the actual error guarantee holds with probability `>= 1 - delta`. Choosing `delta = 0` would compute `ln(infinity)` — guarded by `max(1)`.
+- `HyperLogLog::new(precision)` CLAMPS precision to `[4, 18]` silently. Standard error: `1.04 / sqrt(2^p)`. p=14 gives ~0.81%.
+- `HyperLogLog::count()` returns `f64` (estimate), not `u64`. May be non-integer. For low cardinalities (< ~2.5 * m), small-range correction is applied; for high cardinalities (> 2^32 / 30), large-range correction is applied.
+- `CuckooFilter::insert` returns `false` when the filter is FULL (all kick attempts exhausted) — NOT when the item is already present. Distinguishing "already in" vs "rejected" requires a prior `contains` check.
+- `CuckooFilter::delete` returns `true` iff a matching fingerprint was found and removed. Because fingerprints are 16-bit, deleting an item never inserted may by chance succeed (collision) and corrupt another entry.
+- `Bloom::contains` of unhashable types is not possible by signature; `T: Hash` is the only constraint — `Hash` implementations MUST be consistent between insert and contains.
+
+## Concurrency contracts
+- All four structures are `Send + Sync` but require `&mut self` for `insert` / `add` / `delete`. Concurrent inserts require external locking.
+- `contains` / `estimate` / `count` are `&self` and safe to share across threads.
+- `DefaultHasher` is used internally — hash output is NOT guaranteed stable across Rust versions. Persisting filter state across toolchain upgrades may invalidate `contains` results.
+
+## Failure contracts
+- No `Result` return anywhere. `CuckooFilter::insert` returns `bool` for failure (full). `BloomFilter::insert` always succeeds (returns `()`).
+- `BloomFilter::with_params(size, num_hashes)` with `size = 0` panics on first insert (index out of bounds). No constructor-time validation.
+- `CountMinSketch::new(0, 0)` is silently bumped to `(1, 1)` in `with_error`; via `new` directly it allows zero and panics on first add.
+
+## Determinism contracts
+- All four structures are deterministic given identical insertion order and identical `Hash` impls. No internal RNG on Bloom/Count-Min/HLL.
+- `CuckooFilter::insert` uses internal RNG (`rand::random()`) for victim selection during kicks — NOT deterministic. This is the only non-deterministic path; expect different bucket layouts across runs even with identical input order.
+- `HyperLogLog::merge` is commutative and associative — order-independent for union estimation.
+
+## Memory contracts
+- `BloomFilter` stores `Vec<bool>` (not bit-packed) — 1 byte per bit. For tight memory budgets, callers should consider an external bit-vec wrapper.
+- `HyperLogLog` memory is `2^precision` bytes (one `u8` per register). p=14 = 16KB.
+- `CountMinSketch` memory is `width * depth * 8 bytes` (u64 counters).
+- `CuckooFilter` memory is `num_buckets * BUCKET_SIZE * 2 bytes` plus `Vec` overhead per bucket. `num_buckets` is rounded UP to next power of two.

--- a/crates/ix-quality-trend/CONTEXT.md
+++ b/crates/ix-quality-trend/CONTEXT.md
@@ -1,0 +1,55 @@
+# ix-quality-trend Context
+
+> Fresh-session orientation for this crate. Read BEFORE touching it.
+
+## What this crate is
+
+Aggregates timestamped JSON quality snapshots from the GuitarAlchemist ecosystem and emits an executive-readable markdown trend report (+ optional `out_json` health artifact). Three categories supported today: `embeddings/` (from `ix-embedding-diagnostics`), `voicing-analysis/` (from .NET `Demos/VoicingAnalysisAudit`, PascalCase JSON), `chatbot-qa/` (from `ga-chatbot qa --benchmark`). Schema-tolerant: every snapshot field is `Option<T>` so older files missing newer metrics still load. Computes 7-day / 30-day averages, regression flags vs configurable threshold, sparklines, and drift detection via `ix-signal::timeseries::page_hinkley`. The CLI binary `ix-quality-trend` is what CI calls; three helper binaries (`bootstrap`, `build-ci-index`, `seed-history`) cover repo setup and CI fan-in.
+
+## Key invariants (DO NOT VIOLATE)
+
+- Filename stem MUST parse as `YYYY-MM-DD`. Files that don't match are SILENTLY skipped — this has burned the ecosystem twice (chatbot-qa producer + embeddings producer filename drift, see GA project memory). Don't add tolerant filename matching; instead make the producer conform.
+- Schema tolerance is at the FIELD level (`Option<T>`), NOT the document level. A malformed JSON file is a hard error, not silently ignored.
+- Series are sorted ascending by date inside `load_all`. Downstream `trend` code relies on this invariant; don't push points after the sort.
+- `TrendDirection` is part of the contract surface — `HigherIsBetter` (pass rates, consistency, Forte coverage) vs `LowerIsBetter` (leak accuracy, unknown-chord rate, invariant failures) drive arrow/checkmark rendering. Misclassifying a metric inverts the regression flag.
+- `RetrievalConsistency::match_pct()` prefers `avg_pc_set_match_pct_top10` over `avg_pc_set_match_pct` — both names ship in the wild; do not collapse them.
+- `CrossInstrumentConsistency::consistency_pct()` prefers an explicit `pct` field over the derived `consistent/shared_sets*100` ratio.
+- `InvariantFailures::total()` sums the four named buckets only (`midi_notes_mismatch`, `null_pitch_class_set`, `negative_physical_layout`, `interval_spread_invariant`). Adding a new failure kind requires updating both the struct and `total()`.
+- CLI `--baseline` is INFORMATIONAL only; the report always anchors on the most recent snapshot. Don't change this without revisiting the health-artifact contract.
+
+## The 5-10 files that matter
+
+- `src/lib.rs` — public surface (`build_health_artifact`, `QualityAlert`, `MetricSeries`, etc.) and the layout contract docstring.
+- `src/snapshot.rs` — typed Deserialize structs for all three categories + `load_all` (the filename-date gate lives here).
+- `src/trend.rs` — `MetricSeries`, `MetricTrend`, `TrendDirection`, regression/drift flagging.
+- `src/report.rs` — markdown renderer + `QualityHealthArtifact` JSON shape consumed by Demerzel/ga-react dashboards.
+- `src/main.rs` — `ix-quality-trend` CLI; arg validation (especially the `--baseline` date check) and exit codes.
+- `src/bin/bootstrap.rs` — first-time repo scaffold (creates `embeddings/`, `voicing-analysis/`, `chatbot-qa/` subdirs).
+- `src/bin/build_ci_index.rs` — fan-in of per-PR snapshots into the trend index (used by `karpathy-cherny-discipline.yml`).
+- `src/bin/seed_history.rs` — backfill from existing producers when adding a new category.
+
+## How to add a new snapshot category
+
+1. Add a variant to `SnapshotCategory` with `dir_name()` and `display()` strings. Update `SnapshotCategory::all()`.
+2. Define a `<Name>Snapshot` struct in `snapshot.rs` with `#[derive(Default, Deserialize)] #[serde(default)]`. Every field MUST be `Option<T>` for schema tolerance. Match the producer's case convention via `rename_all`.
+3. Add a `Vec<DatedSnapshot<...>>` field to `SnapshotSet` and load it in `load_all`. Sort by date after load.
+4. Wire metrics into `report::summarize` and the markdown renderer in `report::render`. Decide `TrendDirection` per metric.
+5. Add to `is_key_metric_name` if the metric should drive `QualityHealthStatus`.
+6. Producer side: write `<root>/<dir-name>/YYYY-MM-DD.json`. **Filename stem must be ISO date** or the loader will silently skip it.
+
+## What NOT to do here
+
+- Don't make the filename-date parse tolerant ("YYYY-MM-DD-foo.json" etc.). The silent skip is the contract, not a bug — but fix it at the producer.
+- Don't surface JSON parse errors as soft warnings. Document-level malformed JSON is a hard error per the schema-tolerance discipline doc.
+- Don't make `TrendDirection::Neutral` the default. Forces every metric to declare its direction; missing direction = silent regression-flag inversion.
+- Don't pull in `rmp-serde` for snapshot loading — it's there for the health artifact only. Snapshots stay JSON for diffability.
+- Don't add HashMap-keyed series; trend code assumes deterministic iteration order (`BTreeMap` already in `cardinality_distribution`).
+- Don't merge a producer change that bumps a metric name without keeping the old name as a fallback (see `avg_pc_set_match_pct` vs `_top10`).
+
+## Where to look for related context
+
+- Top-level `README.md` — workspace layout, Stable-tier maturity table.
+- `docs/MANUAL.md` — pipeline format + how trend reports feed Demerzel governance.
+- GA project memory (`reference_quality_trend_pipeline.md`) — the two filename-mismatch incidents that shaped these invariants.
+- `.github/workflows/karpathy-cherny-discipline.yml` (in GA repo) — CI consumer.
+- `ix-signal::timeseries::page_hinkley_detect` — drift detector this crate composes.

--- a/crates/ix-rl/CONTRACTS.md
+++ b/crates/ix-rl/CONTRACTS.md
@@ -1,0 +1,37 @@
+# ix-rl Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `EpsilonGreedy::select_arm` returns a UNIFORM random arm with probability `epsilon`, else argmax of `q_values`. Ties broken by FIRST occurrence (lowest index). `epsilon` is NOT clamped to `[0, 1]` — values outside silently bias selection.
+- `EpsilonGreedy::update` uses incremental mean: `q_values[arm] += (reward - q_values[arm]) / n`. Equivalent to running sample mean — no learning-rate parameter. Calling `update` BEFORE first `select_arm` is allowed and bumps the count.
+- `UCB1::select_arm` plays each arm AT LEAST ONCE first (sequential warm-up). After warm-up, picks `argmax(q + sqrt(2 * ln(total) / count))`. The exploration term diverges if any arm has `count == 0` after warm-up — but warm-up guarantees this can't happen.
+- `UCB1::select_arm` is `&self` (NOT `&mut self`) — does not advance internal state. Caller must call `update` to advance counts. EpsilonGreedy and Thompson `select_arm` are `&mut self` (consume RNG).
+- `ThompsonSampling::select_arm` PANICS via `Normal::new(...).unwrap()` if `variance` produces a non-positive stddev — guarded by `.sqrt().max(0.01)` (minimum stddev floor of 0.01). Do NOT set `variances[i]` to NaN.
+- `ThompsonSampling::update` resets `variances[arm] = 1.0 / n` for `n > 1` — this is a simplified update, NOT the conjugate Normal-Inverse-Gamma posterior. Documented as "Simplified variance update" in source; downstream consumers needing proper Bayesian updates must wrap externally.
+- `QLearning::select_action_index` argmax tie-break = lowest action index (`max_by` with `partial_cmp` is stable in Rust 1.62+).
+- `QLearning::update` is off-policy: bootstraps from `max(Q[next_state, :])`, NOT from `Q[next_state, next_action]`. SARSA (on-policy) is a separate function — do not confuse.
+- `bandit::*::update(arm, reward)` PANICS on out-of-range `arm` index (Vec indexing). No validation.
+
+## Concurrency contracts
+- All bandit types contain `StdRng` and are `!Sync` — `select_arm` requires `&mut self`. Clone per thread.
+- `UCB1` could be `Sync` (no RNG) but is conservatively `!Sync` for trait consistency. `select_arm` is `&self`, so `Arc<UCB1>` reads work; `update` still needs `&mut`.
+- `QLearning::q_table` is a public `Array2<f64>` — direct mutation possible but bypasses learning-rate logic.
+
+## Failure contracts
+- No `Result` returns. Out-of-range arm indices panic. NaN rewards corrupt `q_values` silently (no NaN guard).
+- `Normal::new` unwrap inside `ThompsonSampling::select_arm` is the only documented panic site; protected by the 0.01 stddev floor.
+
+## Determinism contracts
+- All bandits take an explicit `seed: u64` at construction. Identical seed + identical (arm, reward) sequence = identical decisions.
+- `UCB1` has NO seed — it's deterministic given its q/count state (no RNG). Two `UCB1` instances with identical histories choose identically.
+- `QLearning::select_action_index` is deterministic given its `q_table` for the greedy path; epsilon-greedy exploration uses the seeded RNG.
+- `ThompsonSampling::select_arm` samples from `Normal(mean, sqrt(var).max(0.01))` — deterministic given seed and history.
+
+## Memory contracts
+- All bandit types allocate three `Vec`s of length `n_arms` at construction. No further allocation after that point.
+- `QLearning::q_table` is a single `(num_states, num_actions)` `Array2<f64>` — memory is fixed at construction. No dynamic state-space expansion.
+- `select_arm` on Thompson allocates a fresh `Vec<f64>` of samples per call — for hot loops on large arm counts, consider externally-pooled buffers.
+- `traits::Environment` (in `env.rs`) is trait-only — does not impose memory layout on implementations.

--- a/crates/ix-search/CONTRACTS.md
+++ b/crates/ix-search/CONTRACTS.md
@@ -1,0 +1,35 @@
+# ix-search Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `astar` returns `None` iff no path exists (frontier exhausted). It does NOT return `None` on heuristic mistakes; an inadmissible heuristic produces a SUBOPTIMAL but extant path silently.
+- `astar` requires an ADMISSIBLE heuristic for optimality. Inadmissibility is the caller's responsibility — the API cannot detect it.
+- `weighted_astar(start, h, 1.0)` is exactly `astar`. `weight > 1.0` returns a path whose cost is at most `weight * optimal_cost`.
+- `astar` / `weighted_astar` path: `path[0]` = start, `path[last]` = goal. `actions[i]` is the action taken from `path[i]` to `path[i+1]`. `actions.len() == path.len() - 1`.
+- `SearchState::successors` MUST return `(action, successor, step_cost)` with `step_cost >= 0`. Negative costs break the priority-queue invariant and produce undefined results (no panic, just wrong answers).
+- `bfs` returns the shortest path BY EDGE COUNT, not by cost. Use `astar` with `h = 0` for shortest path by cost.
+- `mcts_search` returns the action with the HIGHEST visit count at the root (not highest mean reward). Ties broken by first-encountered.
+- `MctsState::reward()` MUST be in `[0.0, 1.0]` (0=loss, 0.5=draw, 1=win). Out-of-range values bias UCB1 selection.
+- `local::hill_climb` returns the BEST seen state, not the last state — local maxima are honored.
+
+## Concurrency contracts
+- All search algorithms are single-threaded by design. No internal rayon/threading.
+- `SearchState: Clone + Eq + Hash` — these traits' impls MUST be consistent across threads if the caller intends to parallelize over different start states. Hash/Eq inconsistency corrupts the closed set silently.
+
+## Failure contracts
+- No `Result` returns. Failure to find a path = `None`. Pathological inputs (e.g. `successors()` panicking, NaN heuristic) propagate the panic.
+- A heuristic returning NaN breaks `partial_cmp` in `SearchNode::Ord` — falls back to `Ordering::Equal`, causing non-deterministic node ordering. Callers MUST ensure heuristic is finite.
+
+## Determinism contracts
+- `astar`, `bfs`, `dfs` are deterministic IF `SearchState::successors()` returns successors in deterministic order AND `Hash` is consistent (`HashMap` iteration is NOT used for selection — only `BinaryHeap` priority, which is total on f_cost).
+- `mcts_search` requires `seed: u64` and is deterministic given seed + identical `MctsState` implementation.
+- F-cost ties in A*'s heap are broken by `BinaryHeap`'s internal order — NOT a stable tie-break across crate versions. Callers needing tie-break stability must embed a tiebreaker in `f_cost`.
+- `weighted_astar(.., 1.0)` is byte-identical to `astar` (literally delegates).
+
+## Memory contracts
+- A* / BFS allocate `g_scores` and `came_from` HashMaps that grow with the explored frontier. No upper bound — pathological graphs OOM.
+- `SearchResult.path` and `.actions` are owned `Vec`s (cloned from the state during reconstruction). Large states = large clones.
+- `mcts_search` stores nodes in a flat `Vec<MctsNode>`; children stored as indices (no `Rc`/`Box` per node). Memory = O(iterations) in nodes generated.

--- a/crates/ix-signal/CONTRACTS.md
+++ b/crates/ix-signal/CONTRACTS.md
@@ -1,0 +1,39 @@
+# ix-signal Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `fft::fft` and `fft::ifft` ZERO-PAD silently to the next power of two. Output length = `input.len().next_power_of_two()`, NOT `input.len()`. Callers requiring fixed length must check `is_power_of_two()` first.
+- `fft::irfft` discards the imaginary parts of `ifft` output — assumes the input spectrum is conjugate-symmetric. Non-symmetric input produces a "real projection", NOT an error.
+- `fft::ifft` applies the `1/N` normalization (so `ifft(fft(x)) == x` within rounding). Some libraries apply `1/sqrt(N)` symmetrically; this crate does NOT.
+- `fft::Complex` has `PartialEq` derived on `(re, im)` — two complex numbers `==` iff both fields bit-equal. NaN propagates per IEEE 754 (`NaN != NaN`).
+- `kalman::KalmanFilter::new` initializes `transition = I`, `observation = 0`, `process_noise = 0.01 * I`, `measurement_noise = I`, `state = 0`, `covariance = I`. Defaults are NOT a usable filter — caller must overwrite at least `observation`.
+- `filter::FirFilter` applies a CAUSAL filter (no look-ahead); output length equals input length with leading samples reflecting the filter's transient response (not zero-padded mathematically symmetric).
+- `wavelet::dwt_haar` requires input length to be a power of two; non-power-of-two input panics inside the internal indexing.
+- `spectral::spectrogram` returns shape `(n_frames, n_freqs)` where `n_frames = (signal_len - window_size) / hop_size + 1`. Final partial frame is DROPPED, not padded.
+- `timeseries::page_hinkley_detect` returns `DriftState::Drift { index }` at the FIRST detection point; subsequent drifts in the same series are NOT reported in a single call.
+- `correlation::auto_correlation` returns unnormalized correlation; divide by `series.len()` for biased estimator or by `(n - lag)` for unbiased — caller's choice.
+
+## Concurrency contracts
+- All functions are pure with `&[T]` or `&Array` inputs; safe to call from multiple threads concurrently.
+- `KalmanFilter` is `!Sync` for `predict`/`update` (mutates internal state via `&mut self`); clone per thread.
+
+## Failure contracts
+- FFT functions are infallible by signature — no Result. Empty input (`len() == 0`) panics inside `next_power_of_two()` (returns 1, then resize to 1 works, but `magnitude_spectrum` on empty returns empty).
+- `kalman::KalmanFilter::update` panics on dimension mismatch between observation and the filter's `obs_dim`.
+- `wavelet::dwt_haar` panics on non-power-of-two input.
+- No `Result`-typed surface in this crate.
+
+## Determinism contracts
+- All transforms are pure functions of input — no RNG anywhere on the public surface.
+- `fft` is bit-identical across runs on the same platform/toolchain. Twiddle factors are computed via `f64::cos/sin` — cross-platform rounding may differ at ULP scale.
+- `KalmanFilter` predict/update are deterministic given the initial state and observation sequence.
+- `spectral::spectrogram` window iteration is left-to-right with fixed hop; output order matches input order.
+
+## Memory contracts
+- `fft::fft` allocates a single `Vec<Complex>` of length `next_power_of_two(input.len())`. No in-place variant on the public surface (the in-place is private).
+- `Complex` is `Copy` (no heap); slice operations are zero-allocation until output materialization.
+- `KalmanFilter` allocates fresh matrices for predict/update intermediate products — no buffer reuse. For high-frequency calls, callers may want a pooling wrapper externally.
+- `spectrogram` allocates `(n_frames, n_freqs)` upfront; memory scales with signal length and inverse hop size.

--- a/crates/ix-supervised/CONTRACTS.md
+++ b/crates/ix-supervised/CONTRACTS.md
@@ -1,0 +1,37 @@
+# ix-supervised Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `Regressor::fit` / `Classifier::fit` return `()`; failure modes (singular matrix, empty input) typically PANIC rather than return Err. Callers MUST pre-validate `x.nrows() > 0` and `x.nrows() == y.len()`.
+- `Classifier::predict` and `predict_proba` MUST be called only after `fit`. Calling before `fit` panics (uninitialized state). This is the discipline; consider it a precondition contract.
+- `predict_proba` returns probabilities that sum to 1.0 per row within f64 rounding. Number of columns = `*y.iter().max() + 1` (i.e. classes are `0..=max_label`; missing labels in training still occupy a column).
+- `metrics::accuracy(y_true, y_pred)` panics on length mismatch (no Result wrapper). Callers must ensure same length.
+- `metrics::r_squared` returns `0.0` (not NaN) when `ss_tot < 1e-12` — degenerate constant-target case.
+- `metrics::roc_curve` requires binary labels `{0, 1}`. Multi-class labels produce undefined results; no validation.
+- `DecisionTree::fit` with `max_depth = 0` produces a single-leaf tree predicting the majority class.
+- `KNN::predict` ties broken by lowest-numbered class (deterministic but not configurable).
+- `linear_regression::LinearRegression` uses normal-equations (via `ndarray-linalg`-free pseudo-inverse). Singular X^T X panics; callers should pre-check feature rank.
+
+## Concurrency contracts
+- Fitted models (`DecisionTree`, `RandomForest` via ix-ensemble, `KNN`, `LinearRegression`) are `Send + Sync`. Safe to share `&model` across threads for `predict`.
+- `fit` requires `&mut self`; serialize fits or clone per thread.
+
+## Failure contracts
+- This crate panics on contract violation (length mismatch, predict-before-fit, NaN labels). It does NOT use `Result`-typed `Regressor::fit` / `Classifier::fit`.
+- `metrics::*` functions are `fn` returning bare scalars; no Result. Empty input or length mismatch panics inside ndarray `mean()`.
+- `text::*` (TF-IDF) treats unseen vocabulary at predict time as zero-weight, not panic.
+- `resampling::SMOTE` with `k_neighbors >= minority_class_size` panics.
+
+## Determinism contracts
+- All seeded algorithms (`KNN` with random tie-break, `RandomForest` via ix-ensemble, SMOTE) use `StdRng::seed_from_u64`. Identical seed + identical input = identical model.
+- `DecisionTree` split selection iterates features in `0..n_features` order and thresholds in sorted order; ties broken by lowest feature index.
+- `metrics::confusion_matrix` rows = true class, columns = predicted class — opposite convention from some libraries. Diagonal = correct predictions.
+
+## Memory contracts
+- `DecisionTree` stores nodes via `Box<Node>` recursion (heap, one allocation per node). Deep trees risk stack overflow on serialization; depth bound = `max_depth` (default unbounded in test harnesses, set explicitly in production).
+- `predict_proba` allocates a fresh `Array2<f64>` per call (no buffer reuse).
+- `KNN::fit` stores the full training set (no copy elision); memory = O(n * p).
+- `text::TfidfVectorizer` builds a `HashMap<String, usize>` vocabulary; vocabulary order is INSERTION-ORDERED (not sorted) — see resampling contract.

--- a/crates/ix-unsupervised/CONTRACTS.md
+++ b/crates/ix-unsupervised/CONTRACTS.md
@@ -1,0 +1,37 @@
+# ix-unsupervised Behavioral Contracts
+
+> Guarantees the public API makes that the stable-surface guard (API hash) can't enforce.
+> Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) may rely on these.
+> Breaking any of these requires a major version bump regardless of whether the API shape changed.
+
+## Functional contracts
+- `Clusterer::predict` MUST be called after `fit`; calling first panics (`expect("Model not fitted")` in DBSCAN; uninitialized centroids in KMeans).
+- `DBSCAN` labels: `0` = NOISE, clusters start at `1`. Do NOT collapse to "cluster 0 is first cluster" — this convention is load-bearing for callers using `label == 0` as a noise check.
+- `DBSCAN::predict` on new points uses NEAREST-CORE-POINT assignment from the fitted data, not re-clustering. New points may receive `NOISE` if no core point is within `eps`.
+- `KMeans::fit` uses K-Means++ initialization (NOT random init). Centroid count = `self.k`; the result has exactly `k` clusters or panics if `n_samples < k`.
+- `KMeans::save_state` returns `None` until `fit` has been called. `load_state` reconstructs a fitted model whose `predict` works without re-running `fit`.
+- `KMeans::load_state` panics (`expect("KMeansState centroids dimensions mismatch")`) if the saved state's `centroids[i].len()` is inconsistent — defensive but not Result-typed.
+- `PCA::transform` projects onto the top-k components by eigenvalue magnitude (descending). Sign of components is NOT canonicalized — sign flips across runs are valid even with the same input.
+- `tsne` is Barnes-Hut (theta-approximated); output coordinates are NOT comparable across runs even with the same seed unless `theta = 0.0` (exact).
+- `GMM::fit` is EM with k-means init; converges when log-likelihood delta < `tol` or `max_iterations` reached. `predict_proba` rows sum to 1.0 within f64 rounding.
+
+## Concurrency contracts
+- Fitted models are `Send + Sync`. `predict` is `&self` and thread-safe.
+- `fit` requires `&mut self`. No internal parallelism in DBSCAN (O(n^2) region queries) — for large n, callers should batch externally.
+
+## Failure contracts
+- All `Clusterer` / `DimensionReducer` methods are infallible by signature; failure paths panic via `expect`.
+- `DBSCAN` with `min_points = 0` produces a single cluster (every point qualifies). With `min_points > n` produces all noise.
+- `KMeans` with `k = 0` panics at array construction. With `k > n_samples` produces empty clusters at the tail; predict still returns indices in `0..k`.
+
+## Determinism contracts
+- `KMeans` is deterministic given `seed`. Default seed = 42. K-Means++ probability-weighted picks use `StdRng` seeded once.
+- `DBSCAN` is fully deterministic (no RNG). Cluster ID assignment depends on row-iteration order — reordering rows in `x` changes which cluster gets ID 1 vs 2.
+- `GMM`, `tsne` use seeded RNG; identical seeds + input = identical output.
+- DBSCAN border points: a point reachable from multiple clusters gets assigned to the FIRST cluster that reaches it (row-iteration order). This is a stable but not order-independent contract.
+
+## Memory contracts
+- `DBSCAN::fit` stores a clone of the training data (`fitted_data: Some(x.to_owned())`) for predict; memory = O(n * p) post-fit.
+- `KMeans` stores only the `(k, p)` centroid matrix — no training-set retention.
+- `PCA` stores `(n_components, n_features)` components matrix and `(n_features,)` mean.
+- `tsne` allocates a `(n, n)` affinity matrix during fit — memory scales QUADRATICALLY in input size. Not suitable for n > ~10k.


### PR DESCRIPTION
## Summary

Two complementary doc types serving distinct purposes:

**CONTEXT.md** (orientation for fresh AI sessions) — 2 high-traffic crates:
- `crates/ix-autoresearch/CONTEXT.md` (57 lines)
- `crates/ix-quality-trend/CONTEXT.md` (55 lines)

**CONTRACTS.md** (behavioral guarantees the stable-surface API hash guard can't catch) — all 12 Stable-tier crates listed in workspace README:
- ix-math, ix-optimize, ix-supervised, ix-ensemble, ix-unsupervised, ix-search, ix-graph, ix-signal, ix-cache, ix-probabilistic, ix-game, ix-rl

## Why CONTRACTS.md exists

The new stable-surface guard (PR #46) sees API SHAPE — types, signatures, public symbol set. It cannot see BEHAVIOR. Downstream consumers (ga, tars, Demerzel, agent-blackbox, hari) build on top of guarantees that aren't in the type system, e.g.:

- `ix-signal::fft::fft` silently zero-pads to next power of two. Output length != input length even though the signature `&[Complex] -> Vec<Complex>` looks length-preserving.
- `ix-cache::Cache::set` PANICS on Serialize failure — no Result variant. The signature does not advertise this panic site.
- `ix-probabilistic::CuckooFilter::insert` uses internal `rand::random()` for victim kicks. It's the only non-deterministic path in an otherwise deterministic crate. Two identical insert sequences may yield different bucket layouts.
- `ix-supervised::Classifier::predict` panics if called before `fit`. No Result wrapper.
- `ix-search::astar` requires an admissible heuristic for optimality. The API cannot detect inadmissibility — a contract the caller owns.
- `ix-unsupervised::DBSCAN` labels: `0` = NOISE, clusters start at `1`. Downstream code uses `label == 0` as a noise check. Renumbering would be a silent breaking change.

Breaking any contract requires a major version bump regardless of whether the API shape changed.

## Diff-stat

```
14 files changed, 557 insertions(+)
avg 39.8 lines / max 57 / min 32
```

All CONTEXT.md <= 150 lines (template constraint). All CONTRACTS.md <= 80 lines (template constraint).

## Test plan

- [x] Files are pure new-file additions; no code changes, no workspace README edits.
- [x] Line counts within constraints.
- [x] CI green (advisory risk-report red is pre-existing per workspace doctrine).
- [x] No `--admin` merge needed; standard squash-merge once CI greens.