### PR TITLE
feat(ix-assumption-graph): autonomous belief-revision loop + research ingest

### DIFF
--- a/.claude/skills/assumption-graph-loop/SKILL.md
+++ b/.claude/skills/assumption-graph-loop/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assumption-graph-loop
+description: Autonomous belief-revision loop — fuse @ai: annotations + /deep-research claims into the temporal assumption graph and revise the persistent belief log over time
+---
+
+# Assumption-Graph Loop
+
+One turn of the longitudinal belief loop for the temporal assumption graph
+(`crates/ix-assumption-graph`, contract `docs/contracts/2026-05-31-assumption-graph.contract.md`):
+
+```
+@ai: annotations ─┐
+                  ├─► fuse (ix-fuzzy, Belnap C synthesis) ─► revise ─► belief-events.jsonl
+research claims ──┘        cross-source only                 (append on verdict change)
+```
+
+It ingests the workspace's `@ai:` annotations plus any research-domain claims,
+fuses each claim's evidence, and appends a `BeliefEvent` for every claim whose
+verdict changed since the last run. Re-running on unchanged evidence is a no-op
+— so it is safe to schedule.
+
+## When to Use
+
+- On a schedule (daily / weekly), to keep the belief log current as code and
+  research evolve — the "semantic story over a long period".
+- After a `/deep-research` run, to fold its verified findings into the graph and
+  detect where new evidence contradicts a standing assumption.
+- Before a review, to surface `escalated` (Contradictory) claims.
+
+## Run It
+
+```bash
+cargo run -p ix-assumption-graph --bin ix-assumption-graph-loop -- \
+  --workspace .                                   \
+  --research state/assumptions/research-claims.json   \  # optional
+  --log     state/assumptions/belief-events.jsonl     \
+  --trigger deep-research-reverify
+```
+
+Defaults: `--workspace .`, `--log state/assumptions/belief-events.jsonl`,
+`--trigger loop`, no research file. The log is created (with parent dirs) if
+absent. Output reports node count, total/appended belief events, and each flip
+(`T -> C`, etc.).
+
+## The `research-claims.json` shape
+
+A JSON array. The **truth-value judgment** — mapping a verified finding to a
+hexavalent value — is the adapter's responsibility, NOT the crate's, so this
+file is the seam between `/deep-research`'s output and the graph:
+
+```json
+[
+  {
+    "claim": "p99 latency under 5ms",
+    "truth_value": "F",
+    "confidence": 0.85,
+    "source": "deep-research",
+    "evidence": "arxiv:2510.11822"
+  }
+]
+```
+
+- `truth_value`: one of `T P U D F C` (hexavalent).
+- `confidence`: `0.0`–`1.0`.
+- `source` (optional, default `"deep-research"`): the **independence class**.
+  Distinct sources are what let fusion synthesize a contradiction — give
+  genuinely independent runs distinct source labels; do NOT relabel correlated
+  re-runs as independent (contract §7.1 — over-counting).
+- `evidence` (optional): a confirmed-real citation.
+
+## Converting a `/deep-research` run → `research-claims.json`
+
+`/deep-research` returns `result.findings[]` (with `claim`, `confidence`
+high/medium/low, `vote`, `sources`) and `result.refuted[]`. Suggested mapping:
+
+| deep-research | truth_value | confidence |
+|---|---|---|
+| confirmed finding, confidence high | `T` | 0.85–0.95 |
+| confirmed finding, confidence medium | `P` | 0.6–0.75 |
+| confirmed finding, confidence low | `U` | ~0.4 |
+| `refuted[]` entry | `F` | by vote margin |
+
+**Fail-closed (contract §7.2):** a multi-judge panel confirms well but catches
+invalidity poorly (~96% TPR / <25% TNR). Treat panel agreement as a gate to
+*promote*, and let any credible dissent push to `U`/`D`/`C` — never relabel
+correlated judges as independent sources. Verify every cited source resolves
+before writing it as `evidence` (deep-research has hallucinated arXiv ids).
+
+## Scheduling
+
+Wrap the command in your scheduled-runner of choice (cron, the
+`octo:schedule` skill, or a `state/`-driven local runner like the adversarial-qa
+runner). Commit `state/assumptions/belief-events.jsonl` if you want the belief
+story versioned; otherwise treat it as regenerable local state.
+
+## What it does NOT do
+
+- It does not invoke `/deep-research` itself — produce `research-claims.json`
+  first (a `/deep-research` run + the mapping above), then run the loop.
+- It does not run tests to verify code assumptions — feed test outcomes as
+  additional `@ai:` annotation reconciliation or research claims.

