### PR TITLE
feat(traceability-tree): schema contract + validation plan (phase 0 of 6)

### DIFF
--- a/docs/contracts/2026-05-24-traceability-tree.contract.md
+++ b/docs/contracts/2026-05-24-traceability-tree.contract.md
@@ -1,0 +1,330 @@
+# Traceability Tree — Cross-Repo Contract
+
+**Version:** 0.1.0 (draft, Phase 0 of 6)
+**Schema version:** 1
+**Status:** Draft (Phase 0 of `traceability-tree` campaign, 2026-05-24)
+**Producers:** future `ix-traceability-tree` crate, future ga BACKLOG.md parser exporter
+**Consumers:** future `ix_tree_query` / `ix_tree_zoom` / `ix_tree_drift` / `ix_tree_rebuild` MCP tools, future ga dashboard zoom UI, `grade-last-pr` skill, post-mortem ingestion
+**Schema file:** `docs/contracts/traceability-tree.schema.json`
+**Related contracts:** `docs/contracts/2026-05-24-ai-annotation.contract.md` (PR #54)
+
+---
+
+## 1. Why This Contract Exists
+
+The ecosystem now produces three roughly parallel hierarchies that no one can hold in their head at the same time:
+
+1. The **product hierarchy** — `BACKLOG.md` in ga: epic → epic-subsection → task → subtask, parsed by a TypeScript reader into `BacklogEpic` / `EpicSubSection` / `BacklogItem`.
+2. The **code hierarchy** — workspace → crate → module → file → symbol, with line-local `@ai:` annotations (PR #54, just shipped: `2026-05-24-ai-annotation.contract.md`) attaching invariants and contracts at the leaf.
+3. The **process hierarchy** — test plans, QA sessions, demos, post-mortems, dated `docs/plans/` and `docs/solutions/` — currently a flat set of files connected only by date prefix and grep.
+
+Agents (and operators) re-derive the mapping between these three on every task. A bug report cites a symbol; the agent has to find the file, walk to the module README, climb to the crate-level CONTEXT.md, locate the matching task in BACKLOG, find the test plan, find the post-mortem, find the `@ai:invariant` that was supposed to prevent this. Every climb costs context and silently drops detail. Every drop is a future hallucination.
+
+The **traceability tree** is one Merkle-style summary tree that unifies all three hierarchies — code, product, process — under a single semantic-zoom contract. The leaves are raw (a symbol's source span, an annotation, a single task line, a single test). Each internal node is a level-appropriate summary of its children, with an explicit `kept` / `dropped` manifest so an operator (or the next agent) can see what was compressed away without having to drill down to find out. AI annotations are pinned: every `@ai:invariant` and `@ai:contract` at any leaf is hoisted into every ancestor's `kept` list — they are the *low-frequency coefficients* of the wavelet decomposition and survive every zoom-out. This PR ships the contract; a Phase-1 `ix-traceability-tree` crate will materialize trees against it.
+
+---
+
+## 2. Mental Model
+
+Three converging metaphors. None alone is right; the contract sits at their intersection.
+
+### 2.1 Wavelet-style multi-resolution
+
+A traceability tree is a discrete wavelet decomposition over the workspace. Each level is a coarser approximation of the level below, and every level can be **reconstructed exactly** by walking back down to the leaves. The `kept` field carries the low-frequency coefficients that survive zoom-out (invariants, contracts, public API shapes, named architectural decisions). The `dropped` field is the explicit accounting of the high-frequency detail compressed away. *Lossy at this level, lossless from the root* — that is the trick.
+
+### 2.2 Merkle-tree provenance
+
+Every node is content-addressed: `id = blake3(canonical(content || sorted(children_hashes)))`. A child re-summarization changes the child's hash, which changes the parent's hash, which propagates to the root. This makes drift cheap to detect (one hash compare per parent) and gives every summary cryptographic provenance — the hash is the receipt that "this summary is what you got from these children at this moment."
+
+### 2.3 Hierarchical GraphRAG / Tree Index
+
+Microsoft's GraphRAG (<https://microsoft.github.io/graphrag/>) shows that hierarchical summaries — community → super-community — make global queries cheap on graphs that would otherwise require flat retrieval over the whole corpus. LlamaIndex's Tree Index (<https://docs.llamaindex.ai/en/stable/api_reference/indices/tree/>) demonstrates the same pattern for documents: query goes to the root, the root routes to the relevant child, the child routes further down. The traceability tree is the GraphRAG / Tree Index pattern applied to the code-plus-process-plus-product graph, with the additional discipline of *provenance* (Merkle) and *signal preservation* (kept/dropped manifests).
+
+### 2.4 Related work and prior art
+
+- **Microsoft GraphRAG** — <https://github.com/microsoft/graphrag> — community summarization, hierarchical query routing.
+- **LlamaIndex Tree Index** — <https://docs.llamaindex.ai/en/stable/api_reference/indices/tree/> — recursive document summaries for question-answering.
+- **Aider repo-map** — <https://aider.chat/docs/repomap.html> — code-graph extraction for LLM context, no hierarchy / no provenance.
+- **OpenTelemetry tree-of-spans** — <https://opentelemetry.io/docs/specs/otel/trace/api/> — runtime traces as trees; we borrow the parent/child + cross-link shape, applied statically.
+- **ix-bracelet `grothendieck_delta`** — `crates/ix-bracelet/src/grothendieck.rs` — signed Z⁶ delta between musical PC-sets via interval-class vectors. The *idea* (cheap signed delta over a structured fingerprint) is what we want for code-content drift; the *implementation* is music-theory-specific and not directly reusable. A future general `ix-grothendieck-delta` crate would close this gap.
+- **ix-context::cache** — `crates/ix-context/src/cache.rs` — content-hash-keyed cache with path-based invalidation; the existing primitive most analogous to the Merkle layer.
+- **ix-io::watcher** — `crates/ix-io/src/watcher.rs` — file-mtime watcher that emits change events; the existing trigger most analogous to the drift-alarm layer.
+
+---
+
+## 3. Node Format
+
+The full JSON Schema is in `docs/contracts/traceability-tree.schema.json`. Field-by-field commentary:
+
+| field | required | meaning |
+|---|---|---|
+| `id` | yes | Content-addressed blake3 hash over canonical(`summary` ⊕ `kind` ⊕ `level` ⊕ `provenance.source_path` ⊕ sorted(`children`)). Determines node identity. |
+| `schema_version` | yes | `const: 1`. Bumped only on breaking field rename/removal. |
+| `level` | yes | Integer `0..=6`. Section 4 defines the semantics. |
+| `kind` | yes | One of the 13-entry enum (Section 4). Aligns with ga's `BacklogEpic` / `EpicSubSection` / `BacklogItem` as a *superset* — the contract owns more kinds because it also covers code and process artifacts. |
+| `summary` | yes | Self-contained markdown body at this level. Must be readable without the children. |
+| `children` | no | Ordered list of child node `id`s. Empty for leaves. |
+| `parent` | no | Single parent `id` or `null` for root. Trees are forests-of-one in v1. |
+| `cross_refs` | no | Non-tree edges. Example: a `task` node cross-references the `test_unit` that proves it; a `file` cross-references the `post_mortem` whose root cause lives in this file. Cross-refs are typed by the kinds at both ends — schema does not enforce a typed-edge enum in v1. |
+| `provenance.source_path` | yes | Repo-relative path. For aggregate nodes, the directory or BACKLOG section path. |
+| `provenance.source_line_range` | no | `[start, end]` for leaf nodes that point at a span. |
+| `provenance.source_mtime` | no | Filesystem mtime at summarization time — feeds the drift detector. |
+| `provenance.summarizer_model` | no | `claude-opus-4-7@2026-05-24` style — captures both model and date so a model swap shows up as drift. |
+| `provenance.summarized_at` | no | ISO-8601 timestamp of the summarization call. |
+| `fidelity` | no | 0.0 – 1.0 self-report from the summarizer. Useful as a soft signal; not load-bearing. Leaves are 1.0 by definition. |
+| `kept` | no | Explicit list of facts preserved at this level. AI annotations always go here (Section 5). |
+| `dropped` | no | Explicit list of facts compressed away. Each entry should be a one-line summary readable on its own. |
+| `stale` | no | Set by the sync engine when the underlying children have changed but this node has not yet been re-summarized. |
+| `stale_reason` | no | Free text: which child diverged, by what hash delta, when. |
+| `ai_claims` | no | List of `@ai:` annotation ids (per `ai-annotation.schema.json`) that live in the subtree rooted here. Promoted upward by the build. |
+| `contract_invariants` | no | Free-text invariants this node guarantees to its parent. The parent's `kept` list must include every entry here. |
+
+Two non-obvious rules:
+
+1. **`id` is recursive**: it depends on `children`, which are themselves hashes. Building bottom-up is required.
+2. **`kept` is a contract with the parent**, not a hint to the reader. The sync engine treats a divergence between a child's `kept` and the parent's `kept` as an alarm condition (Section 6.3).
+
+---
+
+## 4. Level Semantics
+
+Seven levels, L0 (raw) to L6 (epic). The compression rate at each level is a target, not a hard constraint — fidelity matters more than ratio.
+
+| level | name | kind examples | compression target | what KIND of summary lives here |
+|---|---|---|---|---|
+| **L0** | Raw leaf | `symbol`, `test_unit`, `@ai:` annotation row, single BACKLOG line | 1.0× (no compression) | Verbatim source span or annotation. No LLM. |
+| **L1** | Local | `symbol` (function-with-docstring), small `test_integration` | ~3–5× | One-paragraph LLM summary of the leaf in context. Names, signatures, and `@ai:invariant` claims are preserved. |
+| **L2** | Aggregate | `file`, `test_plan`, `qa_session` | ~5–10× | Per-file or per-session summary. Lists the L1 children's invariants. |
+| **L3** | Composite | `module`, `subsystem` | ~10–20× | Cross-file summary. The boundary at which a human reviewer can still hold the entire summary in working memory. |
+| **L4** | Subsystem | `subsystem` (crate-level), `demo` | ~20–50× | Crate-level overview. Architectural shape, public surface, named invariants, integration points. |
+| **L5** | Story | `story`, `post_mortem` | ~50–100× | A unit of delivered or planned work spanning multiple subsystems. Mirrors ga `EpicSubSection` granularity. |
+| **L6** | Epic | `epic` | ~100×+ | Top-level objective; mirrors ga `BacklogEpic`. The root of a workspace tree. |
+
+Levels do not have to be fully populated — a small workspace may have empty L5/L6. A node's `level` is **declarative**: it tells the consumer what compression contract to expect, not how the node was built.
+
+A node MUST NOT have children at a strictly higher level than itself, and MUST NOT have children at a level more than two below itself (so an L4 can have L2 or L3 children, never L1 directly — force the intermediate aggregation).
+
+---
+
+## 5. Signal Preservation Contract
+
+This is the load-bearing idea of the contract.
+
+A naive recursive summary loses information silently. A reader at L4 sees a polished paragraph and has no way to know that "thread-safety of `Foo::bar` under MIRI" was dropped two levels below. The traceability tree forbids this. Every summary above L0 MUST:
+
+1. Carry an explicit `kept` array of facts preserved at this level. Each entry is a short string the reader can take to the bank.
+2. Carry an explicit `dropped` array of facts compressed away. Each entry must be drilled-down-reachable — the reader can follow `children` until a descendant's `summary` covers that fact in full.
+3. Promote **every** `@ai:invariant` and `@ai:contract` annotation in the subtree into its own `kept` list, verbatim or as a one-line rephrase that preserves the truth-value tag. AI annotations are the wavelet's low-frequency coefficients: they are short, structured, named, and operator-relevant. They survive every zoom-out.
+
+The contract guarantees: **a fact named in any descendant's `kept` is named in every ancestor's `kept` up to the root.** A fact in `dropped` at level N is reachable in `summary` or `kept` at some level < N. Nothing disappears.
+
+The reconciler (Phase 1) will enforce this with a structural check. A summarizer that drops an `@ai:invariant` without recording it explicitly is a build failure, not a soft warning.
+
+---
+
+## 6. Sync Protocol
+
+Three layers, ordered cheapest-first.
+
+### 6.1 Merkle hash propagation (free)
+
+On any file change, walk up from the affected leaf to the root, recomputing `id`s. Any node whose recomputed `id` differs from its stored `id` is marked `stale`. This is O(depth) per file change, runs on every git commit hook, and costs no LLM tokens.
+
+### 6.2 Selective re-summarization (LLM cost)
+
+A `stale` node is re-summarized by the L-appropriate prompt. Re-summarization is **bottom-up and lazy** — only when a `stale` node is queried (or on a scheduled rebuild) does the LLM call happen. The Phase-1 builder will emit a cost telemetry line per re-summarization so the operator can see "$3.40 spent re-summarizing 17 L1 nodes after PR #56."
+
+### 6.3 Drift alarm (algedonic signal)
+
+The most interesting layer. When a re-summarization changes a node's `kept` set in a way that violates the parent's `contract_invariants` (i.e., a fact the parent promised has been silently dropped by the new child summary), the sync engine raises a *drift alarm*: a structured event written to `state/quality/traceability-drift.jsonl` and surfaced to the operator via the ga dashboard. This is the algedonic channel — pain signal back to the operator when the tree's invariants stop holding. The parent is not auto-rebuilt; the operator (or a follow-up agent) decides whether the drift is acceptable (update the parent's contract) or whether the child has regressed (revert or fix the underlying code).
+
+---
+
+## 7. LLM Orchestration
+
+For v1, the Phase-1 builder shells out to the `claude` CLI per summary call. Rationale: zero new dependencies, easy to swap models, no API key handling in the crate, easy to cap per-invocation cost via the CLI's own controls. The summarization prompt is checked into the crate's `prompts/` directory so the prompt history is git-tracked alongside the schema.
+
+Future options, documented but not adopted in v1:
+
+- **`async-anthropic`** — <https://docs.rs/async-anthropic/> — direct API client. Justified once the cost telemetry shows per-rebuild costs that warrant a tighter feedback loop than `claude` CLI provides.
+- **Hari MCP cache** — `hari_record_observation` + `hari_query_belief` — store every summary as a Hari observation and let Hari's belief-state machinery answer "has this content already been summarized at this level?" before each LLM call. Big potential cost savings on repeated builds; only worthwhile after Phase 3.
+- **Local models for L0→L1** — L1 summaries are short and structured; a 7B local model probably suffices. Investigated when local-model infra exists in the workspace.
+
+Cost discipline (v1):
+
+- Hard cap per build invocation: `--max-cost 5.00` USD (configurable). Builds that would exceed it stop with a checkpoint and surface `state/quality/traceability-cost-budget.json` to the operator.
+- L1 batches: at most 32 leaves per `claude` call (context window discipline).
+- L4+ summaries cache aggressively — they should change only when L3 children's `kept` lists materially change.
+
+---
+
+## 8. Cross-References
+
+How this contract composes with the rest of the workspace:
+
+- **`@ai:` annotations** — see `2026-05-24-ai-annotation.contract.md`. Every annotation id is a candidate for hoisting into `ai_claims` and `kept` on every ancestor. The traceability tree is the index *over* the annotation corpus; the annotation contract owns the leaf format.
+- **ga BACKLOG.md parser** — the TypeScript reader emitting `BacklogEpic` / `EpicSubSection` / `BacklogItem` is the L6 / L5 / L4 producer on the product side. The traceability tree's `kind` enum is a superset of those three so a BACKLOG entry maps to a node with no schema bending.
+- **`ix-bracelet::grothendieck_delta`** — signed Z⁶ delta on musical PC-sets. The *shape* of the idea — cheap signed delta over a fingerprint — is the model for a future general code-content delta primitive. Not used directly in v1; cited as inspiration.
+- **`ix-context::cache`** — the existing content-hash-keyed cache. The traceability tree's `id` field uses the same blake3 family of primitives; integration will likely share a hash helper.
+- **`ix-category`** — composable transformations and categorical primitives. The summarization functor `L_n → L_{n+1}` is a candidate for expression as a category arrow once the data shape stabilizes; not pursued in v1.
+- **`ix-graph`** — graph data structures. `children` + `cross_refs` form a DAG that can be loaded into `ix-graph` for whole-tree queries (ancestor / descendant / shortest path).
+
+---
+
+## 9. MCP Tools (specification only; no implementation in this PR)
+
+Four tools to be implemented by the Phase-5 `ix-traceability-tree` MCP surface. Schemas are provisional; Phase 1 will lock them.
+
+### 9.1 `ix_tree_query`
+
+Find nodes by content or structure.
+
+```json
+{
+  "input": {
+    "workspace": "string (repo root path)",
+    "query": "string (free-text, matched against summary + kept + ai_claims)",
+    "level_min": "integer 0..=6 (optional, default 0)",
+    "level_max": "integer 0..=6 (optional, default 6)",
+    "kind": "string (optional, restrict to one kind)",
+    "limit": "integer (optional, default 10)"
+  },
+  "output": {
+    "matches": [
+      {
+        "id": "string (node id)",
+        "level": "integer",
+        "kind": "string",
+        "summary": "string",
+        "path_from_root": ["string (id chain)"],
+        "score": "number 0.0..=1.0"
+      }
+    ]
+  }
+}
+```
+
+### 9.2 `ix_tree_zoom`
+
+Navigate the tree by id. The primary zoom-in / zoom-out operator.
+
+```json
+{
+  "input": {
+    "node_id": "string",
+    "direction": "string enum: in | out | siblings",
+    "depth": "integer (optional, default 1, max 3)"
+  },
+  "output": {
+    "focus": "node object (full schema)",
+    "neighbors": ["node objects per direction + depth"]
+  }
+}
+```
+
+### 9.3 `ix_tree_drift`
+
+List drift alarms.
+
+```json
+{
+  "input": {
+    "workspace": "string",
+    "since": "ISO-8601 timestamp (optional)",
+    "level_min": "integer (optional)"
+  },
+  "output": {
+    "alarms": [
+      {
+        "node_id": "string (the parent whose contract was violated)",
+        "child_id": "string",
+        "violated_invariant": "string",
+        "first_seen": "ISO-8601 timestamp",
+        "current_status": "string enum: open | acknowledged | resolved"
+      }
+    ]
+  }
+}
+```
+
+### 9.4 `ix_tree_rebuild`
+
+Trigger selective re-summarization.
+
+```json
+{
+  "input": {
+    "workspace": "string",
+    "scope": "string enum: stale | subtree | full",
+    "root_id": "string (required if scope=subtree)",
+    "max_cost_usd": "number (optional, default 5.00)",
+    "dry_run": "boolean (optional, default false)"
+  },
+  "output": {
+    "rebuilt_count": "integer",
+    "skipped_count": "integer",
+    "cost_usd_estimated": "number",
+    "cost_usd_actual": "number (omitted on dry_run)",
+    "stopped_reason": "string enum: complete | cost_cap | error"
+  }
+}
+```
+
+---
+
+## 10. Out of Scope for v1
+
+Captured here so they're not silently re-litigated in Phase 1.
+
+- **Source-line-accurate test coverage mapping.** The schema reserves `cross_refs` for code↔test edges, but populating them from `cargo-llvm-cov` source-line data is a separate workstream. Phase 1 emits coverage cross-refs at file granularity only.
+- **UI rendering.** The zoom UX lives in ga (separate PR). This contract owns the data shape; the renderer is downstream.
+- **Cross-repo trees.** v1 is single-workspace. Federation (one tree spanning ix + ga + tars + Demerzel) requires resolving repo-relative paths across siblings and likely a dedicated cross-repo node kind. Deferred.
+- **Auto-update of `kept` contracts.** When `contract_invariants` evolves, the operator must reconcile manually. Auto-derivation from the L0 layer is interesting but moves the contract from "human-readable" toward "LLM-readable" and is not free.
+- **Translation / multilingual summaries.** Per `feedback_french_docs.md` and `user_french.md`, the workspace cares about French. v1 stores English summaries only; a `lang` field is a candidate v2 addition.
+
+---
+
+## 11. Validation Plan
+
+A one-week proof-of-concept against `ix-code` (specifically its `catalog.rs` module — small, meta, hand-verifiable). See `docs/plans/2026-05-24-traceability-tree-validation-plan.md` for the day-by-day breakdown.
+
+Success criteria (operator-visible):
+
+- Clean L0–L3 build on the `ix-code` crate with < 2 % staleness false positives over 10 random file edits.
+- Zoom UX (MCP only, no UI) answers 5 representative queries correctly (e.g., "what invariants does `ix-code::analyze` promise?" → returns the L3 node with `kept` covering the relevant `@ai:invariant`s).
+- Total LLM cost for the full one-week PoC < USD 50.
+- Drift alarm fires on at least one synthetic regression where a child's invariant is silently dropped.
+
+Failure on any single criterion is a go-back-to-the-drawing-board signal, not a soft regress.
+
+---
+
+## 12. Open Questions
+
+Surfaced rather than papered over. Phase 1 must resolve these before locking.
+
+1. **Multi-language workspaces.** ix is Rust; ga is C# + TypeScript + React; tars is F#. A workspace-rooted tree spanning all three has to handle three symbol-extraction toolchains. v1 assumes single-language per workspace. Is that sustainable, or do we need a per-language adapter trait in Phase 1?
+2. **L4+ rebuild cadence.** Cron vs on-demand vs hybrid. Cron risks expensive rebuilds when no one will read the result; on-demand risks stale roots when an operator zooms in cold. Phase 1 will probably start on-demand-only and add cron later, but the right answer depends on usage telemetry.
+3. **Contract versioning.** When the schema itself evolves (v1 → v2), every existing tree's `schema_version: 1` either gets migrated or pinned. Which? Lock-and-migrate is safer; lock-and-pin is cheaper. The `ai-annotation` contract took lock-and-migrate; should this one match?
+4. **`cross_refs` type system.** v1 leaves edge types implicit (the kinds at both ends imply the type). Phase 1 may need an explicit `edge_kind` enum for the `task ↔ test`, `code ↔ doc`, `demo ↔ post_mortem` cases to make MCP queries tractable.
+5. **Fidelity self-report calibration.** `fidelity: number` is currently free-form. Is "0.8" comparable across summarizers? Probably not without a calibration pass. Either drop the field or define a rubric in Phase 1.
+6. **Algedonic channel integration.** Drift alarms (Section 6.3) feel like they want to flow into the Demerzel algedonic-channel substrate once that contract lands. Wait for it, or define our own channel and migrate later?
+7. **Backlog parser ownership.** The BACKLOG.md → tree producer naturally lives in ga (where the parser already is). But the schema lives in ix. Phase 1 needs a clear ownership boundary — likely: ga emits node JSON conforming to this schema; ix consumes and aggregates.
+
+---
+
+## 13. Phase Plan (this contract = Phase 0)
+
+- **Phase 0 (this PR):** schema + contract + validation plan.
+- **Phase 1:** `ix-traceability-tree` crate scaffold; L0–L3 builder; cost telemetry; one-week PoC against `ix-code`.
+- **Phase 2:** L4–L6 builder; drift alarm wired to `state/quality/traceability-drift.jsonl`.
+- **Phase 3:** MCP surface (`ix_tree_query`, `ix_tree_zoom`, `ix_tree_drift`, `ix_tree_rebuild`).
+- **Phase 4:** ga BACKLOG.md producer emits compliant node JSON; ix consumes.
+- **Phase 5:** ga dashboard zoom UI.
+- **Phase 6:** Cross-repo federation; contract freeze at end of Phase 6.
+
+---
+
+## 14. Versioning
+
+The contract is `v0.1.0` (draft). Per the ix cross-repo contracts pattern, schema_version bumps are reserved for breaking field rename / removal. New optional fields are additive. Freeze milestone: end of Phase 6 (full pipeline shipped + ≥ 3 weeks of drift-alarm telemetry showing < 1 false-positive-per-day on the ix workspace).

--- a/docs/contracts/traceability-tree.schema.json
+++ b/docs/contracts/traceability-tree.schema.json
@@ -1,0 +1,136 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ix/contracts/traceability-tree-v1.json",
+  "title": "Traceability Tree Node",
+  "description": "A single node in a hierarchical Merkle-style summary tree over a codebase plus dev-process artifacts. Supports semantic zoom-in / zoom-out with explicit kept/dropped manifests so compression is lossy at the level but lossless from the root. See docs/contracts/2026-05-24-traceability-tree.contract.md for the full contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "schema_version", "level", "kind", "summary", "provenance"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^blake3:[a-f0-9]{64}$",
+      "description": "Stable content-addressed hash. Computed as blake3 over canonical(summary || kind || level || provenance.source_path || sorted(children)). Determines node identity across rebuilds."
+    },
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Bumped only on breaking field rename or removal. New optional fields are additive without a bump."
+    },
+    "level": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 6,
+      "description": "0 (raw leaf) to 6 (epic). See contract section 4 for per-level semantics and compression targets. A node MUST NOT have children whose level is strictly greater than its own, nor more than two below."
+    },
+    "kind": {
+      "type": "string",
+      "enum": [
+        "epic",
+        "story",
+        "task",
+        "subsystem",
+        "module",
+        "file",
+        "symbol",
+        "test_unit",
+        "test_integration",
+        "test_plan",
+        "qa_session",
+        "demo",
+        "post_mortem"
+      ],
+      "description": "Semantic kind. Superset of ga BACKLOG.md parser kinds (BacklogEpic / EpicSubSection / BacklogItem) so a BACKLOG entry maps to a node with no schema bending. Extended to cover code (module / file / symbol), tests (test_unit / test_integration / test_plan), and process artifacts (qa_session / demo / post_mortem)."
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Markdown body. MUST be self-contained at this level - readable without consulting the children. The wavelet's coarse approximation at this resolution."
+    },
+    "children": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^blake3:[a-f0-9]{64}$" },
+      "description": "Ordered list of child node ids. Empty for leaves. Order is significant for the canonical hash."
+    },
+    "parent": {
+      "type": ["string", "null"],
+      "pattern": "^blake3:[a-f0-9]{64}$",
+      "description": "Parent node id, or null for root. Trees are forests-of-one in v1."
+    },
+    "cross_refs": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^blake3:[a-f0-9]{64}$" },
+      "description": "Non-tree edges to nodes in the same workspace. Examples: task to test_unit (proof-of-implementation), file to post_mortem (root cause site), demo to story (delivers). Edge type is implicit from the kinds at both ends in v1; an explicit edge_kind enum is a candidate v2 addition."
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_path"],
+      "properties": {
+        "source_path": {
+          "type": "string",
+          "description": "Repo-relative path. For aggregate nodes (L2+), the directory or section path the aggregate covers."
+        },
+        "source_line_range": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 1 },
+          "minItems": 2,
+          "maxItems": 2,
+          "description": "[start_line, end_line] inclusive. Only meaningful for leaf nodes that point at a specific span."
+        },
+        "source_mtime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Filesystem mtime of source_path at summarization time. Feeds the drift detector - a newer mtime than source_mtime is the first signal that re-summarization may be needed."
+        },
+        "summarizer_model": {
+          "type": "string",
+          "description": "Model and date used to produce summary. Example: claude-opus-4-7@2026-05-24. A model swap shows up as drift and forces re-summarization."
+        },
+        "summarized_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO-8601 timestamp of the summarization LLM call. Absent for L0 (raw) nodes."
+        }
+      }
+    },
+    "fidelity": {
+      "type": "number",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "description": "0.0 (lost everything) to 1.0 (lossless at this level). Self-report from the summarizer. Soft signal, not load-bearing in v1. Leaves are 1.0 by definition. Calibration across summarizers is an open question - see contract section 12."
+    },
+    "kept": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Explicit list of facts preserved at this level. Each entry is a short string the reader can take to the bank. AI annotations (@ai:invariant, @ai:contract) MUST be promoted from descendants into this list - they are the wavelet's low-frequency coefficients and survive every zoom-out. The reconciler enforces this structurally."
+    },
+    "dropped": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Explicit list of facts compressed away at this level. Each entry MUST be drilled-down-reachable - the reader can follow children until a descendant's summary covers that fact in full. Nothing disappears - lossy at the level, lossless from the root."
+    },
+    "stale": {
+      "type": "boolean",
+      "default": false,
+      "description": "Set by the sync engine when the underlying children have changed but this node has not yet been re-summarized. Triggers Phase-1 selective re-summarization."
+    },
+    "stale_reason": {
+      "type": ["string", "null"],
+      "description": "Free-text explanation: which child diverged, by what hash delta, when. Surfaced to the operator via ix_tree_drift."
+    },
+    "ai_claims": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^sha256:[a-f0-9]{64}$"
+      },
+      "description": "References to @ai: annotation ids (per docs/contracts/ai-annotation.schema.json) that live in the subtree rooted here. Promoted upward by the build. The annotation contract owns the leaf format; the traceability tree is the index over the annotation corpus."
+    },
+    "contract_invariants": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Free-text invariants this node guarantees to its parent. The parent's kept array MUST include every entry here. A divergence triggers a drift alarm (algedonic signal) routed to state/quality/traceability-drift.jsonl."
+    }
+  }
+}

