### PR TITLE
feat(ai-annotations): schema contract + extractor crate (phase 0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "crates/ga-chatbot",
     "crates/ix-autoresearch",
     "crates/ix-blast-radius",
+    "crates/ix-ai-annotations",
 ]
 
 [workspace.package]
@@ -169,6 +170,7 @@ ix-invariant-coverage = { path = "crates/ix-invariant-coverage", version = "0.1.
 ix-bracelet = { path = "crates/ix-bracelet", version = "0.1.0" }
 ix-autoresearch = { path = "crates/ix-autoresearch", version = "0.1.0" }
 ix-blast-radius = { path = "crates/ix-blast-radius", version = "0.1.0" }
+ix-ai-annotations = { path = "crates/ix-ai-annotations", version = "0.1.0" }
 serde_yaml = "0.9"
 parking_lot = "0.12"
 

--- a/crates/ix-ai-annotations/Cargo.toml
+++ b/crates/ix-ai-annotations/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ix-ai-annotations"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["command-line-utilities", "development-tools"]
+keywords = ["annotations", "hexavalent", "governance", "ai", "static-analysis"]
+description = "Extracts in-source AI-authored semantic annotations (@ai:invariant, @ai:assumption, etc.) with hexavalent truth values (T/P/U/D/F/C) and certainty markers. Emits the ai-annotation contract JSONL stream consumed by the reconciler and the GA dashboard."
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+clap = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+regex = { workspace = true }
+ignore = "0.4"
+sha2 = "0.10"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "ix-ai-annotations"
+path = "src/bin/extract.rs"

--- a/crates/ix-ai-annotations/src/bin/extract.rs
+++ b/crates/ix-ai-annotations/src/bin/extract.rs
@@ -1,0 +1,58 @@
+//! `ix-ai-annotations` CLI — extract every `@ai:` marker in the workspace and
+//! write a JSONL stream to `state/quality/ai-annotations.jsonl`.
+
+use clap::Parser;
+use ix_ai_annotations::extract_workspace;
+use std::fs::{create_dir_all, File};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "ix-ai-annotations",
+    about = "Extract @ai: source-code annotations to a JSONL stream"
+)]
+struct Args {
+    /// Workspace root to scan.
+    #[arg(long, default_value = ".")]
+    workspace: PathBuf,
+
+    /// Output file. Default: <workspace>/state/quality/ai-annotations.jsonl
+    #[arg(long)]
+    out: Option<PathBuf>,
+
+    /// Print a one-line summary to stderr.
+    #[arg(long, default_value_t = false)]
+    quiet: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let out_path = args.out.unwrap_or_else(|| {
+        args.workspace
+            .join("state")
+            .join("quality")
+            .join("ai-annotations.jsonl")
+    });
+
+    let annotations = extract_workspace(&args.workspace)?;
+
+    if let Some(parent) = out_path.parent() {
+        create_dir_all(parent)?;
+    }
+    let mut f = BufWriter::new(File::create(&out_path)?);
+    for a in &annotations {
+        serde_json::to_writer(&mut f, a)?;
+        f.write_all(b"\n")?;
+    }
+    f.flush()?;
+
+    if !args.quiet {
+        eprintln!(
+            "ix-ai-annotations: {} annotations -> {}",
+            annotations.len(),
+            out_path.display()
+        );
+    }
+    Ok(())
+}