--- a/crates/ix-assumption-graph/Cargo.toml
+++ b/crates/ix-assumption-graph/Cargo.toml
@@ -26,3 +26,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "ix-assumption-graph-report"
 path = "src/bin/report.rs"
+
+[[bin]]
+name = "ix-assumption-graph-loop"
+path = "src/bin/loop_runner.rs"

--- a/crates/ix-assumption-graph/src/bin/loop_runner.rs
+++ b/crates/ix-assumption-graph/src/bin/loop_runner.rs
@@ -1,0 +1,98 @@
+//! Autonomous-loop runner — one turn of the longitudinal belief loop.
+//!
+//! Ingests the workspace's `@ai:` annotations plus (optionally) research claims
+//! from a JSON file, loads the persistent belief log, calls
+//! [`ix_assumption_graph::AssumptionGraph::revise`], and writes the log back.
+//! Scheduling this on an interval (and producing the research-claims file from a
+//! `/deep-research` run) is the `assumption-graph-loop` skill's job.
+//!
+//! ```text
+//! ix-assumption-graph-loop [--workspace DIR] [--research FILE.json]
+//!     [--log FILE.jsonl] [--trigger LABEL]
+//! ```
+//! Defaults: workspace `.`, log `state/assumptions/belief-events.jsonl`,
+//! trigger `loop`.
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use chrono::Utc;
+use ix_assumption_graph::{AssumptionGraph, BeliefLog, ResearchClaim};
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut workspace = ".".to_string();
+    let mut research_path: Option<String> = None;
+    let mut log_path = "state/assumptions/belief-events.jsonl".to_string();
+    let mut trigger = "loop".to_string();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--workspace" => workspace = next(&args, &mut i)?,
+            "--research" => research_path = Some(next(&args, &mut i)?),
+            "--log" => log_path = next(&args, &mut i)?,
+            "--trigger" => trigger = next(&args, &mut i)?,
+            "-h" | "--help" => {
+                println!("ix-assumption-graph-loop [--workspace DIR] [--research FILE.json] [--log FILE.jsonl] [--trigger LABEL]");
+                return Ok(());
+            }
+            other => return Err(format!("unknown argument: {other}").into()),
+        }
+        i += 1;
+    }
+
+    let research: Vec<ResearchClaim> = match &research_path {
+        Some(p) => serde_json::from_str(&fs::read_to_string(p)?)?,
+        None => Vec::new(),
+    };
+
+    let graph = AssumptionGraph::from_workspace_with_research(Path::new(&workspace), research)?;
+
+    let mut log = match fs::read_to_string(&log_path) {
+        Ok(s) => BeliefLog::from_jsonl(&s)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => BeliefLog::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let appended = graph.revise(&mut log, Utc::now(), &trigger)?;
+
+    if let Some(parent) = Path::new(&log_path).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    fs::write(&log_path, log.to_jsonl())?;
+
+    println!("assumption-graph loop ({trigger})");
+    println!("  nodes:          {}", graph.node_count());
+    println!(
+        "  belief events:  {} (+{} this run)",
+        log.len(),
+        appended.len()
+    );
+    for e in &appended {
+        let from = e
+            .from_truth_value
+            .map(|h| h.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let short = &e.node_id[..e.node_id.len().min(19)];
+        println!("  ↻ {short}… : {from} -> {}  [{}]", e.to_truth_value, e.trigger);
+    }
+    Ok(())
+}
+
+fn next(args: &[String], i: &mut usize) -> Result<String, Box<dyn Error>> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| Box::<dyn Error>::from("missing value for flag"))
+}

