### PR TITLE
feat(ix-assumption-graph): Phase 4 - MCP exposure + faceted navigation + enum split

### DIFF
--- a/crates/ix-agent/Cargo.toml
+++ b/crates/ix-agent/Cargo.toml
@@ -54,6 +54,7 @@ ix-fuzzy = { workspace = true }
 ix-bracelet = { workspace = true }
 ix-autoresearch = { workspace = true }
 ix-sentrux-annotations = { workspace = true }
+ix-assumption-graph = { workspace = true }
 chrono = { workspace = true }
 ix-optick = { path = "../ix-optick" }
 ix-types = { workspace = true }

--- a/crates/ix-agent/src/skills/assumption_graph.rs
+++ b/crates/ix-agent/src/skills/assumption_graph.rs
@@ -1,0 +1,119 @@
+//! Assumption-graph MCP skills — the agent-facing navigation surface for the
+//! temporal assumption graph (`crates/ix-assumption-graph`).
+//!
+//! - `assumption.query` (→ `ix_assumption_query`): scan the workspace's `@ai:`
+//!   annotations (optionally folding in a research-claims file), fuse, and
+//!   return the faceted view — counts by namespace / kind / domain, plus the
+//!   escalated (Contradictory) claims. This is the navigable structure a UI
+//!   (Prime Radiant, a dashboard) or an agent reads.
+//! - `assumption.belief_at` (→ `ix_assumption_belief_at`): reconstruct the
+//!   belief state at a point in time from a `belief-events.jsonl` log.
+//!
+//! Both are stateless reads (a full scan / log replay per call), like
+//! `governance.graph`.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use ix_assumption_graph::{AssumptionGraph, BeliefLog, ResearchClaim};
+use ix_skill_macros::ix_skill;
+use serde_json::{json, Value};
+
+fn workspace_root() -> PathBuf {
+    if let Ok(root) = std::env::var("IX_ROOT") {
+        return PathBuf::from(root);
+    }
+    if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
+        return Path::new(&manifest).join("../..");
+    }
+    PathBuf::from(".")
+}
+
+fn assumption_query_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "workspace": {
+                "type": "string",
+                "description": "Workspace dir to scan for @ai: annotations (default: auto-detect)"
+            },
+            "research": {
+                "type": "string",
+                "description": "Optional path to a research-claims.json file to fold into the graph"
+            }
+        }
+    })
+}
+
+/// Build the unified assumption graph for a workspace and return its faceted
+/// navigation view (counts by namespace / kind / domain + escalated claims).
+#[ix_skill(
+    domain = "assumption",
+    name = "assumption.query",
+    governance = "safety,deterministic",
+    schema_fn = "crate::skills::assumption_graph::assumption_query_schema"
+)]
+pub fn assumption_query(params: Value) -> Result<Value, String> {
+    let workspace = params
+        .get("workspace")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(workspace_root);
+
+    let research: Vec<ResearchClaim> = match params.get("research").and_then(|v| v.as_str()) {
+        Some(p) => {
+            let text = std::fs::read_to_string(p).map_err(|e| format!("read {p}: {e}"))?;
+            serde_json::from_str(&text).map_err(|e| format!("parse {p}: {e}"))?
+        }
+        None => Vec::new(),
+    };
+
+    let graph = AssumptionGraph::from_workspace_with_research(&workspace, research)
+        .map_err(|e| e.to_string())?;
+    let view = graph.view().map_err(|e| e.to_string())?;
+    serde_json::to_value(view).map_err(|e| e.to_string())
+}
+
+fn assumption_belief_at_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "log": {
+                "type": "string",
+                "description": "Path to belief-events.jsonl (default: state/assumptions/belief-events.jsonl)"
+            },
+            "at": {
+                "type": "string",
+                "description": "RFC3339 timestamp; default = now"
+            }
+        }
+    })
+}
+
+/// Reconstruct the belief state at a point in belief-time from a belief-event
+/// log: `{ at, beliefs: { <claim-id>: { truth_value, opinion, at } } }`.
+#[ix_skill(
+    domain = "assumption",
+    name = "assumption.belief_at",
+    governance = "safety,deterministic",
+    schema_fn = "crate::skills::assumption_graph::assumption_belief_at_schema"
+)]
+pub fn assumption_belief_at(params: Value) -> Result<Value, String> {
+    let log_path = params
+        .get("log")
+        .and_then(|v| v.as_str())
+        .unwrap_or("state/assumptions/belief-events.jsonl");
+
+    let contents = std::fs::read_to_string(log_path).map_err(|e| format!("read {log_path}: {e}"))?;
+    let log = BeliefLog::from_jsonl(&contents).map_err(|e| e.to_string())?;
+
+    let at = match params.get("at").and_then(|v| v.as_str()) {
+        Some(ts) => DateTime::parse_from_rfc3339(ts)
+            .map_err(|e| format!("invalid `at` timestamp: {e}"))?
+            .with_timezone(&Utc),
+        None => Utc::now(),
+    };
+
+    let beliefs = serde_json::to_value(log.belief_at(at)).map_err(|e| e.to_string())?;
+    Ok(json!({ "at": at.to_rfc3339(), "beliefs": beliefs }))
+}

