### PR TITLE
feat(hooks): periodic mid-session digest + auto /correct + PR rationale capture

### DIFF
--- a/.claude/hooks/correction-detector.sh
+++ b/.claude/hooks/correction-detector.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook — Enhancement 2 (Cherny auto /correct trigger).
+# If the user's prompt matches correction language, nudge Claude to invoke
+# /correct so the rule lands in CLAUDE.md. Throttled: fires once per N=5 prompts.
+
+set -e
+
+repoRoot="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$repoRoot" ] && exit 0
+
+digestDir="$repoRoot/state/digests"
+mkdir -p "$digestDir"
+counterPath="$digestDir/.correction-counter"
+
+prompt=""
+if [ ! -t 0 ]; then
+  payload="$(cat || true)"
+  if [ -n "$payload" ] && command -v jq >/dev/null 2>&1; then
+    prompt="$(echo "$payload" | jq -r '.prompt // .user_prompt // empty' 2>/dev/null || true)"
+  fi
+  # Fallback: raw stdin if not JSON
+  if [ -z "$prompt" ]; then
+    prompt="$payload"
+  fi
+fi
+
+[ -z "$prompt" ] && exit 0
+
+# Match correction language (case-insensitive, anchored at start, word boundary)
+firstWord="$(printf '%s' "$prompt" | head -c 200 | tr '[:upper:]' '[:lower:]')"
+if ! printf '%s' "$firstWord" | grep -qE "^(no|don't|dont|stop|wait|actually|that's wrong|thats wrong|incorrect)\b"; then
+  exit 0
+fi
+
+# Throttle: increment counter, fire only every N=5
+THROTTLE="${IX_CORRECTION_THROTTLE:-5}"
+count=0
+if [ -f "$counterPath" ]; then
+  raw="$(cat "$counterPath" 2>/dev/null | tr -d '[:space:]')"
+  if echo "$raw" | grep -qE '^[0-9]+$'; then
+    count="$raw"
+  fi
+fi
+count=$((count + 1))
+echo "$count" > "$counterPath"
+
+# Only fire on count == 1 (first correction) or every Nth thereafter
+if [ "$count" -ne 1 ] && [ $((count % THROTTLE)) -ne 0 ]; then
+  exit 0
+fi
+
+msg="Detected correction language. Consider invoking /correct to formalize this into CLAUDE.md so the rule persists across sessions (Cherny self-improvement loop)."
+
+if command -v jq >/dev/null 2>&1; then
+  jq -n --arg ctx "[correction-nudge] $msg" '{additionalContext: $ctx}'
+else
+  printf '{"additionalContext":"[correction-nudge] %s"}\n' "$msg"
+fi
+exit 0

--- a/.claude/hooks/digest-activity-tracker.sh
+++ b/.claude/hooks/digest-activity-tracker.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 # PostToolUse hook (matcher: Edit|Write|Bash) — increments mutation counter.
+# Enhancement 1 (Cherny periodic mid-session digest): when activity threshold
+# OR time threshold is hit, write a mid-session metadata digest so we survive
+# crashes/network drops without waiting for Stop or PreCompact.
 
 set -e
 repoRoot="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -z "$repoRoot" ] && exit 0
 
 digestDir="$repoRoot/state/digests"
+archDir="$digestDir/archive"
 counterPath="$digestDir/.activity-counter"
-mkdir -p "$digestDir"
+midCounterPath="$digestDir/.activity-count"
+latest="$digestDir/latest.md"
+mkdir -p "$digestDir" "$archDir"
 
+# Existing mutation counter (for staleness nudge)
 count=0
 if [ -f "$counterPath" ]; then
   raw="$(cat "$counterPath" 2>/dev/null | tr -d '[:space:]')"
@@ -18,4 +25,80 @@ if [ -f "$counterPath" ]; then
 fi
 count=$((count + 1))
 echo "$count" > "$counterPath"