--- a/crates/ix-assumption-graph/src/fusion.rs
+++ b/crates/ix-assumption-graph/src/fusion.rs
@@ -75,7 +75,16 @@ impl AssumptionGraph {
                 .collect();
 
             let merged = merge_all(&observations)?;
-            let verdict = hexavalent_argmax(&merged.distribution);
+            let escalated = escalation_triggered(&merged.distribution);
+            // §7.2 discipline: an active contradiction (C above the escalation
+            // threshold) IS the verdict — a higher-confidence dissenting source
+            // must not let the argmax paper over it. Otherwise the tiebreak-aware
+            // argmax wins.
+            let verdict = if escalated {
+                Hexavalent::Contradictory
+            } else {
+                hexavalent_argmax(&merged.distribution)
+            };
 
             let mut sources: Vec<&str> = nodes.iter().map(|n| n.source.author.as_str()).collect();
             sources.sort_unstable();
@@ -85,7 +94,7 @@ impl AssumptionGraph {
                 claim: nodes[0].claim.clone(),
                 verdict,
                 confidence: merged.distribution.get(&verdict),
-                escalated: escalation_triggered(&merged.distribution),
+                escalated,
                 source_count: sources.len(),
                 contradiction_count: merged.contradictions.len(),
             });

--- a/crates/ix-assumption-graph/src/graph.rs
+++ b/crates/ix-assumption-graph/src/graph.rs
@@ -8,7 +8,7 @@ use ix_ai_annotations::{Annotation, TruthValue};
 use ix_pipeline::dag::Dag;
 use serde::Serialize;
 
-use crate::node::{polarity, AssumptionNode, Polarity};
+use crate::node::{polarity, AssumptionNode, Polarity, ResearchClaim};
 
 /// Errors raised while building the graph.
 #[derive(Debug, thiserror::Error)]