--- a/crates/ix-ai-annotations/src/lib.rs
+++ b/crates/ix-ai-annotations/src/lib.rs
@@ -1,0 +1,41 @@
+//! In-source AI annotation extractor.
+//!
+//! Walks a workspace, finds comments matching the `@ai:` marker syntax defined in
+//! `docs/contracts/2026-05-24-ai-annotation.contract.md`, and emits a stream of
+//! [`Annotation`] structs (canonical JSON shape).
+//!
+//! ```ignore
+//! // @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]
+//! ```
+//!
+//! The extractor is intentionally language-agnostic — it matches against the
+//! `@ai:` token inside any single-line comment (`//`, `#`, `--`) or a single-line
+//! block comment (`/* ... */`, `<!-- ... -->`). Multi-line block comments are
+//! NOT supported in v1.
+
+pub mod parser;
+pub mod types;
+pub mod walker;
+
+pub use parser::{parse_line, ParsedMarker};
+pub use types::{Annotation, AnnotationKind, Certainty, Source, Location, TruthValue, SCHEMA_VERSION};
+pub use walker::extract;
+
+use std::path::Path;
+
+/// High-level convenience: walk `workspace`, return all annotations.
+///
+/// Equivalent to [`walker::extract`].
+pub fn extract_workspace(workspace: &Path) -> Result<Vec<Annotation>, Error> {
+    walker::extract(workspace)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("regex error: {0}")]
+    Regex(#[from] regex::Error),
+    #[error("serde error: {0}")]
+    Serde(#[from] serde_json::Error),
+}

--- a/crates/ix-ai-annotations/src/parser.rs
+++ b/crates/ix-ai-annotations/src/parser.rs
@@ -1,0 +1,226 @@
+//! Parser for `@ai:` markers inside source comments.
+//!
+//! Recognizes the form documented in
+//! `docs/contracts/2026-05-24-ai-annotation.contract.md`:
+//!
+//! ```text
+//! <comment-marker> @ai:<kind> <claim> [<T>:<certainty> conf:<confidence> src:<evidence>]
+//! ```
+//!
+//! Supported comment markers (single-line and single-line block):
+//! - `//`  (C-family, Rust, JS/TS, C#, F#, Java, Go, Swift)
+//! - `#`   (Python, Ruby, Shell, PowerShell, YAML, TOML)
+//! - `--`  (Lua, SQL, Haskell)
+//! - `/* ... */`   (single-line block)
+//! - `<!-- ... -->` (single-line HTML/XML/MD block)
+
+use crate::types::{AnnotationKind, Certainty, TruthValue};
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// One parsed `@ai:` marker — language-agnostic intermediate form.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedMarker {
+    pub kind: AnnotationKind,
+    pub claim: String,
+    pub truth_value: TruthValue,
+    pub certainty: Certainty,
+    pub confidence: Option<f64>,
+    pub evidence: Option<String>,
+}
+
+// The single regex that captures everything after we've stripped comment markers.
+// We accept a payload like:
+//
+//     @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]
+//
+// Capture groups:
+// 1. kind            (`invariant`)
+// 2. claim           (`arr is sorted ascending`)
+// 3. truth_value     (`T`)
+// 4. certainty       (`test`)
+// 5. confidence      (`0.95`, optional)
+// 6. evidence        (`test_search.rs:42`, optional)
+fn marker_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?x)
+            @ai:(?P<kind>[a-zA-Z_-]+)
+            \s+
+            (?P<claim>.+?)
+            \s+
+            \[
+              (?P<tv>[TPUDFC])
+              :
+              (?P<cert>[a-z][a-z\-]*)
+              (?:\s+conf:(?P<conf>[0-9]*\.?[0-9]+))?
+              (?:\s+src:(?P<src>[^\]]+?))?
+            \]
+            ",
+        )
+        .expect("static regex compiles")
+    })
+}
+
+/// Strip the leading comment marker from a line (returning the text after the
+/// marker), or `None` if the line has no comment marker we recognize.
+fn strip_comment_marker(line: &str) -> Option<&str> {
+    let trimmed = line.trim_start();
+    // Block comments: /* ... */ — accept only single-line form.
+    if let Some(rest) = trimmed.strip_prefix("/*") {
+        let rest = rest.trim_start();
+        if let Some(closed) = rest.rsplit_once("*/") {
+            return Some(closed.0);
+        }
+        // No closing marker on the same line: still try to parse the rest.
+        return Some(rest);
+    }
+    // HTML comment: <!-- ... -->
+    if let Some(rest) = trimmed.strip_prefix("<!--") {
+        let rest = rest.trim_start();
+        if let Some(closed) = rest.rsplit_once("-->") {
+            return Some(closed.0);
+        }
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix("///") {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix("//!") {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix("//") {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix("#!") {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix('#') {
+        return Some(rest);
+    }
+    if let Some(rest) = trimmed.strip_prefix("--") {
+        return Some(rest);
+    }
+    None
+}
+
+/// Parse one source line. Returns `Some` if the line contains a well-formed
+/// `@ai:` marker.
+pub fn parse_line(line: &str) -> Option<ParsedMarker> {
+    let payload = strip_comment_marker(line)?;
+    // Quick reject: must contain "@ai:" before regex.
+    if !payload.contains("@ai:") {
+        return None;
+    }
+    let caps = marker_re().captures(payload)?;
+    let kind = AnnotationKind::parse(caps.name("kind")?.as_str())?;
+    let claim = caps.name("claim")?.as_str().trim().to_string();
+    let tv_char = caps.name("tv")?.as_str().chars().next()?;
+    let truth_value = TruthValue::from_char(tv_char)?;
+    let certainty = Certainty::parse(caps.name("cert")?.as_str())?;
+    let confidence = caps
+        .name("conf")
+        .and_then(|m| m.as_str().parse::<f64>().ok());
+    let evidence = caps.name("src").map(|m| m.as_str().trim().to_string());
+
+    Some(ParsedMarker {
+        kind,
+        claim,
+        truth_value,
+        certainty,
+        confidence,
+        evidence,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_double_slash_full_marker() {
+        let line = "    // @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Invariant);
+        assert_eq!(m.claim, "arr is sorted ascending");
+        assert_eq!(m.truth_value, TruthValue::T);
+        assert_eq!(m.certainty, Certainty::Test);
+        assert_eq!(m.confidence, Some(0.95));
+        assert_eq!(m.evidence.as_deref(), Some("test_search.rs:42"));
+    }
+
+    #[test]
+    fn python_hash_assumption_no_evidence() {
+        let line = "# @ai:assumption caller holds the lock [P:assumed conf:0.7]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Assumption);
+        assert_eq!(m.truth_value, TruthValue::P);
+        assert_eq!(m.certainty, Certainty::Assumed);
+        assert_eq!(m.confidence, Some(0.7));
+        assert!(m.evidence.is_none());
+    }
+
+    #[test]
+    fn lua_double_dash() {
+        let line = "-- @ai:hypothesis race-free under MIRI [U:uncertain conf:0.4]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Hypothesis);
+        assert_eq!(m.truth_value, TruthValue::U);
+        assert_eq!(m.certainty, Certainty::Uncertain);
+    }
+
+    #[test]
+    fn rust_block_comment_single_line() {
+        let line = "/* @ai:smell deep nesting [D:inferred conf:0.6] */";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Smell);
+        assert_eq!(m.truth_value, TruthValue::D);
+    }
+
+    #[test]
+    fn html_comment() {
+        let line = "<!-- @ai:hint prefer KaTeX over MathJax [U:uncertain] -->";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Hint);
+        assert!(m.confidence.is_none());
+    }
+
+    #[test]
+    fn rust_triple_slash_doc_comment() {
+        let line = "/// @ai:contract returns non-empty iff input is non-empty [T:manually-reviewed conf:0.85 src:PR#313]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::Contract);
+        assert_eq!(m.certainty, Certainty::ManuallyReviewed);
+        assert_eq!(m.evidence.as_deref(), Some("PR#313"));
+    }
+
+    #[test]
+    fn missing_marker_yields_none() {
+        assert!(parse_line("// just a normal comment").is_none());
+        assert!(parse_line("let x = 5;").is_none());
+        assert!(parse_line("# also normal").is_none());
+    }
+
+    #[test]
+    fn malformed_bracket_rejected() {
+        // missing certainty
+        assert!(parse_line("// @ai:invariant something [T:]").is_none());
+        // wrong truth value letter
+        assert!(parse_line("// @ai:invariant something [X:test]").is_none());
+    }
+
+    #[test]
+    fn refuted_false_value() {
+        let line = "// @ai:hypothesis no allocator in hot path [F:test conf:0.92 src:bench.rs:18]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.truth_value, TruthValue::F);
+    }
+
+    #[test]
+    fn contradictory_value() {
+        let line = "// @ai:invariant len > 0 [C:test conf:0.5]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.truth_value, TruthValue::C);
+    }
+}

--- a/crates/ix-ai-annotations/src/types.rs
+++ b/crates/ix-ai-annotations/src/types.rs
@@ -1,0 +1,163 @@
+//! Canonical types for AI annotations.
+//!
+//! Mirrors `docs/contracts/ai-annotation.schema.json`.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version pinned by the contract.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Hexavalent truth value, aligned with
+/// `governance/demerzel/schemas/hexavalent-distribution.schema.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TruthValue {
+    /// True — verified with evidence.
+    T,
+    /// Probable — evidence leans true, not yet verified.
+    P,
+    /// Unknown — insufficient evidence, triggers investigation.
+    U,
+    /// Doubtful — evidence leans false, not yet refuted.
+    D,
+    /// False — refuted with evidence.
+    F,
+    /// Contradictory — conflicting evidence, triggers escalation.
+    C,
+}
+
+impl TruthValue {
+    pub fn from_char(c: char) -> Option<Self> {
+        match c {
+            'T' => Some(Self::T),
+            'P' => Some(Self::P),
+            'U' => Some(Self::U),
+            'D' => Some(Self::D),
+            'F' => Some(Self::F),
+            'C' => Some(Self::C),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::T => "T",
+            Self::P => "P",
+            Self::U => "U",
+            Self::D => "D",
+            Self::F => "F",
+            Self::C => "C",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Certainty {
+    Test,
+    FormalProof,
+    ManuallyReviewed,
+    Assumed,
+    Uncertain,
+    Inferred,
+    Dismissed,
+}
+
+impl Certainty {
+    /// Parse from the kebab-case form used in the marker bracket.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "test" => Some(Self::Test),
+            "formal-proof" => Some(Self::FormalProof),
+            "manually-reviewed" => Some(Self::ManuallyReviewed),
+            "assumed" => Some(Self::Assumed),
+            "uncertain" => Some(Self::Uncertain),
+            "inferred" => Some(Self::Inferred),
+            "dismissed" => Some(Self::Dismissed),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnnotationKind {
+    Invariant,
+    Assumption,
+    Hypothesis,
+    Contract,
+    Smell,
+    Decision,
+    Hint,
+}
+
+impl AnnotationKind {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "invariant" => Some(Self::Invariant),
+            "assumption" => Some(Self::Assumption),
+            "hypothesis" => Some(Self::Hypothesis),
+            "contract" => Some(Self::Contract),
+            "smell" => Some(Self::Smell),
+            "decision" => Some(Self::Decision),
+            "hint" => Some(Self::Hint),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Source {
+    pub author: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Location {
+    pub path: String,
+    pub line_start: u32,
+    pub line_end: u32,
+}
+
+/// One extracted annotation, in canonical wire form (serializes to
+/// `ai-annotation.schema.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotation {
+    pub schema_version: u32,
+    pub id: String,
+    pub kind: AnnotationKind,
+    pub claim: String,
+    pub truth_value: TruthValue,
+    pub certainty: Certainty,
+    pub confidence: f64,
+    pub source: Source,
+    pub location: Location,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub stale: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reconciliation: Option<Reconciliation>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Reconciliation {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_match: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub promoted_to_c_from: Vec<TruthValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weighted_truth_value: Option<TruthValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weighted_confidence: Option<f64>,
+}
+
+/// Deterministic id over `path:line_start:kind:claim`.
+pub fn annotation_id(path: &str, line_start: u32, kind: AnnotationKind, claim: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let key = format!("{}:{}:{:?}:{}", path, line_start, kind, claim);
+    let digest = Sha256::digest(key.as_bytes());
+    format!("sha256:{:x}", digest)
+}

--- a/crates/ix-ai-annotations/src/walker.rs
+++ b/crates/ix-ai-annotations/src/walker.rs
@@ -1,0 +1,127 @@
+//! File-system walker that streams [`Annotation`]s out of a workspace.
+
+use crate::parser::{parse_line, ParsedMarker};
+use crate::types::{annotation_id, Annotation, Location, Source, SCHEMA_VERSION};
+use crate::Error;
+use ignore::WalkBuilder;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// File extensions we'll bother scanning. Tuned to the GuitarAlchemist ecosystem
+/// languages plus common config/docs.
+const SCANNABLE_EXTS: &[&str] = &[
+    "rs", "cs", "fs", "fsx", "fsi", "ts", "tsx", "js", "jsx", "py", "rb", "go", "java", "swift",
+    "c", "h", "cpp", "hpp", "lua", "sql", "hs", "sh", "ps1", "psm1", "yml", "yaml", "toml",
+    "html", "htm", "xml", "md",
+];
+
+fn has_scannable_ext(path: &Path) -> bool {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| SCANNABLE_EXTS.iter().any(|w| w.eq_ignore_ascii_case(e)))
+        .unwrap_or(false)
+}
+
+/// Extract every `@ai:` annotation under `workspace`. Uses `ignore::WalkBuilder`
+/// so we honor `.gitignore`, `.ignore`, and skip hidden dirs by default.
+pub fn extract(workspace: &Path) -> Result<Vec<Annotation>, Error> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut out = Vec::new();
+
+    let mut walker = WalkBuilder::new(workspace);
+    walker
+        .hidden(false) // .claude/, .github/ should be visible — they may have annotations
+        .git_ignore(true)
+        .git_exclude(true)
+        .filter_entry(|e| {
+            let name = e.file_name().to_string_lossy();
+            // Hard-exclude these regardless of .gitignore
+            !matches!(
+                name.as_ref(),
+                "target" | "node_modules" | ".git" | "dist" | "build" | ".next" | ".venv" | "venv"
+            )
+        });
+
+    for result in walker.build() {
+        let entry = match result {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let path = entry.path();
+        if !has_scannable_ext(path) {
+            continue;
+        }
+        scan_file(workspace, path, &now, &mut out)?;
+    }
+
+    Ok(out)
+}
+
+fn scan_file(
+    workspace: &Path,
+    path: &Path,
+    now: &str,
+    out: &mut Vec<Annotation>,
+) -> Result<(), Error> {
+    let file = match File::open(path) {
+        Ok(f) => f,
+        Err(_) => return Ok(()), // Skip files we can't open
+    };
+    let reader = BufReader::new(file);
+    let rel = path
+        .strip_prefix(workspace)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    for (idx, line_res) in reader.lines().enumerate() {
+        let line = match line_res {
+            Ok(l) => l,
+            Err(_) => return Ok(()), // Likely binary or invalid UTF-8
+        };
+        let lineno = (idx + 1) as u32;
+        if let Some(marker) = parse_line(&line) {
+            out.push(promote(marker, &rel, lineno, now));
+        }
+    }
+    Ok(())
+}
+
+fn promote(marker: ParsedMarker, rel_path: &str, lineno: u32, now: &str) -> Annotation {
+    let ParsedMarker {
+        kind,
+        claim,
+        truth_value,
+        certainty,
+        confidence,
+        evidence,
+    } = marker;
+    let id = annotation_id(rel_path, lineno, kind, &claim);
+    Annotation {
+        schema_version: SCHEMA_VERSION,
+        id,
+        kind,
+        claim,
+        truth_value,
+        certainty,
+        confidence: confidence.unwrap_or(0.5),
+        source: Source {
+            author: "auto".to_string(),
+            model: None,
+            evidence,
+        },
+        location: Location {
+            path: rel_path.to_string(),
+            line_start: lineno,
+            line_end: lineno,
+        },
+        created_at: now.to_string(),
+        updated_at: now.to_string(),
+        stale: false,
+        reconciliation: None,
+    }
+}

--- a/crates/ix-ai-annotations/tests/extract_integration.rs
+++ b/crates/ix-ai-annotations/tests/extract_integration.rs
@@ -1,0 +1,72 @@
+use ix_ai_annotations::{extract_workspace, AnnotationKind, TruthValue};
+use std::path::PathBuf;
+
+#[test]
+fn fixture_dir_yields_expected_annotations() {
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let mut annotations = extract_workspace(&fixtures).expect("extract ok");
+
+    // Deterministic order for assertions
+    annotations.sort_by(|a, b| {
+        a.location
+            .path
+            .cmp(&b.location.path)
+            .then_with(|| a.location.line_start.cmp(&b.location.line_start))
+    });
+
+    // 5 in sample.rs (invariant, assumption, contract, hypothesis, smell)
+    // 1 in sample.py (hint)
+    assert_eq!(
+        annotations.len(),
+        6,
+        "expected 6 annotations, got {} -> {:#?}",
+        annotations.len(),
+        annotations.iter().map(|a| &a.claim).collect::<Vec<_>>()
+    );
+
+    let kinds: Vec<_> = annotations.iter().map(|a| a.kind).collect();
+    assert!(kinds.contains(&AnnotationKind::Invariant));
+    assert!(kinds.contains(&AnnotationKind::Assumption));
+    assert!(kinds.contains(&AnnotationKind::Contract));
+    assert!(kinds.contains(&AnnotationKind::Hypothesis));
+    assert!(kinds.contains(&AnnotationKind::Smell));
+    assert!(kinds.contains(&AnnotationKind::Hint));
+
+    // Truth values cover the spectrum we wrote in the fixture
+    let tvs: Vec<_> = annotations.iter().map(|a| a.truth_value).collect();
+    assert!(tvs.contains(&TruthValue::T));
+    assert!(tvs.contains(&TruthValue::P));
+    assert!(tvs.contains(&TruthValue::U));
+    assert!(tvs.contains(&TruthValue::D));
+
+    // Every annotation gets a deterministic sha256 id
+    for a in &annotations {
+        assert!(
+            a.id.starts_with("sha256:") && a.id.len() == "sha256:".len() + 64,
+            "bad id: {}",
+            a.id
+        );
+        assert_eq!(a.schema_version, 1);
+    }
+}
+
+#[test]
+fn id_is_stable_across_runs() {
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let first = extract_workspace(&fixtures).unwrap();
+    let second = extract_workspace(&fixtures).unwrap();
+    let ids1: Vec<_> = first.iter().map(|a| a.id.clone()).collect();
+    let ids2: Vec<_> = second.iter().map(|a| a.id.clone()).collect();
+    assert_eq!(ids1, ids2);
+}
+
+#[test]
+fn confidence_defaults_to_half_when_omitted() {
+    let fixtures = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    let annotations = extract_workspace(&fixtures).unwrap();
+    let hint = annotations
+        .iter()
+        .find(|a| a.kind == AnnotationKind::Hint)
+        .expect("hint present in sample.py");
+    assert_eq!(hint.confidence, 0.5);
+}

--- a/crates/ix-ai-annotations/tests/fixtures/sample.py
+++ b/crates/ix-ai-annotations/tests/fixtures/sample.py
@@ -1,0 +1,5 @@
+# A Python sample to verify cross-language extraction.
+
+# @ai:hint prefer dict over OrderedDict in 3.7+ [U:uncertain]
+def foo(x):
+    return x + 1

--- a/crates/ix-ai-annotations/tests/fixtures/sample.rs
+++ b/crates/ix-ai-annotations/tests/fixtures/sample.rs
@@ -1,0 +1,25 @@
+// Sample fixture file used by the ix-ai-annotations integration test.
+// Each annotation below should round-trip through extract_workspace.
+
+pub fn binary_search(arr: &[i32], target: i32) -> Option<usize> {
+    // @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]
+    let mut lo = 0;
+    let mut hi = arr.len();
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        // @ai:assumption (hi - lo) does not overflow [P:assumed conf:0.7]
+        match arr[mid].cmp(&target) {
+            std::cmp::Ordering::Less => lo = mid + 1,
+            std::cmp::Ordering::Greater => hi = mid,
+            std::cmp::Ordering::Equal => return Some(mid),
+        }
+    }
+    None
+}
+
+/// @ai:contract returns None iff target not present [T:manually-reviewed conf:0.85 src:PR#313]
+pub fn search_api() {}
+
+// @ai:hypothesis race-free under MIRI [U:uncertain conf:0.4]
+// @ai:smell duplicate constants below [D:inferred conf:0.6]
+fn _placeholder() {}

--- a/docs/contracts/2026-05-24-ai-annotation.contract.md
+++ b/docs/contracts/2026-05-24-ai-annotation.contract.md
@@ -1,0 +1,185 @@
+# AI Source-Code Annotation — Cross-Repo Contract
+
+**Version:** 0.1.0 (draft, Phase 0)
+**Schema version:** 1
+**Status:** Draft (Phase 0 of `ai-annotations` campaign, 2026-05-24)
+**Producers:** `ix-ai-annotations` extractor, ga PostToolUse hook `Scripts/ai-annotation-scan.ps1`, human authors
+**Consumers:** `ix-ai-annotations` reconciler, `ix_annotations_scan` MCP tool, ga dashboard `/dev-data/ai-annotations`, `grade-last-pr` skill, pre-merge gate
+**Schema file:** `docs/contracts/ai-annotation.schema.json`
+
+---
+
+## 1. Why This Contract Exists
+
+AI agents (Claude, Codex, Gemini, Junie, Auggie) routinely write code with implicit beliefs that disappear into the diff:
+
+- "This array is sorted ascending"
+- "The caller already holds the lock"
+- "This is race-free under MIRI"
+
+Today these claims live in commit messages, PR descriptions, ephemeral chat turns, or worse — nowhere. The next agent (often the same agent in a later session) has to re-derive them, frequently mis-deriving. Tests don't capture intent, only behavior. ADRs capture decisions but not micro-claims at the line level.
+
+This contract defines a **lightweight, in-comment, structured marker** that:
+
+1. Lives at the exact line the claim applies to.
+2. Carries a **hexavalent truth value** (T/P/U/D/F/C) per Demerzel's canonical logic.
+3. Carries a **certainty marker** (test / formal-proof / manually-reviewed / assumed / uncertain / inferred / dismissed).
+4. Carries a **0.0–1.0 confidence** matching Demerzel's autonomous-action thresholds (≥0.9 / ≥0.7 / ≥0.5 / ≥0.3 / <0.3).
+5. Optionally references **evidence** (a test path, PR number, MIRI run id).
+
+The reconciler in Phase 1 cross-checks `[T:test]` claims against actual test runs, promotes conflicting same-line annotations to `C` (contradictory), and flags stale annotations whose file has changed without the annotation being updated.
+
+This is complementary to `ix-invariant-coverage`, which scans an **external markdown catalog** of ecosystem-wide invariants. `ai-annotation` is **in-source, line-local, agent-authored**.
+
+The contract is a **one-way door** on the field names and the truth_value enum (these align with Demerzel's `hexavalent-distribution.schema.json`). Field additions are additive and optional until v2.
+
+---
+
+## 2. The In-Source Marker Syntax
+
+Annotations are written as comments using the language's native comment style. The parser supports:
+
+- `//` (C, C++, Rust, JavaScript, TypeScript, C#, F#, Java, Go, Swift)
+- `#` (Python, Ruby, Shell, PowerShell, YAML, TOML)
+- `--` (Lua, SQL, Haskell)
+- `/* ... */` (block, single-line only in v1)
+- `<!-- ... -->` (HTML, XML, Markdown)
+
+The canonical form:
+
+```
+<comment-marker> @ai:<kind> <claim> [<T>:<certainty> conf:<confidence> src:<evidence>]
+```
+
+Examples:
+
+```rust
+// @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]
+// @ai:assumption caller holds the lock [P:assumed conf:0.7]
+// @ai:hypothesis race-free under MIRI [U:uncertain conf:0.4]
+```
+
+```python
+# @ai:contract returns non-empty iff input is non-empty [T:manually-reviewed conf:0.85 src:PR#313]
+```
+
+```fsharp
+// @ai:smell deep nesting; consider extracting [D:inferred conf:0.6]
+```
+
+Field order inside the brackets is fixed: `T:certainty` first, then optional `conf:`, then optional `src:`.
+
+---
+
+## 3. Annotation Kinds (`kind`)
+
+| kind         | meaning                                                                 |
+|--------------|-------------------------------------------------------------------------|
+| `invariant`  | something that holds at this point and the surrounding code relies on it |
+| `assumption` | something the code assumes about its environment / caller / inputs       |
+| `hypothesis` | a guess to be verified; expect this to flip to T or F over time          |
+| `contract`   | an externally-visible pre/post-condition (lighter than a full ADR)       |
+| `smell`      | code-smell or suspicion; will likely be addressed                        |
+| `decision`   | a one-line ADR pointer (the "why" of nearby code)                        |
+| `hint`       | guidance for the next reader / agent (no truth claim, default `U`)       |
+
+---
+
+## 4. Truth Value Enum (Hexavalent)
+
+Aligned with `governance/demerzel/schemas/hexavalent-distribution.schema.json`:
+
+| code | name          | meaning                                        |
+|------|---------------|------------------------------------------------|
+| `T`  | True          | verified with evidence                         |
+| `P`  | Probable      | evidence leans true, not yet verified          |
+| `U`  | Unknown       | insufficient evidence, triggers investigation  |
+| `D`  | Doubtful      | evidence leans false, not yet refuted          |
+| `F`  | False         | refuted with evidence                          |
+| `C`  | Contradictory | conflicting evidence, triggers escalation      |
+
+---
+
+## 5. Certainty Marker
+
+The `certainty` field describes **how** the truth value was reached:
+
+| marker             | meaning                                                                |
+|--------------------|------------------------------------------------------------------------|
+| `test`             | a unit/integration/property test exercises this claim                  |
+| `formal-proof`     | a checker (MIRI, prusti, kani, lean) verifies this                     |
+| `manually-reviewed`| a human or reviewing agent inspected and signed off                    |
+| `assumed`          | taken on faith from the spec / docs / caller contract                  |
+| `uncertain`        | best-guess; explicit acknowledgement of low confidence                 |
+| `inferred`         | derived from context (e.g., heuristic match against another test)      |
+| `dismissed`        | previously flagged, now considered not-applicable                      |
+
+---
+
+## 6. Confidence Thresholds (Demerzel-aligned)
+
+| range     | behavior                          |
+|-----------|-----------------------------------|
+| `≥ 0.9`   | autonomous action                 |
+| `≥ 0.7`   | act with note                     |
+| `≥ 0.5`   | ask confirmation                  |
+| `≥ 0.3`   | escalate                          |
+| `< 0.3`   | do not act                        |
+
+---
+
+## 7. Canonical JSON Shape (extractor output)
+
+```json
+{
+  "schema_version": 1,
+  "id": "sha256:f3b1c2...",
+  "kind": "invariant",
+  "claim": "arr is sorted ascending",
+  "truth_value": "T",
+  "certainty": "test",
+  "confidence": 0.95,
+  "source": {
+    "author": "claude",
+    "model": "claude-opus-4-7",
+    "evidence": "test_search.rs:42"
+  },
+  "location": {
+    "path": "crates/ix-search/src/binary.rs",
+    "line_start": 42,
+    "line_end": 42
+  },
+  "created_at": "2026-05-24T18:00:00Z",
+  "updated_at": "2026-05-24T18:00:00Z"
+}
+```
+
+`id` is a deterministic SHA-256 of `path:line_start:kind:claim` so the same annotation hashes the same across runs (allows reconciler to track lifecycle).
+
+The extractor in Phase 0 writes a JSONL file at `state/quality/ai-annotations.jsonl`, one annotation per line.
+
+---
+
+## 8. Storage Layout
+
+| file                                                  | producer                            | consumer                          |
+|-------------------------------------------------------|-------------------------------------|-----------------------------------|
+| `state/quality/ai-annotations.jsonl`                  | `ix-ai-annotations extract`         | ga dashboard, reconciler          |
+| `state/quality/ai-annotations-reconciliation.json`    | `ix-ai-annotations reconcile`       | ga dashboard, pre-merge gate      |
+
+---
+
+## 9. Phase Plan (this contract = Phase 0)
+
+- **Phase 0 (this PR):** schema + extractor crate (`ix-ai-annotations`).
+- **Phase 1:** reconciler + `ix_annotations_scan` MCP tool.
+- **Phase 2:** ga dashboard tab on `/test#dev`.
+- **Phase 3:** workflow hooks + pre-merge gate + `/grade-last-pr` integration.
+
+---
+
+## 10. Versioning
+
+The contract is `v0.1.0` (draft). Field shapes and the truth-value enum are stable from Phase 0 onward; we only bump `schema_version` when a field is renamed or removed. New optional fields are additive (no bump).
+
+Freeze milestone: end of Phase 3 (full pipeline shipped + ≥ 50 annotations in the codebase actively reconciled).

--- a/docs/contracts/ai-annotation.schema.json
+++ b/docs/contracts/ai-annotation.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ix/contracts/ai-annotation-v1.json",
+  "title": "AI Source-Code Annotation",
+  "description": "An in-source, line-local, agent-authored claim about code: an invariant, assumption, hypothesis, contract, smell, decision, or hint. Carries hexavalent truth value (T/P/U/D/F/C) and certainty marker. Aligned with governance/demerzel/schemas/hexavalent-distribution.schema.json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "kind",
+    "claim",
+    "truth_value",
+    "certainty",
+    "confidence",
+    "source",
+    "location",
+    "created_at",
+    "updated_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "integer", "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$",
+      "description": "Deterministic SHA-256 over path:line_start:kind:claim; identifies the same annotation across extractions."
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["invariant", "assumption", "hypothesis", "contract", "smell", "decision", "hint"]
+    },
+    "claim": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 500,
+      "description": "Human-readable text of the claim."
+    },
+    "truth_value": {
+      "type": "string",
+      "enum": ["T", "P", "U", "D", "F", "C"],
+      "description": "Hexavalent truth value per Demerzel hexavalent-distribution.schema.json."
+    },
+    "certainty": {
+      "type": "string",
+      "enum": [
+        "test",
+        "formal-proof",
+        "manually-reviewed",
+        "assumed",
+        "uncertain",
+        "inferred",
+        "dismissed"
+      ],
+      "description": "How the truth value was reached."
+    },
+    "confidence": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "0.0-1.0 per Demerzel confidence thresholds (>=0.9 autonomous, >=0.7 with note, >=0.5 confirm, >=0.3 escalate, <0.3 do not act)."
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["author"],
+      "properties": {
+        "author": {
+          "type": "string",
+          "enum": ["claude", "codex", "gemini", "junie", "auggie", "human", "auto"]
+        },
+        "model": {
+          "type": "string",
+          "description": "Optional model id e.g. claude-opus-4-7."
+        },
+        "evidence": {
+          "type": "string",
+          "description": "Optional evidence reference: test path:line, PR#, MIRI run id, etc."
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "line_start", "line_end"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Repo-relative file path."
+        },
+        "line_start": { "type": "integer", "minimum": 1 },
+        "line_end": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "stale": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set by the reconciler when the underlying file has been modified materially after the annotation was last updated."
+    },
+    "reconciliation": {
+      "type": "object",
+      "description": "Optional block populated by the reconciler in Phase 1. Absent in raw extractor output.",
+      "additionalProperties": false,
+      "properties": {
+        "test_match": {
+          "type": ["string", "null"],
+          "description": "Test path that appears to exercise this claim, or null."
+        },
+        "promoted_to_C_from": {
+          "type": "array",
+          "items": { "type": "string", "enum": ["T", "P", "U", "D", "F"] },
+          "description": "Other truth values seen at the same location that triggered C-promotion."
+        },
+        "weighted_truth_value": {
+          "type": "string",
+          "enum": ["T", "P", "U", "D", "F", "C"],
+          "description": "Multi-source weighted hexavalent result."
+        },
+        "weighted_confidence": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase 0 of the **AI source-code annotations** campaign. Ships the contract + extractor; reconciler/dashboard/gates come in phases 1-3.

The user wants to drop semantic markers in source comments:

```rust
// @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]
// @ai:assumption caller holds the lock [P:assumed conf:0.7]
// @ai:hypothesis race-free under MIRI [U:uncertain conf:0.4]
```

with **hexavalent truth values** (T/P/U/D/F/C, aligned with Demerzel) and certainty markers.

## What's in this PR

- **Contract**: \`docs/contracts/2026-05-24-ai-annotation.contract.md\` (v0.1.0 draft, freezes at Phase 3)
- **Schema**: \`docs/contracts/ai-annotation.schema.json\` — references Demerzel's \`hexavalent-distribution.schema.json\` enum for truth_value
- **Crate**: \`crates/ix-ai-annotations\`
  - Parser: \`//\`, \`///\`, \`//!\`, \`#\`, \`--\`, \`/* */\`, \`<!-- -->\` comment styles (covers Rust, C#, F#, TS/JS, Python, PowerShell, YAML, SQL, Lua, HTML, MD)
  - Walker: \`ignore::WalkBuilder\` honors \`.gitignore\`; scans 30+ extensions; skips \`target/\`, \`node_modules/\`, etc.
  - Deterministic SHA-256 ids over \`path:line:kind:claim\` so the same annotation hashes consistently across runs
  - CLI binary writes JSONL to \`state/quality/ai-annotations.jsonl\`
- 10 unit tests for the parser + 3 integration tests on a fixture dir

## Phase plan

| phase | scope | PR |
|-------|-------|----|
| 0 | schema + extractor | **this PR** |
| 1 | reconciler (test-coverage match, C-promotion, stale flag) + \`ix_annotations_scan\` MCP tool | (queued) |
| 2 | ga dashboard tab on \`/test#dev\` | (queued) |
| 3 | hooks + pre-merge gate + \`/grade-last-pr\` integration | (queued) |

## Design notes

- **No new \`tetravalent-state.schema.json\`**: the campaign spec referenced one that doesn't exist on disk. Demerzel already canonicalizes the 6-valued enum in \`hexavalent-distribution.schema.json\`, so we reference that.
- **Schema lives in \`docs/contracts/\` of ix, not in Demerzel**: Demerzel's \`no-runtime-code.md\` rule scopes that submodule to behavioral specs only.

## Test plan

- [x] \`cargo test -p ix-ai-annotations\` — 13/13 passing
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] CLI smoke test against \`crates/ix-ai-annotations/\` extracts the fixture annotations
- [ ] CI green (this PR)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>