### PR TITLE
feat(ai-annotations): @ai:business-value + @ai:hot-path kinds (schema v2)

### DIFF
--- a/crates/ix-ai-annotations/src/parser.rs
+++ b/crates/ix-ai-annotations/src/parser.rs
@@ -223,4 +223,35 @@ mod tests {
         let m = parse_line(line).expect("parses");
         assert_eq!(m.truth_value, TruthValue::C);
     }
+
+    // --- schema v2 additive kinds ---
+
+    #[test]
+    fn business_value_kind_parses() {
+        let line = "// @ai:business-value core chord-recognition pipeline drives all voicing search [T:manually-reviewed conf:0.95 src:product-owner@2026-05-24]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::BusinessValue);
+        assert_eq!(m.truth_value, TruthValue::T);
+        assert_eq!(m.certainty, Certainty::ManuallyReviewed);
+        assert_eq!(m.confidence, Some(0.95));
+        assert_eq!(m.evidence.as_deref(), Some("product-owner@2026-05-24"));
+    }
+
+    #[test]
+    fn hot_path_kind_parses() {
+        let line = "// @ai:hot-path 92% of /api/chord calls hit this method [T:test conf:0.99 src:https://grafana.example/d/abc]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::HotPath);
+        assert_eq!(m.truth_value, TruthValue::T);
+        assert_eq!(m.certainty, Certainty::Test);
+        assert_eq!(m.evidence.as_deref(), Some("https://grafana.example/d/abc"));
+    }
+
+    #[test]
+    fn business_value_python_hash_marker() {
+        let line = "# @ai:business-value primary user onboarding entry point [P:assumed conf:0.8]";
+        let m = parse_line(line).expect("parses");
+        assert_eq!(m.kind, AnnotationKind::BusinessValue);
+        assert_eq!(m.truth_value, TruthValue::P);
+    }
 }

--- a/crates/ix-ai-annotations/src/types.rs
+++ b/crates/ix-ai-annotations/src/types.rs
@@ -5,7 +5,11 @@
 use serde::{Deserialize, Serialize};
 
 /// Schema version pinned by the contract.
-pub const SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (2026-05-24): additive `business-value` and `hot-path` kinds for the
+/// value × complexity quadrant heatmap. No field removals — v1 readers are
+/// expected to drop unknown kinds rather than error.
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Hexavalent truth value, aligned with
 /// `governance/demerzel/schemas/hexavalent-distribution.schema.json`.
@@ -88,6 +92,15 @@ pub enum AnnotationKind {
     Smell,
     Decision,
     Hint,
+    /// Operator-declared assertion that this code drives meaningful product
+    /// value. Carries a free-text rationale + optional metric. Source author
+    /// should be `human` or `product-owner`; rarely auto-detected. Introduced
+    /// in schema v2 (2026-05-24) for the value × complexity quadrant heatmap.
+    BusinessValue,
+    /// Measured-traffic assertion. Source should be `telemetry` or similar
+    /// with a metric reference (e.g., Grafana panel URL). Introduced in
+    /// schema v2 (2026-05-24).
+    HotPath,
 }
 
 impl AnnotationKind {
@@ -100,6 +113,8 @@ impl AnnotationKind {
             "smell" => Some(Self::Smell),
             "decision" => Some(Self::Decision),
             "hint" => Some(Self::Hint),
+            "business-value" => Some(Self::BusinessValue),
+            "hot-path" => Some(Self::HotPath),
             _ => None,
         }
     }