--- a/crates/ix-agent/src/skills/mod.rs
+++ b/crates/ix-agent/src/skills/mod.rs
@@ -11,6 +11,7 @@
 //! matching entries from `tools.rs`. The 43-tool parity test enforces that
 //! every tool remains reachable during the transition.
 
+pub mod assumption_graph;
 pub mod batch1;
 pub mod batch2;
 pub mod batch3;

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -19,6 +19,8 @@ use std::collections::HashSet;
 /// PC-set algebra tools backed by ix-bracelet.
 const EXPECTED: &[&str] = &[
     "ix_adversarial_fgsm",
+    "ix_assumption_belief_at",
+    "ix_assumption_query",
     "ix_ast_query",
     "ix_autograd_run",
     "ix_bandit",
@@ -139,9 +141,11 @@ fn parity_expected_count() {
     // ix_autoresearch_run = 68. + ix_tsne (2026-04-29) = 69.
     // + ix_voicings_payload (2026-05-02, voicings -> Prime Radiant Phase 1) = 70.
     // + ix_sentrux_annotate (2026-05-24, sentrux structural-rules bridge) = 71.
+    // + ix_assumption_query + ix_assumption_belief_at (2026-05-31, temporal
+    //   assumption graph Phase 4) = 73.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 71);
+    assert_eq!(EXPECTED.len(), 73);
 }
 
 #[test]
@@ -272,8 +276,8 @@ fn parity_all_43_registry_backed() {
     // algorithm tools are registry-backed. ix_demo is manual.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 48,
-        "expected 48 registry skills, got {registry_count}"
+        registry_count, 50,
+        "expected 50 registry skills, got {registry_count}"
     );
 }
 

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -26,22 +26,32 @@ fn main() {
         println!("    ⚠ \"{}\": {} vs {}", c.claim, c.a_truth.as_str(), c.b_truth.as_str());
     }
 