@@ -38,12 +38,30 @@ pub struct AssumptionGraph {
 }
 
 impl AssumptionGraph {
-    /// Build from a list of annotations. Duplicate ids (same
-    /// `path:line:kind:claim`) are de-duplicated — first occurrence wins.
+    /// Build from a list of annotations (each promoted to a node).
     pub fn from_annotations(annotations: Vec<Annotation>) -> Result<Self, BuildError> {
+        Self::build(annotations.into_iter().map(AssumptionNode::from).collect())
+    }
+
+    /// Build the **unified** graph from both dev annotations AND research
+    /// claims. A research claim sharing a normalized claim with a dev
+    /// annotation participates in fusion exactly like any other source — so a
+    /// `/deep-research` finding that contradicts a code assumption escalates.
+    pub fn from_parts(
+        annotations: Vec<Annotation>,
+        research: Vec<ResearchClaim>,
+    ) -> Result<Self, BuildError> {
+        let mut nodes: Vec<AssumptionNode> =
+            annotations.into_iter().map(AssumptionNode::from).collect();
+        nodes.extend(research.into_iter().map(AssumptionNode::from));
+        Self::build(nodes)
+    }
+
+    /// Core builder: de-duplicates nodes by id (first occurrence wins), then
+    /// derives contradictions.
+    fn build(nodes: Vec<AssumptionNode>) -> Result<Self, BuildError> {
         let mut dag: Dag<AssumptionNode> = Dag::new();
-        for ann in annotations {
-            let node: AssumptionNode = ann.into();
+        for node in nodes {
             if dag.get(&node.id).is_some() {
                 continue;
             }
@@ -51,16 +69,20 @@ impl AssumptionGraph {
             dag.add_node(id, node)?;
         }
         let contradictions = derive_contradictions(&dag);
-        Ok(Self {
-            dag,
-            contradictions,
-        })
+        Ok(Self { dag, contradictions })
     }
 
     /// Walk a workspace, extract `@ai:` annotations, and build the graph.
     pub fn from_workspace(workspace: &Path) -> Result<Self, BuildError> {
-        let annotations = ix_ai_annotations::extract_workspace(workspace)?;
-        Self::from_annotations(annotations)
+        Self::from_parts(ix_ai_annotations::extract_workspace(workspace)?, Vec::new())
+    }
+
+    /// Walk a workspace and combine its `@ai:` annotations with research claims.
+    pub fn from_workspace_with_research(
+        workspace: &Path,
+        research: Vec<ResearchClaim>,
+    ) -> Result<Self, BuildError> {
+        Self::from_parts(ix_ai_annotations::extract_workspace(workspace)?, research)
     }
 
     /// Number of assumption nodes.
@@ -252,6 +274,43 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(g.node_count(), 1);
+    }
+
+    #[test]
+    fn research_claim_contradicting_a_dev_assumption_escalates() {
+        use crate::node::ResearchClaim;
+        use ix_types::Hexavalent;
+
+        // A code assumption says latency is under budget (T); a /deep-research
+        // finding refutes it (F). Distinct sources ⇒ fusion escalates to C.
+        // graph-test `ann` hardcodes author "claude".
+        let annotations = vec![ann(
+            "perf.rs",
+            10,
+            AnnotationKind::Invariant,
+            "p99 latency under 5ms",
+            TruthValue::T,
+            0.9,
+        )];
+        let research = vec![ResearchClaim {
+            claim: "p99 latency under 5ms".to_string(),
+            truth_value: TruthValue::F,
+            confidence: 0.85,
+            source: "deep-research".to_string(),
+            evidence: Some("bench-2026-05".to_string()),
+        }];
+
+        let g = AssumptionGraph::from_parts(annotations, research).unwrap();
+        assert_eq!(g.node_count(), 2);
+
+        let fused = g.fuse().unwrap();
+        let latency = fused
+            .iter()
+            .find(|f| f.claim.to_lowercase().contains("latency"))
+            .expect("latency claim present");
+        assert_eq!(latency.verdict, Hexavalent::Contradictory);
+        assert!(latency.escalated);
+        assert_eq!(latency.source_count, 2);
     }
 
     #[test]

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -26,7 +26,7 @@ pub mod temporal;
 
 pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
-pub use node::{polarity, AssumptionNode, Polarity};
+pub use node::{polarity, AssumptionNode, Polarity, ResearchClaim};
 pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
 pub use temporal::{claim_id, BeliefChange, BeliefEvent, BeliefLog, BeliefSnapshot};
 

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -2,6 +2,7 @@
 
 use ix_ai_annotations::{Annotation, AnnotationKind, Certainty, Location, Source, TruthValue};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// A node in the temporal assumption graph.
 ///
@@ -40,6 +41,77 @@ impl From<Annotation> for AssumptionNode {
     }
 }
 
+impl AssumptionNode {
+    /// Build a research-claim node (no code location) — e.g. a verified finding
+    /// from a `/deep-research` run.
+    ///
+    /// NOTE: the reused annotation vocabulary ([`AnnotationKind`]) has no
+    /// dedicated `research-claim` variant, so a research claim is represented as
+    /// a [`AnnotationKind::Hypothesis`] with `certainty = Inferred`; the
+    /// originating run is identified by `source.author` (conventionally
+    /// `"deep-research"`). Splitting the node enums from the annotation enums —
+    /// so the contract's `research-claim` kind and `adversarial-panel` certainty
+    /// become first-class — is a Phase 4 item. Id is `sha256` over
+    /// `research:<author>:<normalized claim>` per the contract.
+    pub fn research_claim(
+        claim: impl Into<String>,
+        truth_value: TruthValue,
+        confidence: f64,
+        source_author: impl Into<String>,
+        evidence: Option<String>,
+    ) -> Self {
+        let claim = claim.into();
+        let author = source_author.into();
+        let key = format!("research:{}:{}", author, crate::graph::normalize_claim(&claim));
+        let id = format!("sha256:{:x}", Sha256::digest(key.as_bytes()));
+        Self {
+            id,
+            kind: AnnotationKind::Hypothesis,
+            claim,
+            truth_value,
+            certainty: Certainty::Inferred,
+            confidence,
+            source: Source {
+                author,
+                model: None,
+                evidence,
+            },
+            location: None,
+        }
+    }
+
+    /// `true` iff this node originated from a research run (`source.author`
+    /// is `"deep-research"`), as opposed to a code-anchored `@ai:` annotation.
+    pub fn is_research_claim(&self) -> bool {
+        self.source.author == "deep-research"
+    }
+}
+
+/// A research-domain claim in the small JSON shape the loop runner ingests.
+/// The truth-value/confidence *judgment* (mapping a verified finding to a
+/// hexavalent value) is the adapter's job — see the `assumption-graph-loop`
+/// skill — so this crate stays unopinionated about `/deep-research`'s output.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResearchClaim {
+    pub claim: String,
+    pub truth_value: TruthValue,
+    pub confidence: f64,
+    #[serde(default = "default_research_source")]
+    pub source: String,
+    #[serde(default)]
+    pub evidence: Option<String>,
+}
+
+fn default_research_source() -> String {
+    "deep-research".to_string()
+}
+
+impl From<ResearchClaim> for AssumptionNode {
+    fn from(r: ResearchClaim) -> Self {
+        AssumptionNode::research_claim(r.claim, r.truth_value, r.confidence, r.source, r.evidence)
+    }
+}
+
 /// Evidential polarity of a hexavalent truth value — the axis along which two
 /// claims about the same thing can contradict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,5 +135,51 @@ pub fn polarity(tv: TruthValue) -> Polarity {
         TruthValue::D | TruthValue::F => Polarity::Negative,
         TruthValue::U => Polarity::Neutral,
         TruthValue::C => Polarity::Contradictory,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn research_claim_id_is_stable_and_claim_normalized() {
+        let a = AssumptionNode::research_claim("Latency  under 5ms", TruthValue::P, 0.8, "deep-research", None);
+        let b = AssumptionNode::research_claim("latency under 5ms", TruthValue::P, 0.8, "deep-research", None);
+        assert_eq!(a.id, b.id, "normalized claim ⇒ same id");
+        assert!(a.id.starts_with("sha256:"));
+        assert!(a.location.is_none());
+        assert_eq!(a.kind, AnnotationKind::Hypothesis);
+        assert!(a.is_research_claim());
+    }
+
+    #[test]
+    fn different_source_gives_different_id() {
+        let a = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "deep-research", None);
+        let b = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "manual-review", None);
+        assert_ne!(a.id, b.id);
+    }
+
+    #[test]
+    fn research_claim_from_struct_carries_fields() {
+        let r = ResearchClaim {
+            claim: "buffer is flushed".to_string(),
+            truth_value: TruthValue::F,
+            confidence: 0.7,
+            source: "deep-research".to_string(),
+            evidence: Some("arxiv:2510.11822".to_string()),
+        };
+        let n: AssumptionNode = r.into();
+        assert_eq!(n.truth_value, TruthValue::F);
+        assert_eq!(n.source.author, "deep-research");
+        assert_eq!(n.source.evidence.as_deref(), Some("arxiv:2510.11822"));
+    }
+
+    #[test]
+    fn research_claim_json_defaults_source() {
+        let r: ResearchClaim =
+            serde_json::from_str(r#"{"claim":"x","truth_value":"P","confidence":0.6}"#).unwrap();
+        assert_eq!(r.source, "deep-research");
+        assert!(r.evidence.is_none());
     }
 }