@@ -160,4 +175,119 @@ pub fn annotation_id(path: &str, line_start: u32, kind: AnnotationKind, claim: &
     let key = format!("{}:{}:{:?}:{}", path, line_start, kind, claim);
     let digest = Sha256::digest(key.as_bytes());
     format!("sha256:{:x}", digest)
+}
+
+#[cfg(test)]
+mod kind_serde_tests {
+    use super::*;
+
+    #[test]
+    fn business_value_round_trip_kebab_case() {
+        let kind = AnnotationKind::BusinessValue;
+        let json = serde_json::to_string(&kind).expect("ser ok");
+        assert_eq!(json, "\"business-value\"");
+        let back: AnnotationKind = serde_json::from_str(&json).expect("de ok");
+        assert_eq!(back, AnnotationKind::BusinessValue);
+    }
+
+    #[test]
+    fn hot_path_round_trip_kebab_case() {
+        let kind = AnnotationKind::HotPath;
+        let json = serde_json::to_string(&kind).expect("ser ok");
+        assert_eq!(json, "\"hot-path\"");
+        let back: AnnotationKind = serde_json::from_str(&json).expect("de ok");
+        assert_eq!(back, AnnotationKind::HotPath);
+    }
+
+    #[test]
+    fn all_v1_kinds_still_parse_in_v2() {
+        // Backward-compat: v1 readers wrote these strings; the v2 enum must
+        // still accept every one.
+        for s in [
+            "invariant",
+            "assumption",
+            "hypothesis",
+            "contract",
+            "smell",
+            "decision",
+            "hint",
+        ] {
+            let json = format!("\"{}\"", s);
+            let kind: AnnotationKind = serde_json::from_str(&json)
+                .unwrap_or_else(|e| panic!("v1 kind {} should parse: {}", s, e));
+            // Round-trips back to the same string.
+            let back = serde_json::to_string(&kind).unwrap();
+            assert_eq!(back, json);
+        }
+    }
+
+    #[test]
+    fn annotation_round_trip_with_business_value() {
+        let a = Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id("foo.rs", 12, AnnotationKind::BusinessValue, "core engine"),
+            kind: AnnotationKind::BusinessValue,
+            claim: "core engine".to_string(),
+            truth_value: TruthValue::T,
+            certainty: Certainty::ManuallyReviewed,
+            confidence: 0.95,
+            source: Source {
+                author: "product-owner".to_string(),
+                model: None,
+                evidence: Some("PR#123".to_string()),
+            },
+            location: Location {
+                path: "foo.rs".to_string(),
+                line_start: 12,
+                line_end: 12,
+            },
+            created_at: "2026-05-24T00:00:00Z".to_string(),
+            updated_at: "2026-05-24T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        };
+        let json = serde_json::to_string(&a).expect("ser ok");
+        assert!(json.contains("\"kind\":\"business-value\""));
+        assert!(json.contains("\"schema_version\":2"));
+        let back: Annotation = serde_json::from_str(&json).expect("de ok");
+        assert_eq!(back.kind, AnnotationKind::BusinessValue);
+        assert_eq!(back.schema_version, 2);
+    }
+
+    #[test]
+    fn backward_compat_v1_annotation_parses() {
+        // An existing v1 annotation (schema_version: 1, no new kinds) must
+        // still parse cleanly into the v2 struct.
+        let v1_json = r#"{
+            "schema_version": 1,
+            "id": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "kind": "invariant",
+            "claim": "arr is sorted ascending",
+            "truth_value": "T",
+            "certainty": "test",
+            "confidence": 0.95,
+            "source": { "author": "claude" },
+            "location": { "path": "foo.rs", "line_start": 1, "line_end": 1 },
+            "created_at": "2026-05-24T00:00:00Z",
+            "updated_at": "2026-05-24T00:00:00Z"
+        }"#;
+        let a: Annotation = serde_json::from_str(v1_json).expect("v1 parses into v2 struct");
+        assert_eq!(a.schema_version, 1);
+        assert_eq!(a.kind, AnnotationKind::Invariant);
+        assert!(!a.stale);
+        assert!(a.reconciliation.is_none());
+    }
+
+    #[test]
+    fn parse_kind_string_for_new_kinds() {
+        assert_eq!(
+            AnnotationKind::parse("business-value"),
+            Some(AnnotationKind::BusinessValue)
+        );
+        assert_eq!(
+            AnnotationKind::parse("hot-path"),
+            Some(AnnotationKind::HotPath)
+        );
+        assert_eq!(AnnotationKind::parse("nonsense"), None);
+    }
 }

--- a/crates/ix-ai-annotations/tests/extract_integration.rs
+++ b/crates/ix-ai-annotations/tests/extract_integration.rs
@@ -1,4 +1,4 @@
-use ix_ai_annotations::{extract_workspace, AnnotationKind, TruthValue};
+use ix_ai_annotations::{extract_workspace, AnnotationKind, TruthValue, SCHEMA_VERSION};
 use std::path::PathBuf;
 
 #[test]
@@ -46,7 +46,7 @@ fn fixture_dir_yields_expected_annotations() {
             "bad id: {}",
             a.id
         );
-        assert_eq!(a.schema_version, 1);
+        assert_eq!(a.schema_version, SCHEMA_VERSION);
     }
 }
 

--- a/docs/contracts/2026-05-24-ai-annotation.contract.md
+++ b/docs/contracts/2026-05-24-ai-annotation.contract.md
@@ -1,10 +1,10 @@
 # AI Source-Code Annotation — Cross-Repo Contract
 
-**Version:** 0.1.0 (draft, Phase 0)
-**Schema version:** 1
+**Version:** 0.2.0 (draft, Phase 0 — additive v2 kinds for value × complexity heatmap)
+**Schema version:** 2
 **Status:** Draft (Phase 0 of `ai-annotations` campaign, 2026-05-24)