-    // Phase 2: independence-aware fused verdicts.
-    match graph.fuse() {
-        Ok(fused) => {
-            let escalated: Vec<_> = fused.iter().filter(|f| f.escalated).collect();
-            println!("  fused claims:           {}", fused.len());
-            println!(
-                "  escalated to C:         {}  (Phase 2: independent sources disagree)",
-                escalated.len()
-            );
-            for f in escalated {
+    // Phase 4: faceted navigation view (by namespace / kind / domain).
+    match graph.view() {
+        Ok(view) => {
+            println!("  fused claims:           {}", view.claim_count);
+            println!("  escalated to C:         {}", view.escalated_count);
+
+            println!("  by namespace:");
+            for (ns, claims) in &view.by_namespace {
+                let esc = claims.iter().filter(|c| c.escalated).count();
+                let flag = if esc > 0 { format!("  ⚠ {esc} escalated") } else { String::new() };
+                println!("    {:<24} {} claims{}", ns, claims.len(), flag);
+            }
+
+            print!("  by domain:   ");
+            for (d, n) in &view.by_domain {
+                print!("{d}={n}  ");
+            }
+            println!();
+
+            for c in &view.escalations {
                 println!(
-                    "    ⚠ ESCALATE \"{}\": verdict {} ({} sources, {} contradictions)",
-                    f.claim, f.verdict, f.source_count, f.contradiction_count
+                    "    ⚠ ESCALATE [{}] \"{}\": verdict {} ({} sources, {} contradictions)",
+                    c.namespace, c.claim, c.verdict, c.source_count, c.contradiction_count
                 );
             }
         }
-        Err(e) => eprintln!("fuse error: {e}"),
+        Err(e) => eprintln!("view error: {e}"),
     }
 }

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -23,12 +23,14 @@ pub mod graph;
 pub mod node;
 pub mod opinion;
 pub mod temporal;
+pub mod view;
 
 pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
-pub use node::{polarity, AssumptionNode, Polarity, ResearchClaim};
+pub use node::{polarity, AssumptionNode, NodeCertainty, NodeKind, Polarity, ResearchClaim};
 pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
 pub use temporal::{claim_id, BeliefChange, BeliefEvent, BeliefLog, BeliefSnapshot};
+pub use view::{namespace_of, ClaimView, FacetedView};
 
 // Re-export the reused vocabulary so consumers don't need direct dependencies
 // on ix-ai-annotations / ix-types for the common case.

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -4,25 +4,107 @@ use ix_ai_annotations::{Annotation, AnnotationKind, Certainty, Location, Source,
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// Kind of assumption node. A superset of the nine `@ai:` annotation kinds plus
+/// `ResearchClaim` — first-class as of Phase 4 (the annotation enum has no such
+/// variant, so the node model owns its own kind). Matches the contract's node
+/// `kind` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeKind {
+    Invariant,
+    Assumption,
+    Hypothesis,
+    Contract,
+    Smell,
+    Decision,
+    Hint,
+    BusinessValue,
+    HotPath,
+    /// Ingested from a research run (e.g. `/deep-research`).
+    ResearchClaim,
+}
+
+impl NodeKind {
+    /// Kebab-case wire name (matches the serde representation).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeKind::Invariant => "invariant",
+            NodeKind::Assumption => "assumption",
+            NodeKind::Hypothesis => "hypothesis",
+            NodeKind::Contract => "contract",
+            NodeKind::Smell => "smell",
+            NodeKind::Decision => "decision",
+            NodeKind::Hint => "hint",
+            NodeKind::BusinessValue => "business-value",
+            NodeKind::HotPath => "hot-path",
+            NodeKind::ResearchClaim => "research-claim",
+        }
+    }
+}
+
+impl From<AnnotationKind> for NodeKind {
+    fn from(k: AnnotationKind) -> Self {
+        match k {
+            AnnotationKind::Invariant => NodeKind::Invariant,
+            AnnotationKind::Assumption => NodeKind::Assumption,
+            AnnotationKind::Hypothesis => NodeKind::Hypothesis,
+            AnnotationKind::Contract => NodeKind::Contract,
+            AnnotationKind::Smell => NodeKind::Smell,
+            AnnotationKind::Decision => NodeKind::Decision,
+            AnnotationKind::Hint => NodeKind::Hint,
+            AnnotationKind::BusinessValue => NodeKind::BusinessValue,
+            AnnotationKind::HotPath => NodeKind::HotPath,
+        }
+    }
+}
+
+/// How a node's truth value was reached. A superset of the eight `@ai:`
+/// certainty markers plus `AdversarialPanel` — a multi-judge verdict, first-class
+/// as of Phase 4. Matches the contract's node `certainty` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeCertainty {
+    Test,
+    FormalProof,
+    ManuallyReviewed,
+    Assumed,
+    Uncertain,
+    Inferred,
+    Dismissed,
+    DetectedBySentrux,
+    /// Verdict reached by a multi-judge adversarial panel — treated as a
+    /// fail-closed gate, not a truth oracle (contract §7.2).
+    AdversarialPanel,
+}
+
+impl From<Certainty> for NodeCertainty {
+    fn from(c: Certainty) -> Self {
+        match c {
+            Certainty::Test => NodeCertainty::Test,
+            Certainty::FormalProof => NodeCertainty::FormalProof,
+            Certainty::ManuallyReviewed => NodeCertainty::ManuallyReviewed,
+            Certainty::Assumed => NodeCertainty::Assumed,
+            Certainty::Uncertain => NodeCertainty::Uncertain,
+            Certainty::Inferred => NodeCertainty::Inferred,
+            Certainty::Dismissed => NodeCertainty::Dismissed,
+            Certainty::DetectedBySentrux => NodeCertainty::DetectedBySentrux,
+        }
+    }
+}
+
 /// A node in the temporal assumption graph.
