### PR TITLE
docs(claude): /correct rule — attach @ai: annotations for in-code claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,4 +84,4 @@ The hooks are validated in CI by `.github/workflows/karpathy-cherny-discipline.y
 
 _Appended by `/correct` when the user corrects an approach. Persists across sessions._
 
-(none yet)
+- **2026-05-24** Before claiming an invariant, assumption, or hypothesis in code, attach an `@ai:` annotation with truth_value + certainty per `docs/contracts/2026-05-24-ai-annotation.contract.md`. Hexavalent T/P/U/D/F/C only; confidence per Demerzel thresholds. Example: `// @ai:invariant arr is sorted ascending [T:test conf:0.95 src:test_search.rs:42]`.


### PR DESCRIPTION
## Summary

One-line addition to CLAUDE.md Session-learned rules, recording the campaign convention that in-code invariants/assumptions/hypotheses must be annotated per the new ai-annotation contract (shipped in #54/#55).

Mirrors the pattern from #53 (periodic digest /correct rule landed today).

## Cross-repo context

This is the ix half of Phase 3 of the ai-annotations campaign. The ga half ships hooks + pre-merge gate + grade-last-pr integration in its own PR.

| phase | repo | PR |
|-------|------|----|
| 0 | ix | #54 |
| 1 | ix | #55 |
| 2 | ga | guitar-alchemist/ga#353 |
| 3 (ga side) | ga | (next, coming up) |
| 3 (ix side) | ix | **this PR** |

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>