-**Producers:** `ix-ai-annotations` extractor, ga PostToolUse hook `Scripts/ai-annotation-scan.ps1`, human authors
-**Consumers:** `ix-ai-annotations` reconciler, `ix_annotations_scan` MCP tool, ga dashboard `/dev-data/ai-annotations`, `grade-last-pr` skill, pre-merge gate
+**Producers:** `ix-ai-annotations` extractor, ga PostToolUse hook `Scripts/ai-annotation-scan.ps1`, human authors, product-owner declarations, telemetry pipelines
+**Consumers:** `ix-ai-annotations` reconciler, `ix_annotations_scan` MCP tool, ga dashboard `/dev-data/ai-annotations`, ga `ValueComplexityHeatmap`, `grade-last-pr` skill, pre-merge gate
 **Schema file:** `docs/contracts/ai-annotation.schema.json`
 
 ---
@@ -73,15 +73,19 @@ Field order inside the brackets is fixed: `T:certainty` first, then optional `co
 
 ## 3. Annotation Kinds (`kind`)
 
-| kind         | meaning                                                                 |
-|--------------|-------------------------------------------------------------------------|
-| `invariant`  | something that holds at this point and the surrounding code relies on it |
-| `assumption` | something the code assumes about its environment / caller / inputs       |
-| `hypothesis` | a guess to be verified; expect this to flip to T or F over time          |
-| `contract`   | an externally-visible pre/post-condition (lighter than a full ADR)       |
-| `smell`      | code-smell or suspicion; will likely be addressed                        |
-| `decision`   | a one-line ADR pointer (the "why" of nearby code)                        |
-| `hint`       | guidance for the next reader / agent (no truth claim, default `U`)       |
+| kind             | meaning                                                                 |
+|------------------|-------------------------------------------------------------------------|
+| `invariant`      | something that holds at this point and the surrounding code relies on it |
+| `assumption`     | something the code assumes about its environment / caller / inputs       |
+| `hypothesis`     | a guess to be verified; expect this to flip to T or F over time          |
+| `contract`       | an externally-visible pre/post-condition (lighter than a full ADR)       |
+| `smell`          | code-smell or suspicion; will likely be addressed                        |
+| `decision`       | a one-line ADR pointer (the "why" of nearby code)                        |
+| `hint`           | guidance for the next reader / agent (no truth claim, default `U`)       |
+| `business-value` | (v2) operator-declared assertion that this code drives meaningful product value. Carries a free-text rationale + optional metric reference in `src:`. `source.author` should be `human` or `product-owner`; rarely auto-detected. Typical truth value `T` or `P`, certainty `manually-reviewed` or `assumed`. |
+| `hot-path`       | (v2) measured-traffic assertion: this code path is hot in production. `source.author` should be `telemetry`; `src:` should reference the metric source (e.g., Grafana panel URL, OpenTelemetry trace id). Typical truth value `T`, certainty `test` or `manually-reviewed`. |
+
+The `business-value` × `smell` cross-product drives the dashboard's value × complexity 2×2 heatmap (REFACTOR FIRST / DELETE CANDIDATE / KEEP STABLE / MAINTENANCE BURDEN).
 
 ---
 
@@ -180,6 +184,11 @@ The extractor in Phase 0 writes a JSONL file at `state/quality/ai-annotations.js
 
 ## 10. Versioning
 
-The contract is `v0.1.0` (draft). Field shapes and the truth-value enum are stable from Phase 0 onward; we only bump `schema_version` when a field is renamed or removed. New optional fields are additive (no bump).
+The contract is `v0.2.0` (draft). Field shapes and the truth-value enum are stable from Phase 0 onward; we only bump `schema_version` when a field is renamed or removed, OR when the `kind` enum is widened (consumers must opt into the new kinds). New optional fields are additive (no bump).
+
+### Changelog
+
+- **v0.2.0 (2026-05-24, schema_version 2)** — additive: two new kinds (`business-value`, `hot-path`) and two new `source.author` values (`product-owner`, `telemetry`) for the operator-decision-priority surface (value × complexity 2×2 heatmap). v1 readers will see unknown-kind annotations they must drop; v2 readers consume both. No field removals.
+- **v0.1.0 (2026-05-24, schema_version 1)** — initial seven-kind contract (invariant / assumption / hypothesis / contract / smell / decision / hint).
 
 Freeze milestone: end of Phase 3 (full pipeline shipped + ≥ 50 annotations in the codebase actively reconciled).