+
+# Enhancement 1: independent counter for mid-session digest gating
+midCount=0
+if [ -f "$midCounterPath" ]; then
+  raw="$(cat "$midCounterPath" 2>/dev/null | tr -d '[:space:]')"
+  if echo "$raw" | grep -qE '^[0-9]+$'; then
+    midCount="$raw"
+  fi
+fi
+midCount=$((midCount + 1))
+echo "$midCount" > "$midCounterPath"
+
+# Thresholds: N=20 mutations OR M=30 minutes since last digest
+THRESHOLD_COUNT="${IX_DIGEST_MID_COUNT:-20}"
+THRESHOLD_MIN="${IX_DIGEST_MID_MIN:-30}"
+
+get_mtime_sec() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+ageMin=99999
+if [ -f "$latest" ]; then
+  mtime="$(get_mtime_sec "$latest")"
+  if [ -n "$mtime" ] && [ "$mtime" != "0" ]; then
+    ageMin=$(( ($(date +%s) - mtime) / 60 ))
+  fi
+fi
+
+shouldWrite=false
+if [ "$midCount" -ge "$THRESHOLD_COUNT" ]; then
+  shouldWrite=true
+elif [ "$ageMin" -ge "$THRESHOLD_MIN" ] && [ "$midCount" -ge 3 ]; then
+  shouldWrite=true
+fi
+
+[ "$shouldWrite" = false ] && exit 0
+
+# Reset counter
+echo "0" > "$midCounterPath"
+
+tsIso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+tsFile="$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+
+branch="$(git -C "$repoRoot" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+headSha="$(git -C "$repoRoot" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+headSubj="$(git -C "$repoRoot" log -1 --format='%s' 2>/dev/null || echo unknown)"
+
+# Rotate latest -> archive before overwriting
+[ -f "$latest" ] && cp -f "$latest" "$archDir/$tsFile-pre-mid.md"
+
+midPath="$digestDir/mid-$tsFile.md"
+cat > "$midPath" <<EOF
+---
+schema_version: 1
+session_id: mid-session-auto
+written_at: $tsIso
+trigger: activity-tracker-mid-session
+branch: $branch
+head_sha: $headSha
+head_subject: $headSubj
+mutations_since_last: $midCount
+---
+
+# Session digest (mid-session auto — activity threshold reached)
+
+**Branch:** $branch @ $headSha — $headSubj
+
+## Model-driven sections
+
+_Auto-written by digest-activity-tracker after $midCount mutations / ${ageMin}m since last digest.
+Invoke \`/digest\` at your next natural breakpoint to populate **Next action**,
+**In-flight**, **Live hypotheses**, **Open questions**, **Do NOT carry forward**,
+and **Success criteria**._
+EOF
+
+cp -f "$midPath" "$latest"
 exit 0

--- a/.claude/hooks/pr-rationale-capture.sh
+++ b/.claude/hooks/pr-rationale-capture.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# PostToolUse(matcher=Bash) hook — Enhancement 3 (Cherny PR rationale capture).
+# When a Bash invocation runs `gh pr create`, snapshot the title + body + diff
+# stats to state/digests/pr-<num>-<slug>.md so the rationale survives later edits.
+
+set -e
+
+repoRoot="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -z "$repoRoot" ] && exit 0
+
+if [ -t 0 ]; then exit 0; fi
+payload="$(cat || true)"
+[ -z "$payload" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+cmd="$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+output="$(echo "$payload" | jq -r '.tool_response.output // .tool_response // empty' 2>/dev/null || true)"
+
+# Only react to gh pr create
+echo "$cmd" | grep -qE 'gh[[:space:]]+pr[[:space:]]+create' || exit 0
+
+# Extract title and body from command (best-effort — quoted strings vary)
+title="$(printf '%s' "$cmd" | grep -oE -- '--title[[:space:]]+("[^"]*"|'\''[^'\'']*'\'')' | head -1 | sed -E 's/^--title[[:space:]]+(.)(.*)\1$/\2/' || true)"
+body="$(printf '%s' "$cmd" | grep -oE -- '--body[[:space:]]+("[^"]*"|'\''[^'\'']*'\'')' | head -1 | sed -E 's/^--body[[:space:]]+(.)(.*)\1$/\2/' || true)"
+
+# Extract PR number from gh CLI output (URL like https://github.com/x/y/pull/123)
+prNum="$(printf '%s' "$output" | grep -oE 'pull/[0-9]+' | head -1 | sed 's|pull/||')"
+[ -z "$prNum" ] && prNum="unknown"
+
+# Slug from title (lowercased, alphanum + dash, max 40 chars)
+slug="$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9' '-' | tr -s '-' | sed 's/^-//;s/-$//' | head -c 40)"
+[ -z "$slug" ] && slug="untitled"
+
+digestDir="$repoRoot/state/digests"
+mkdir -p "$digestDir"
+outPath="$digestDir/pr-$prNum-$slug.md"
+
+tsIso="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+branch="$(git -C "$repoRoot" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+shortStat="$(git -C "$repoRoot" diff --shortstat HEAD~1 2>/dev/null || echo "")"
+
+cat > "$outPath" <<EOF
+---
+schema_version: 1
+trigger: pr-rationale-capture
+captured_at: $tsIso
+branch: $branch
+pr_number: $prNum
+diff_shortstat: $shortStat
+---
+
+# PR #$prNum — $title
+
+**Branch:** $branch
+**Captured:** $tsIso
+**Diff:** $shortStat
+
+## Title
+
+$title
+
+## Body
+
+$body
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,10 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/digest-staleness-nudge.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/correction-detector.sh"
           }
         ]
       }
@@ -72,6 +76,15 @@
           {
             "type": "command",
             "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/digest-activity-tracker.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/pr-rationale-capture.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Three Cherny session-continuity enhancements layered on top of existing digest hooks.

1. **Mid-session digest** (`digest-activity-tracker.sh`): when 20 mutations OR 30min elapse since last digest, write `state/digests/mid-<ISO>.md` and rotate `latest.md`. Survives crashes/network drops without waiting for Stop or PreCompact. Counter at `state/digests/.activity-count` (already covered by existing `state/digests/*` ignore pattern).
2. **Correction detector** (`correction-detector.sh`): UserPromptSubmit hook that regex-matches `^(no|don't|stop|wait|actually|that's wrong|incorrect)\b` at prompt start and emits `additionalContext` nudging Claude to invoke `/correct`. Throttled once per 5 prompts to prevent spam.
3. **PR rationale capture** (`pr-rationale-capture.sh`): PostToolUse(matcher=Bash) hook that detects `gh pr create`, parses `--title`/`--body`, extracts PR number from gh CLI output, snapshots to `state/digests/pr-<num>-<slug>.md` with branch + diff shortstat.

Wired in `.claude/settings.json` alongside existing hooks; no CLAUDE.md change.

## Test plan

- [x] `bash .claude/hooks/correction-detector.sh < <(echo '{"prompt":"No that is wrong"}')` emits JSON nudge
- [x] Non-correction prompt produces empty output, exit 0
- [x] `pr-rationale-capture.sh` with synthetic gh-pr-create payload writes `pr-42-feat-test-pr.md`
- [x] `digest-activity-tracker.sh` with `.activity-count=25` writes mid-session digest and resets counter
- [ ] Live PR creation will exercise enhancement 3 end-to-end

Part of a 6-repo coordinated rollout (ix, ga, tars, Demerzel, sentrux, hari).

Generated with [Claude Code](https://claude.com/claude-code)