--- a/docs/plans/2026-05-24-traceability-tree-validation-plan.md
+++ b/docs/plans/2026-05-24-traceability-tree-validation-plan.md
@@ -1,0 +1,113 @@
+---
+date: 2026-05-24
+reversibility: two-way door (PoC scope; no schema freeze, no public-API commitment, no production data path)
+revisit-trigger: PoC LLM cost projection > USD 50 per workspace-rebuild; OR drift-alarm false-positive rate > 2 % over 10 controlled edits; OR schema field churn during Phase 1 build exceeds 3 changes
+status: design — depends on `docs/contracts/2026-05-24-traceability-tree.contract.md` (this PR)
+governance: out-of-scope for this PR; Phase-1 implementation will run `ix_governance_check` against Demerzel constitution before shipping
+---
+
+# Traceability Tree — One-Week Proof-of-Concept Validation Plan
+
+## Why this plan exists
+
+The contract in `docs/contracts/2026-05-24-traceability-tree.contract.md` is a hypothesis: that a Merkle-style summary tree with a `kept`/`dropped` manifest is the right shape for the workspace's traceability problem. A one-week PoC against a deliberately small target proves or refutes the hypothesis cheaply, before we commit to the six-phase roadmap. Karpathy R4 (goal-driven execution) applied to a contract: turn the schema into verifiable success criteria; loop until each holds.
+
+## Target
+
+The `catalog` module of the `ix-code` crate (`crates/ix-code/src/catalog.rs` and any L1/L2 neighbors needed to ground the build):
+
+- **Small enough to walk by hand.** ~300 lines of curated data plus query helpers; the operator can verify an L2 summary against the source in under five minutes.
+- **Meta.** The module is itself a catalog of code-analysis tools, which is conceptually adjacent to what the traceability tree does — a useful test of self-description.
+- **Stable.** The module changes infrequently, which makes the staleness signal less noisy than picking a target under active development.
+- **Owned by ix.** No cross-repo handoff to coordinate during the PoC.
+
+Stretch target if Day 3 finishes early: extend to the whole `ix-code` crate (~12 files). Out-of-scope: the entire workspace, anything in ga, anything cross-repo.
+
+## Day-by-day breakdown
+
+### Day 1 — Schema settled; CLI scaffold
+
+- Merge this PR (contract + schema + plan).
+- `cargo new --lib crates/ix-traceability-tree`; wire into the workspace `Cargo.toml`; add `blake3`, `serde`, `serde_json`, `jsonschema` (validation), `chrono`, `clap` (CLI surface).
+- Implement the L0 ingestor: take the existing `ix-code` analysis output (file listing + symbol spans) and emit one L0 JSON-Schema-compliant node per symbol. No LLM yet.
+- `cargo test` proves the L0 nodes validate against `traceability-tree.schema.json`.
+- **Exit gate:** every L0 node round-trips through the schema validator without error; blake3 ids are deterministic across two builds.
+
+### Day 2 — L1 builder; caching; cost telemetry
+
+- L1 prompt template lives in `crates/ix-traceability-tree/prompts/l0-to-l1.md`. Shells out to `claude` CLI per leaf with `--max-cost 0.10` and the symbol's source span as input.
+- Cache: blake3 of (prompt-template-hash || symbol-source-hash) keyed against a local sled or json-file store. Cache hit skips the LLM call entirely.
+- Cost telemetry: every LLM call appends one JSONL line to `state/quality/traceability-cost.jsonl` (timestamp, model, input-tokens, output-tokens, USD-estimated). Sum is the operator-visible spend.
+- **Exit gate:** building L1 over `catalog.rs` costs less than USD 1.00 cold, less than USD 0.05 warm. Every L1 summary contains the symbol's `@ai:` annotations verbatim in its `kept` array.
+
+### Day 3 — L2 and L3 builders; Merkle chain
+
+- L2 prompt aggregates per-file L1 children into one file summary. L3 aggregates per-module L2 children. Templates in `prompts/l1-to-l2.md` and `prompts/l2-to-l3.md`.
+- Implement the canonical hash: `blake3(canonical(summary || kind || level || provenance.source_path || sorted(children)))`. The hash chain MUST be deterministic across builds with the same inputs.
+- Implement the `kept`/`dropped` promotion check: any `@ai:invariant` or `@ai:contract` in a child's `kept` that does not appear in the parent's `kept` is a build failure. Phase-1 enforcement, not a soft warning.
+- **Exit gate:** full L0–L3 build over the `ix-code::catalog` subtree completes; cold cost less than USD 5.00; structural check passes; every annotation is hoisted to L3.
+
+### Day 4 — Sync engine; selective re-summarization
+
+- Stale detection: on `cargo run --bin ix-tree -- check`, walk the tree, recompute every node's hash from its children, mark mismatches `stale: true` with a `stale_reason` populated.
+- Re-summarization: on `cargo run --bin ix-tree -- rebuild --stale-only`, re-summarize every `stale` node bottom-up.
+- Source-side change detection: use `ix-context::cache::hash_file_content` plus `ix-io::watcher` primitives (both already exist; no new general-purpose `ix-grothendieck-delta` crate required in Phase 1). The watcher emits change events; the cache hash confirms material change.
+- Drift alarm: when a re-summarized child's `kept` no longer covers an entry in the parent's `contract_invariants`, write one JSONL line to `state/quality/traceability-drift.jsonl` and surface to stderr.
+- **Exit gate:** on 10 controlled edits to `catalog.rs`, the stale-detection false-positive rate is below 2 %; at least one synthetic regression (delete an `@ai:invariant`) fires a drift alarm correctly.
+
+### Day 5 — `ix_tree_query` MCP surface; minimal ga consumer
+
+- Implement `ix_tree_query` against `ix-agent` per the contract's section 9.1. Input: free-text query + level / kind filters. Output: ranked matches with `path_from_root`.
+- Ranking in v1: substring match on `summary` + `kept` + `ai_claims`, weighted toward higher `kept` matches. No embedding model yet.
+- Minimal ga consumer: a 50-line PowerShell script that hits `ix_tree_query` over MCP and prints the result as plain JSON. No UI in this PoC — confirms the data path end-to-end.
+- **Exit gate:** 5 representative queries (see "Success criteria" below) return correct top-1 results.
+
+### Day 6 — Cost analysis; drift detection rigor
+
+- Run a controlled cost analysis: cold rebuild of the entire `ix-code` crate (not just `catalog.rs`), warm rebuild after no changes, warm rebuild after one localized change. Report each as USD and as fraction of the cold-rebuild cost.
+- Run the drift detector across 10 synthetic regressions (each: delete one `@ai:invariant`, re-summarize, expect alarm; restore, expect alarm clears). Measure true-positive rate, false-positive rate, latency between source edit and alarm.
+- **Exit gate:** cold rebuild of `ix-code` < USD 15.00; warm-no-change rebuild < USD 0.10; drift detector at 100 % true-positive rate, less than 10 % false-positive rate.
+
+### Day 7 — Writeup; go / no-go
+
+- One markdown writeup in `docs/solutions/traceability-tree/2026-05-31-poc-writeup.md` covering: what worked, what broke, total LLM spend, where the schema bent under reality, and a recommendation: GO (proceed to Phase 1 build), HOLD (schema needs revision; recycle), or NO-GO (the wavelet model is not the right shape; rethink).
+- Update the contract's section 12 (Open Questions) with the resolutions PoC produced.
+- File the writeup under `state/digests/` as well so the next session's `sessionstart-digest.sh` hook picks it up.
+
+## Explicit success criteria
+
+Operator-visible. Failure on any one is a no-go signal, not a soft regress.
+
+1. **Schema validates the build.** Every node emitted by Days 1–4 passes `traceability-tree.schema.json` under Ajv 2020 (or equivalent).
+2. **Clean L0–L3 build on `ix-code`.** All four levels populated, no orphan nodes, no broken `parent`/`children` references.
+3. **Staleness false-positive rate below 2 %** over 10 controlled file edits (edit non-load-bearing whitespace, expect no stale; edit load-bearing logic, expect stale).
+4. **Five representative queries answer correctly.** Defined for Day 5:
+   - "What invariants does `ix-code::catalog::all` promise?" → top-1 hit is the L2 node for `catalog.rs` with the invariants in `kept`.
+   - "Which tools in the catalog cover Rust?" → top-1 hit is the L1 node for `by_language`.
+   - "Show me the module summary for `ix-code::catalog`." → top-1 hit is the L3 module node.
+   - "What `@ai:contract` claims live under `ix-code`?" → returns all ancestors whose `ai_claims` include `@ai:contract`-typed annotations.
+   - "Are there any drift alarms open on the catalog subtree?" → returns the open alarms from `traceability-drift.jsonl`, or an empty list if none.
+5. **Drift detector fires on at least one synthetic regression** where a child's `@ai:invariant` is deleted and the parent's `contract_invariants` is silently violated.
+6. **Total LLM spend less than USD 50.00** across the full week. Per-build costs surface in `state/quality/traceability-cost.jsonl` and are summable by `jq`.
+
+## Out of scope for the PoC
+
+- UI rendering (lives in ga, separate PR after Phase 5).
+- Cross-repo trees (single workspace for the PoC; federation deferred to Phase 6).
+- Source-line-accurate test coverage cross-refs (Phase 1 uses file-granularity only).
+- Local-model substitution for `claude` CLI (investigate after the cost telemetry is in hand).
+- Embedding-based query ranking (substring matching is enough for the 5 test queries; embeddings come with Phase 3 MCP polish).
+
+## Open risks
+
+Captured here so they don't surprise us mid-week.
+
+- **`claude` CLI rate-limiting on cold rebuild.** Mitigation: throttle the L0→L1 batch to one call per second; if it blocks the cold build under 30 minutes, look at the `--max-cost` cap rather than parallelism.
+- **`ix-code` analysis output not symbol-accurate enough for L0.** Mitigation: fall back to a regex-based symbol splitter for the PoC; do not block on a richer parser.
+- **`@ai:` annotation extractor (PR #54) not yet merged on main.** Mitigation: cherry-pick or vendor the extractor binary for the PoC; do not block on the PR landing first.
+- **Hash determinism across platforms.** Mitigation: pin blake3 version; canonicalize JSON via `serde_json::to_string_pretty` with a sorted-keys helper; add a Linux + Windows CI smoke test on the determinism property before Day 4.
+- **Cache invalidation on prompt-template edits.** Mitigation: include the prompt-template-hash in every cache key from Day 2. Tested by editing the L1 prompt and confirming a full rebuild.
+
+## Phase gate
+
+If Days 1–7 all pass their exit gates and the success criteria above hold, the PoC is GO and Phase 1 proceeds: full `ix-traceability-tree` build over the entire ix workspace, drift telemetry surfaced to the ga dashboard, and the `ix_tree_query` MCP tool promoted from PoC to stable. If any exit gate fails, the writeup names the failure and either schedules a revision (HOLD) or kills the line (NO-GO).


### PR DESCRIPTION
## Summary

Doc-only PR. Defines the v0.1.0 draft contract for a hierarchical Merkle-style summary tree over codebase + dev-process artifacts that supports semantic zoom-in / zoom-out (the wavelet mental model) while preserving signal across compression levels.

No implementation code in this PR. The contract is the durable artifact that the next session's `ix-traceability-tree` crate will implement against.

## Files

- `docs/contracts/2026-05-24-traceability-tree.contract.md` — full contract (Sections 1–14): purpose, wavelet/Merkle/GraphRAG mental model, 7-level semantics (L0 raw to L6 epic), signal-preservation contract via `kept`/`dropped`, 3-layer sync protocol (Merkle hash propagation → selective re-summarization → drift alarm), LLM orchestration (`claude` CLI v1; `async-anthropic` / Hari-MCP-cache future), cross-references to `@ai:` annotations + BACKLOG.md parser + `ix-bracelet::grothendieck_delta` + `ix-category` + `ix-graph`, four MCP tool specs (`ix_tree_query` / `ix_tree_zoom` / `ix_tree_drift` / `ix_tree_rebuild`), out-of-scope-for-v1, validation plan, 7 open questions, phase plan.
- `docs/contracts/traceability-tree.schema.json` — JSON Schema draft 2020-12. `additionalProperties: false`. 13-kind enum that is a superset of ga's `BacklogEpic` / `EpicSubSection` / `BacklogItem`. blake3-hash ids, level 0..=6, `kept`/`dropped` arrays, `ai_claims` cross-reference to `ai-annotation.schema.json`.
- `docs/plans/2026-05-24-traceability-tree-validation-plan.md` — one-week PoC against `ix-code::catalog`. Day-by-day breakdown with explicit exit gates. Six binary success criteria. Total budget cap USD 50.

## Key novel idea — the `kept` / `dropped` manifest

The load-bearing trick is making compression auditable. A naive recursive summary loses information silently — a reader at L4 sees a polished paragraph and has no way to know that "thread-safety of `Foo::bar` under MIRI" was dropped two levels below.

This contract forbids that. Every summary above L0 carries:

- an explicit `kept` array of facts preserved at this level (each entry is a short string the reader can take to the bank), and
- an explicit `dropped` array of facts compressed away (each entry must be drilled-down-reachable — the reader follows `children` until a descendant's `summary` covers that fact in full).

`@ai:invariant` and `@ai:contract` annotations from PR #54 are pinned: every annotation at any leaf is hoisted into every ancestor's `kept` list, verbatim or as a one-line rephrase that preserves the truth-value tag. They are the *low-frequency coefficients* of the wavelet decomposition and survive every zoom-out.

Result: lossy at the level, lossless from the root. A fact named in any descendant's `kept` is named in every ancestor's `kept`. A fact in `dropped` at level N is reachable in `summary` or `kept` at some level < N. Nothing disappears. The reconciler (Phase 1) enforces this structurally — a summarizer that drops an annotation without recording it explicitly is a build failure, not a soft warning.

## Open questions surfaced (not papered over)

Listed in contract Section 12; Phase 1 must resolve before locking. The seven not-yet-resolved ones:

1. Multi-language workspaces (Rust + TS + C# + F#) — per-language adapter trait, or single-language-per-workspace?
2. L4+ rebuild cadence — cron vs on-demand vs hybrid?
3. Schema versioning — lock-and-migrate (`ai-annotation`'s pattern) or lock-and-pin?
4. `cross_refs` edge typing — implicit-from-kinds or explicit `edge_kind` enum?
5. `fidelity: number` calibration — is "0.8" comparable across summarizers, or does the field need a rubric (or to be dropped)?
6. Algedonic channel integration — wait for the Demerzel algedonic-channel substrate or build our own and migrate?
7. BACKLOG parser ownership — ga emits node JSON (likely) but the schema lives in ix; Phase 1 needs an explicit ownership boundary.

## Verification done

- Schema compiles under Ajv 8 + ajv-formats with draft 2020-12 spec.
- Hand-built sample L3 node (for `ix-code::catalog`) validates against the schema.
- Cross-reference to `ai-annotation.schema.json` (PR #54) verified against the actual file on `feat/ai-annotations-phase-0-extract`.
- `ix-bracelet::grothendieck_delta` cited correctly (the existing music-PC-set Z⁶ delta; the general code-content delta crate referenced in CLAUDE.md does not yet exist, and the contract reflects this honestly — uses `ix-context::cache` + `ix-io::watcher` as the actual change-detection primitives for Phase 1).
- No touches to `CLAUDE.md` / `AGENTS.md` / `governance/*` / `.github/workflows/`.

## Test plan

- [ ] Reviewer confirms contract style matches `2026-05-24-ai-annotation.contract.md` (the other v0.1.x draft just shipped this session).
- [ ] Reviewer confirms `kept`/`dropped` invariant is well-defined enough to be enforceable by the Phase-1 reconciler.
- [ ] Reviewer signs off on the seven open questions as genuinely unresolved (not under-thought).
- [ ] Phase 1 PR (separate, follows this merge) brings up the `ix-traceability-tree` crate against this contract.