--- a/docs/contracts/ai-annotation.schema.json
+++ b/docs/contracts/ai-annotation.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/GuitarAlchemist/ix/contracts/ai-annotation-v1.json",
+  "$id": "https://github.com/GuitarAlchemist/ix/contracts/ai-annotation-v2.json",
   "title": "AI Source-Code Annotation",
-  "description": "An in-source, line-local, agent-authored claim about code: an invariant, assumption, hypothesis, contract, smell, decision, or hint. Carries hexavalent truth value (T/P/U/D/F/C) and certainty marker. Aligned with governance/demerzel/schemas/hexavalent-distribution.schema.json.",
+  "description": "An in-source, line-local, agent-authored claim about code: an invariant, assumption, hypothesis, contract, smell, decision, hint, business-value, or hot-path. Carries hexavalent truth value (T/P/U/D/F/C) and certainty marker. Aligned with governance/demerzel/schemas/hexavalent-distribution.schema.json.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -19,7 +19,7 @@
     "updated_at"
   ],
   "properties": {
-    "schema_version": { "type": "integer", "const": 1 },
+    "schema_version": { "type": "integer", "enum": [1, 2] },
     "id": {
       "type": "string",
       "pattern": "^sha256:[a-f0-9]{64}$",
@@ -27,7 +27,7 @@
     },
     "kind": {
       "type": "string",
-      "enum": ["invariant", "assumption", "hypothesis", "contract", "smell", "decision", "hint"]
+      "enum": ["invariant", "assumption", "hypothesis", "contract", "smell", "decision", "hint", "business-value", "hot-path"]
     },
     "claim": {
       "type": "string",
@@ -66,7 +66,7 @@
       "properties": {
         "author": {
           "type": "string",
-          "enum": ["claude", "codex", "gemini", "junie", "auggie", "human", "auto"]
+          "enum": ["claude", "codex", "gemini", "junie", "auggie", "human", "auto", "product-owner", "telemetry"]
         },
         "model": {
           "type": "string",


### PR DESCRIPTION
## Summary

Adds two additive `AnnotationKind` variants for the **operator-decision-priority surface** (value × complexity quadrant heatmap on the ga dashboard):

- **`business-value`** — operator-declared assertion that this code drives meaningful product value. Carries free-text rationale + optional metric reference. Typical `source.author`: `human` or `product-owner`; rarely auto-detected.
- **`hot-path`** — measured-traffic assertion: this code path is hot in production. Typical `source.author`: `telemetry` with a metric reference (Grafana panel URL, OpenTelemetry trace id).

These compose with the existing `@ai:smell` kind (which sentrux's annotation bridge will auto-emit) to drive the dashboard's 2×2 heatmap:

| | low complexity | high complexity |
|---|---|---|
| **high value** | KEEP STABLE | **REFACTOR FIRST** |
| **low value**  | MAINTENANCE BURDEN | DELETE CANDIDATE |

## Schema bump

- `SCHEMA_VERSION` 1 → **2** (additive: v1 readers drop unknown kinds; v1 annotation JSONL still parses cleanly into v2 structs).
- `docs/contracts/ai-annotation.schema.json`: `kind` enum widened, `schema_version` enum now `{1, 2}`, `source.author` gains `product-owner` and `telemetry`.
- `docs/contracts/2026-05-24-ai-annotation.contract.md`: changelog section appended (v0.2.0 entry), kinds table extended with descriptions of the two new kinds.

## Test plan

- [x] `cargo test -p ix-ai-annotations` — 19 unit + 3 integration, all green
- [x] `cargo clippy -p ix-ai-annotations --all-targets --all-features -- -D warnings` clean
- [x] Round-trip kebab-case ser/de for `BusinessValue` (`"business-value"`) and `HotPath` (`"hot-path"`)
- [x] Backward-compat test: a v1 annotation JSON parses into the v2 struct unchanged
- [x] All seven v1 kinds still round-trip via `serde_json`
- [x] Parser tests for `// @ai:business-value ... [T:manually-reviewed ...]` and `// @ai:hot-path ... [T:test src:https://...]`

## Coordination

Composes cleanly with the in-flight sentrux-annotations bridge (worktree at `C:/tmp/ix-sentrux-annotations-bridge`): that PR consumes the existing `Smell` variant; this PR widens the enum additively. Bridge PR was not yet open at push time; if it lands first, this PR rebases trivially (different lines).

Followup: ga PR (`feat/value-complexity-heatmap`) ships the `ValueComplexityHeatmap.tsx` 2×2 component + seeds 5-10 high-value files with `@ai:business-value` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)