-///
-/// Phase 1 carries exactly the epistemic state an `@ai:` annotation already
-/// provides — no new epistemics. The subjective-logic `opinion`, the
-/// `belief_time` axis, and the JSONL wire form defined in
-/// `docs/contracts/2026-05-31-assumption-graph.contract.md` arrive in Phase 2/3.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssumptionNode {
-    /// Deterministic SHA-256 id, identical to the source annotation's id
-    /// (`sha256:…` over `path:line_start:kind:claim`) so an annotation and its
-    /// graph node share identity.
+    /// Deterministic SHA-256 id. Dev nodes share the source annotation's id;
+    /// research nodes hash `research:<author>:<normalized claim>`.
     pub id: String,
-    pub kind: AnnotationKind,
+    pub kind: NodeKind,
     pub claim: String,
     pub truth_value: TruthValue,
-    pub certainty: Certainty,
+    pub certainty: NodeCertainty,
     pub confidence: f64,
     pub source: Source,
-    /// Present for code-anchored assumptions; `None` for research claims (Phase 3).
+    /// Present for code-anchored assumptions; `None` for research claims.
     pub location: Option<Location>,
 }
 
@@ -30,10 +112,10 @@ impl From<Annotation> for AssumptionNode {
     fn from(a: Annotation) -> Self {
         Self {
             id: a.id,
-            kind: a.kind,
+            kind: a.kind.into(),
             claim: a.claim,
             truth_value: a.truth_value,
-            certainty: a.certainty,
+            certainty: a.certainty.into(),
             confidence: a.confidence,
             source: a.source,
             location: Some(a.location),
@@ -43,16 +125,9 @@ impl From<Annotation> for AssumptionNode {
 
 impl AssumptionNode {
     /// Build a research-claim node (no code location) — e.g. a verified finding
-    /// from a `/deep-research` run.
-    ///
-    /// NOTE: the reused annotation vocabulary ([`AnnotationKind`]) has no
-    /// dedicated `research-claim` variant, so a research claim is represented as
-    /// a [`AnnotationKind::Hypothesis`] with `certainty = Inferred`; the
-    /// originating run is identified by `source.author` (conventionally
-    /// `"deep-research"`). Splitting the node enums from the annotation enums —
-    /// so the contract's `research-claim` kind and `adversarial-panel` certainty
-    /// become first-class — is a Phase 4 item. Id is `sha256` over
-    /// `research:<author>:<normalized claim>` per the contract.
+    /// from a `/deep-research` run. Kind is [`NodeKind::ResearchClaim`] and
+    /// certainty is [`NodeCertainty::AdversarialPanel`] (the panel verdict). Id
+    /// is `sha256` over `research:<author>:<normalized claim>` per the contract.
     pub fn research_claim(
         claim: impl Into<String>,
         truth_value: TruthValue,
@@ -66,10 +141,10 @@ impl AssumptionNode {
         let id = format!("sha256:{:x}", Sha256::digest(key.as_bytes()));
         Self {
             id,
-            kind: AnnotationKind::Hypothesis,
+            kind: NodeKind::ResearchClaim,
             claim,
             truth_value,
-            certainty: Certainty::Inferred,
+            certainty: NodeCertainty::AdversarialPanel,
             confidence,
             source: Source {
                 author,
@@ -80,10 +155,18 @@ impl AssumptionNode {
         }
     }
 
-    /// `true` iff this node originated from a research run (`source.author`
-    /// is `"deep-research"`), as opposed to a code-anchored `@ai:` annotation.
+    /// `true` iff this node is a research claim (vs a code-anchored assumption).
     pub fn is_research_claim(&self) -> bool {
-        self.source.author == "deep-research"
+        matches!(self.kind, NodeKind::ResearchClaim)
+    }
+
+    /// Coarse domain facet: `"research"` or `"dev"`.
+    pub fn domain(&self) -> &'static str {
+        if self.is_research_claim() {
+            "research"
+        } else {
+            "dev"
+        }
     }
 }
 
@@ -149,8 +232,9 @@ mod tests {
         assert_eq!(a.id, b.id, "normalized claim ⇒ same id");
         assert!(a.id.starts_with("sha256:"));
         assert!(a.location.is_none());
-        assert_eq!(a.kind, AnnotationKind::Hypothesis);
+        assert_eq!(a.kind, NodeKind::ResearchClaim);
         assert!(a.is_research_claim());
+        assert_eq!(a.domain(), "research");
     }
 
     #[test]
@@ -158,6 +242,25 @@ mod tests {
         let a = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "deep-research", None);
         let b = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "manual-review", None);
         assert_ne!(a.id, b.id);
+    }
+
+    #[test]
+    fn annotation_kind_and_certainty_map_to_node_enums() {
+        assert_eq!(NodeKind::from(AnnotationKind::Invariant), NodeKind::Invariant);
+        assert_eq!(NodeKind::from(AnnotationKind::HotPath), NodeKind::HotPath);
+        assert_eq!(
+            NodeCertainty::from(Certainty::DetectedBySentrux),
+            NodeCertainty::DetectedBySentrux
+        );
+        // New first-class variants serialize to the contract's kebab names.
+        assert_eq!(
+            serde_json::to_string(&NodeKind::ResearchClaim).unwrap(),
+            "\"research-claim\""
+        );
+        assert_eq!(
+            serde_json::to_string(&NodeCertainty::AdversarialPanel).unwrap(),
+            "\"adversarial-panel\""
+        );
     }
 
     #[test]
@@ -171,6 +274,7 @@ mod tests {
         };
         let n: AssumptionNode = r.into();
         assert_eq!(n.truth_value, TruthValue::F);
+        assert_eq!(n.kind, NodeKind::ResearchClaim);
         assert_eq!(n.source.author, "deep-research");
         assert_eq!(n.source.evidence.as_deref(), Some("arxiv:2510.11822"));
     }

--- a/crates/ix-assumption-graph/src/temporal.rs
+++ b/crates/ix-assumption-graph/src/temporal.rs
@@ -83,7 +83,7 @@ impl BeliefEvent {
 }
 
 /// The epistemic state of one claim at a point in belief-time.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct BeliefSnapshot {
     pub truth_value: Hexavalent,
     pub opinion: Option<Opinion>,

--- a/crates/ix-assumption-graph/src/view.rs
+++ b/crates/ix-assumption-graph/src/view.rs
@@ -1,0 +1,236 @@
+//! Phase 4 — faceted navigation over the assumption graph.
+//!
+//! Answers "how is the graph structured?" along **both** axes:
+//! - **namespace** (project/module) — derived from a code-anchored node's path
+//!   (`crates/<crate>/…` → `<crate>`); research claims bucket under `research`;
+//! - **kind** (invariant / assumption / hypothesis / … / research-claim) and
+//!   **domain** (`dev` vs `research`).
+//!
+//! [`AssumptionGraph::view`] produces a [`FacetedView`] — the serializable data
+//! model a UI (Prime Radiant, a dashboard) or the `ix_assumption_query` MCP tool
+//! renders. Escalated (Contradictory) claims are surfaced separately for triage.
+
+use std::collections::BTreeMap;
+
+use ix_fuzzy::FuzzyError;
+use ix_types::Hexavalent;
+use serde::Serialize;
+
+use crate::graph::{normalize_claim, AssumptionGraph};
+use crate::node::AssumptionNode;
+
+/// Namespace facet for a node: its crate (or top path segment) for code-anchored
+/// nodes, `"research"` for research claims.
+pub fn namespace_of(node: &AssumptionNode) -> String {
+    match &node.location {
+        Some(loc) => namespace_from_path(&loc.path),
+        None => "research".to_string(),
+    }
+}
+
+/// `crates/<crate>/src/…` → `<crate>`; otherwise the first path segment;
+/// `(unknown)` if empty.
+fn namespace_from_path(path: &str) -> String {
+    let norm = path.replace('\\', "/");
+    let parts: Vec<&str> = norm.split('/').filter(|s| !s.is_empty()).collect();
+    if let Some(i) = parts.iter().position(|&s| s == "crates") {
+        if let Some(crate_name) = parts.get(i + 1) {
+            return (*crate_name).to_string();
+        }
+    }
+    parts.first().map(|s| (*s).to_string()).unwrap_or_else(|| "(unknown)".to_string())
+}
+
+/// One claim's fused state, with its navigation facets.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimView {
+    pub claim: String,
+    pub verdict: Hexavalent,
+    pub escalated: bool,
+    pub namespace: String,
+    pub domains: Vec<String>,
+    pub source_count: usize,
+    pub contradiction_count: usize,
+}
+
+/// Faceted snapshot of the whole graph — the UI / MCP data model.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FacetedView {
+    pub node_count: usize,
+    pub claim_count: usize,
+    pub escalated_count: usize,
+    /// Claim views grouped under their primary namespace.
+    pub by_namespace: BTreeMap<String, Vec<ClaimView>>,
+    /// Node counts per kind (kebab name).
+    pub by_kind: BTreeMap<String, usize>,
+    /// Node counts per domain (`dev` / `research`).
+    pub by_domain: BTreeMap<String, usize>,
+    /// Just the escalated (Contradictory) claims, for quick triage.
+    pub escalations: Vec<ClaimView>,
+}
+
+impl AssumptionGraph {
+    /// Build the faceted navigation view. Groups nodes by normalized claim,
+    /// joins each with its fused verdict, and buckets by namespace / kind /
+    /// domain. A claim's *primary namespace* is the most common namespace among
+    /// its contributing nodes (ties broken alphabetically; `research`-only
+    /// claims land under `research`).
+    pub fn view(&self) -> Result<FacetedView, FuzzyError> {
+        // claim (normalized) -> contributing nodes
+        let mut groups: BTreeMap<String, Vec<&AssumptionNode>> = BTreeMap::new();
+        for node in self.nodes() {
+            groups
+                .entry(normalize_claim(&node.claim))
+                .or_default()
+                .push(node);
+        }
+
+        // normalized claim -> fused verdict
+        let fused = self.fuse()?;
+        let by_norm: BTreeMap<String, &crate::FusedClaim> = fused
+            .iter()
+            .map(|f| (normalize_claim(&f.claim), f))
+            .collect();
+
+        let mut view = FacetedView {
+            node_count: self.node_count(),
+            ..Default::default()
+        };
+
+        for node in self.nodes() {
+            *view.by_kind.entry(node.kind.as_str().to_string()).or_default() += 1;
+            *view.by_domain.entry(node.domain().to_string()).or_default() += 1;
+        }
+
+        for (norm, nodes) in &groups {
+            let Some(f) = by_norm.get(norm) else { continue };
+
+            let namespace = primary_namespace(nodes);
+            let mut domains: Vec<String> =
+                nodes.iter().map(|n| n.domain().to_string()).collect();
+            domains.sort_unstable();
+            domains.dedup();
+
+            let cv = ClaimView {
+                claim: f.claim.clone(),
+                verdict: f.verdict,
+                escalated: f.escalated,
+                namespace: namespace.clone(),
+                domains,
+                source_count: f.source_count,
+                contradiction_count: f.contradiction_count,
+            };
+
+            if cv.escalated {
+                view.escalations.push(cv.clone());
+            }
+            view.by_namespace.entry(namespace).or_default().push(cv);
+        }
+
+        view.claim_count = groups.len();
+        view.escalated_count = view.escalations.len();
+        // Deterministic escalation order.
+        view.escalations.sort_by(|a, b| a.claim.cmp(&b.claim));
+        Ok(view)
+    }
+}
+
+/// Most common namespace among a claim's nodes (ties → alphabetical first).
+fn primary_namespace(nodes: &[&AssumptionNode]) -> String {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for n in nodes {
+        *counts.entry(namespace_of(n)).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+        .map(|(ns, _)| ns)
+        .unwrap_or_else(|| "(unknown)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::ResearchClaim;
+    use ix_ai_annotations::types::annotation_id;
+    use ix_ai_annotations::{
+        Annotation, AnnotationKind, Certainty, Location, Source, TruthValue, SCHEMA_VERSION,
+    };
+
+    fn ann(path: &str, line: u32, claim: &str, tv: TruthValue) -> Annotation {
+        let kind = AnnotationKind::Invariant;
+        Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id(path, line, kind, claim),
+            kind,
+            claim: claim.to_string(),
+            truth_value: tv,
+            certainty: Certainty::Test,
+            confidence: 0.9,
+            source: Source { author: "claude".to_string(), model: None, evidence: None },
+            location: Location { path: path.to_string(), line_start: line, line_end: line },
+            created_at: "2026-05-31T00:00:00Z".to_string(),
+            updated_at: "2026-05-31T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        }
+    }
+
+    #[test]
+    fn namespace_derives_crate_from_path() {
+        assert_eq!(namespace_from_path("crates/ix-search/src/binary.rs"), "ix-search");
+        assert_eq!(namespace_from_path("crates\\ix-fuzzy\\src\\ops.rs"), "ix-fuzzy");
+        assert_eq!(namespace_from_path("README.md"), "README.md");
+    }
+
+    #[test]
+    fn view_buckets_by_namespace_and_domain() {
+        let g = AssumptionGraph::from_parts(
+            vec![
+                ann("crates/ix-search/src/a.rs", 1, "alpha holds", TruthValue::T),
+                ann("crates/ix-fuzzy/src/b.rs", 2, "beta holds", TruthValue::T),
+            ],
+            vec![ResearchClaim {
+                claim: "gamma is settled".to_string(),
+                truth_value: TruthValue::P,
+                confidence: 0.8,
+                source: "deep-research".to_string(),
+                evidence: None,
+            }],
+        )
+        .unwrap();
+
+        let view = g.view().unwrap();
+        assert_eq!(view.node_count, 3);
+        assert_eq!(view.claim_count, 3);
+        assert!(view.by_namespace.contains_key("ix-search"));
+        assert!(view.by_namespace.contains_key("ix-fuzzy"));
+        assert!(view.by_namespace.contains_key("research"));
+        assert_eq!(view.by_domain.get("dev"), Some(&2));
+        assert_eq!(view.by_domain.get("research"), Some(&1));
+        assert_eq!(view.by_kind.get("research-claim"), Some(&1));
+        assert_eq!(view.escalated_count, 0);
+    }
+
+    #[test]
+    fn view_surfaces_escalations() {
+        // A research claim refutes a code assumption on the same claim.
+        let g = AssumptionGraph::from_parts(
+            vec![ann("crates/ix-x/src/a.rs", 1, "fast path is safe", TruthValue::T)],
+            vec![ResearchClaim {
+                claim: "fast path is safe".to_string(),
+                truth_value: TruthValue::F,
+                confidence: 0.9,
+                source: "deep-research".to_string(),
+                evidence: None,
+            }],
+        )
+        .unwrap();
+
+        let view = g.view().unwrap();
+        assert_eq!(view.escalated_count, 1);
+        assert_eq!(view.escalations[0].verdict, Hexavalent::Contradictory);
+        // The claim touches both domains.
+        assert_eq!(view.escalations[0].domains, vec!["dev", "research"]);
+    }
+}

--- a/docs/contracts/2026-05-31-assumption-graph.contract.md
+++ b/docs/contracts/2026-05-31-assumption-graph.contract.md
@@ -1,10 +1,10 @@
 # Temporal Assumption Graph — Cross-Repo Contract
 
-**Version:** 0.1.0 (draft, Phase 0 — schema only)
+**Version:** 0.4.0 (Phases 1–4 implemented — **freeze-candidate**, pending operator sign-off)
 **Schema version:** 1
-**Status:** Draft (Phase 0 of the `assumption-graph` campaign, 2026-05-31). Drafts are not frozen; freeze milestone is end of Phase 4 (per ecosystem convention).
-**Producers (planned):** `ix-assumption-graph` builder, `ix-ai-annotations` (via node promotion), `/deep-research` workflow (research-claim nodes), the longitudinal verify→revise loop
-**Consumers (planned):** `ix-assumption-graph` acceptability/query engine, `belief_at(t)` time-travel query, Demerzel promotion gate, (later) an MCP tool `ix_assumption_query`
+**Status:** Phases 1–4 shipped in `ix-assumption-graph` (graph + fusion + belief-time + MCP). The `node`/`edge`/`belief_event` records, the reused enums, and the `opinion` shape are stable. Freeze (→ v1.0.0, locking the one-way-door fields) is a **one-way door requiring operator sign-off** — NOT done unilaterally.
+**Producers:** `ix-assumption-graph` builder (`from_workspace`/`from_parts`), `ix-ai-annotations` (via node promotion), `/deep-research` (research-claim nodes via the `assumption-graph-loop` skill), the `revise` loop
+**Consumers:** `ix-assumption-graph` fusion/`view`/`belief_at`, the MCP tools `ix_assumption_query` + `ix_assumption_belief_at`, Demerzel promotion gate, (later) Prime Radiant / dashboard visualization
 **Schema file:** `docs/contracts/assumption-graph.schema.json`
 **Design doc:** `docs/plans/2026-05-31-temporal-assumption-graph.md`
 
@@ -146,7 +146,18 @@ The "do multi-LLM panels improve correctness or amplify shared bias?" question i
 - **Phase 1:** `ix-assumption-graph` crate — build `Dag<AssumptionNode>` from `@ai:` annotations; derive `contradicts` from `contrary`.
 - **Phase 2:** opinion fusion + Belnap `C` synthesis + the §4 bridge (reuses `ix-fuzzy`, `hari`).
 - **Phase 3:** belief-event log + `belief_at(t)` / `diff(t1,t2)`; the longitudinal loop ( `/deep-research` → research-claim nodes; scheduled re-verify; Demerzel promotion gate).
-- **Phase 4:** MCP exposure + freeze.
+- **Phase 4 (shipped):** node enums split from the annotation enums — `research-claim` kind and `adversarial-panel` certainty are now first-class (`NodeKind`/`NodeCertainty`); faceted navigation `view()` (by namespace / kind / domain + escalations); MCP tools `ix_assumption_query` (faceted view) and `ix_assumption_belief_at` (point-in-time belief state). **Freeze (→ v1.0.0) pending operator sign-off.**
+
+### Navigation & structure
+
+The graph is navigable along two axes (`AssumptionGraph::view` → `FacetedView`):
+- **namespace** — code-anchored nodes by crate (`crates/<crate>/…` → `<crate>`); research claims under `research`;
+- **domain / kind** — `dev` vs `research`; and the node `kind`.
+
+Finer "functional area" grouping (below crate/module) would need explicit tags
+on annotations — not currently modeled. Humans navigate via the
+`ix-assumption-graph-report` CLI or (future) Prime Radiant; agents via
+`ix_assumption_query`.
 
 ---
 


### PR DESCRIPTION
## What

Phase 4 — makes the graph **navigable** (the "is there a UI / how is it structured?" question) and exposes it over MCP. Stacked on #72.

### Enum split (research-claim & adversarial-panel first-class)
`NodeKind` / `NodeCertainty` are now owned by the crate (`From<AnnotationKind>` / `From<Certainty>` bridge the annotation vocabulary). `research-claim` kind and `adversarial-panel` certainty are no longer faked as `Hypothesis`/`Inferred` — they match the contract's node enums.

### Faceted navigation — `AssumptionGraph::view() -> FacetedView`
Answers **"structured by project/namespace or functional area or both?"** → **both axes**:
- **namespace** — code-anchored nodes by crate (`crates/<crate>/… → <crate>`); research claims under `research`;
- **domain / kind** — `dev` vs `research`; node kind counts;
- **escalations** — Contradictory claims surfaced for triage.

This is the serializable data model a UI or MCP renders. (Finer functional-area grouping below crate/module would need explicit annotation tags — noted, not modeled.)

### MCP tools (the agent-native navigation surface)
`crates/ix-agent/src/skills/assumption_graph.rs`:
- **`ix_assumption_query`** — faceted view for a workspace (optional research-claims file).
- **`ix_assumption_belief_at`** — point-in-time belief state from a `belief-events.jsonl` log.

Stateless reads, like `governance.graph`. Parity test updated (71 → 73 tools, 48 → 50 registry).

## On the UI question
There is no graphical UI yet. Today: **agents** navigate via `ix_assumption_query`; **humans** via the `ix-assumption-graph-report` CLI (now prints the faceted view). The natural graphical home is **Prime Radiant** (ga's 3D graph viz already consumes governance graphs) — that's a downstream consumer of `ix_assumption_query`, not in this PR.

## Verification
- 33 crate tests + 9 `ix-agent` parity tests green; clippy clean (`-D warnings`)
- live `report` on the workspace: 16 nodes across namespaces `docs` / `ix-ai-annotations` / `ix-assumption-graph`, `dev=16`

## Freeze
Contract bumped to **0.4.0 freeze-candidate**. Actual freeze (→ v1.0.0, locking the one-way-door id/enum fields) is left as an **operator sign-off** — not done unilaterally.

## Notes
- 5-deep linear stack: `main ← feat/adversarial-llm-panel ← #70 ← #71 ← #72 ← #73`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)