### PR DESCRIPTION
## What

Completes the longitudinal loop — the orchestration that *drives* Phase 3's `revise` — plus the research-claim ingest that makes the graph genuinely **unified** (dev assumptions + research claims). Stacked on #71.

- **Research ingest** (`node.rs`): `AssumptionNode::research_claim` + `ResearchClaim` (JSON shape). A research claim reuses `Hypothesis` kind + `Inferred` certainty, identified by `source.author = "deep-research"`. (The annotation enums have no `research-claim`/`adversarial-panel` variant — splitting node enums from annotation enums is a documented **Phase 4** item.)
- **Unified build** (`graph.rs`): `from_parts(annotations, research)` and `from_workspace_with_research`. A `/deep-research` finding that contradicts a code assumption now participates in fusion and escalates — exactly the "both, unified" goal.
- **Verdict fix** (`fusion.rs`): an escalated claim (`C` above threshold) yields a `C` **verdict**, not just a flag — a higher-confidence dissenting source must not let argmax paper over the contradiction (contract §7.2).
- **`ix-assumption-graph-loop` bin**: one loop turn — ingest workspace annotations + optional `research-claims.json`, load/append/persist `belief-events.jsonl` via `revise`. Idempotent on unchanged evidence.
- **`assumption-graph-loop` skill**: scheduling + the `/deep-research → research-claims.json` mapping, carrying the fail-closed panel discipline (~96% TPR / <25% TNR ⇒ panels promote, dissent demotes).

## Verified live (real workspace)
- baseline run records 12 belief events
- a deep-research `F` refuting a code invariant (`T`) appends exactly one **`T → C`** flip, persisted to the belief log
- 29 tests, clippy clean (`--all-targets --all-features -- -D warnings`)

## Boundary
The loop does **not** invoke `/deep-research` itself — produce `research-claims.json` first (a run + the documented mapping), then run the loop. That orchestration is the skill's job, not the crate's.

## Notes
- **Base is `feat/assumption-graph-phase3` (#71)** — 4-deep linear stack: `main ← feat/adversarial-llm-panel ← #70 ← #71 ← #72`. Retarget down the chain as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)