### PR TITLE
feat(ix-assumption-graph): temporal assumption graph — extract + maintain a hexavalent belief graph over time

### DIFF
--- a/.claude/skills/assumption-graph-loop/SKILL.md
+++ b/.claude/skills/assumption-graph-loop/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: assumption-graph-loop
+description: Autonomous belief-revision loop — fuse @ai: annotations + /deep-research claims into the temporal assumption graph and revise the persistent belief log over time
+---
+
+# Assumption-Graph Loop
+
+One turn of the longitudinal belief loop for the temporal assumption graph
+(`crates/ix-assumption-graph`, contract `docs/contracts/2026-05-31-assumption-graph.contract.md`):
+
+```
+@ai: annotations ─┐
+                  ├─► fuse (ix-fuzzy, Belnap C synthesis) ─► revise ─► belief-events.jsonl
+research claims ──┘        cross-source only                 (append on verdict change)
+```
+
+It ingests the workspace's `@ai:` annotations plus any research-domain claims,
+fuses each claim's evidence, and appends a `BeliefEvent` for every claim whose
+verdict changed since the last run. Re-running on unchanged evidence is a no-op
+— so it is safe to schedule.
+
+## When to Use
+
+- On a schedule (daily / weekly), to keep the belief log current as code and
+  research evolve — the "semantic story over a long period".
+- After a `/deep-research` run, to fold its verified findings into the graph and
+  detect where new evidence contradicts a standing assumption.
+- Before a review, to surface `escalated` (Contradictory) claims.
+
+## Run It
+
+```bash
+cargo run -p ix-assumption-graph --bin ix-assumption-graph-loop -- \
+  --workspace .                                   \
+  --research state/assumptions/research-claims.json   \  # optional
+  --log     state/assumptions/belief-events.jsonl     \
+  --trigger deep-research-reverify
+```
+
+Defaults: `--workspace .`, `--log state/assumptions/belief-events.jsonl`,
+`--trigger loop`, no research file. The log is created (with parent dirs) if
+absent. Output reports node count, total/appended belief events, and each flip
+(`T -> C`, etc.).
+
+## The `research-claims.json` shape
+
+A JSON array. The **truth-value judgment** — mapping a verified finding to a
+hexavalent value — is the adapter's responsibility, NOT the crate's, so this
+file is the seam between `/deep-research`'s output and the graph:
+
+```json
+[
+  {
+    "claim": "p99 latency under 5ms",
+    "truth_value": "F",
+    "confidence": 0.85,
+    "source": "deep-research",
+    "evidence": "arxiv:2510.11822"
+  }
+]
+```
+
+- `truth_value`: one of `T P U D F C` (hexavalent).
+- `confidence`: `0.0`–`1.0`.
+- `source` (optional, default `"deep-research"`): the **independence class**.
+  Distinct sources are what let fusion synthesize a contradiction — give
+  genuinely independent runs distinct source labels; do NOT relabel correlated
+  re-runs as independent (contract §7.1 — over-counting).
+- `evidence` (optional): a confirmed-real citation.
+
+## Converting a `/deep-research` run → `research-claims.json`
+
+`/deep-research` returns `result.findings[]` (with `claim`, `confidence`
+high/medium/low, `vote`, `sources`) and `result.refuted[]`. Suggested mapping:
+
+| deep-research | truth_value | confidence |
+|---|---|---|
+| confirmed finding, confidence high | `T` | 0.85–0.95 |
+| confirmed finding, confidence medium | `P` | 0.6–0.75 |
+| confirmed finding, confidence low | `U` | ~0.4 |
+| `refuted[]` entry | `F` | by vote margin |
+
+**Fail-closed (contract §7.2):** a multi-judge panel confirms well but catches
+invalidity poorly (~96% TPR / <25% TNR). Treat panel agreement as a gate to
+*promote*, and let any credible dissent push to `U`/`D`/`C` — never relabel
+correlated judges as independent sources. Verify every cited source resolves
+before writing it as `evidence` (deep-research has hallucinated arXiv ids).
+
+## Scheduling
+
+Wrap the command in your scheduled-runner of choice (cron, the
+`octo:schedule` skill, or a `state/`-driven local runner like the adversarial-qa
+runner). Commit `state/assumptions/belief-events.jsonl` if you want the belief
+story versioned; otherwise treat it as regenerable local state.
+
+## What it does NOT do
+
+- It does not invoke `/deep-research` itself — produce `research-claims.json`
+  first (a `/deep-research` run + the mapping above), then run the loop.
+- It does not run tests to verify code assumptions — feed test outcomes as
+  additional `@ai:` annotation reconciliation or research claims.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ members = [
     "crates/ix-blast-radius",
     "crates/ix-ai-annotations",
     "crates/ix-sentrux-annotations",
+    "crates/ix-assumption-graph",
 ]
 
 [workspace.package]
@@ -173,6 +174,7 @@ ix-autoresearch = { path = "crates/ix-autoresearch", version = "0.1.0" }
 ix-blast-radius = { path = "crates/ix-blast-radius", version = "0.1.0" }
 ix-ai-annotations = { path = "crates/ix-ai-annotations", version = "0.1.0" }
 ix-sentrux-annotations = { path = "crates/ix-sentrux-annotations", version = "0.1.0" }
+ix-assumption-graph = { path = "crates/ix-assumption-graph", version = "0.1.0" }
 serde_yaml = "0.9"
 parking_lot = "0.12"
 

--- a/crates/ix-agent/Cargo.toml
+++ b/crates/ix-agent/Cargo.toml
@@ -54,6 +54,7 @@ ix-fuzzy = { workspace = true }
 ix-bracelet = { workspace = true }
 ix-autoresearch = { workspace = true }
 ix-sentrux-annotations = { workspace = true }
+ix-assumption-graph = { workspace = true }
 chrono = { workspace = true }
 ix-optick = { path = "../ix-optick" }
 ix-types = { workspace = true }

--- a/crates/ix-agent/src/skills/assumption_graph.rs
+++ b/crates/ix-agent/src/skills/assumption_graph.rs
@@ -104,7 +104,8 @@ pub fn assumption_belief_at(params: Value) -> Result<Value, String> {
         .and_then(|v| v.as_str())
         .unwrap_or("state/assumptions/belief-events.jsonl");
 
-    let contents = std::fs::read_to_string(log_path).map_err(|e| format!("read {log_path}: {e}"))?;
+    let contents =
+        std::fs::read_to_string(log_path).map_err(|e| format!("read {log_path}: {e}"))?;
     let log = BeliefLog::from_jsonl(&contents).map_err(|e| e.to_string())?;
 
     let at = match params.get("at").and_then(|v| v.as_str()) {

--- a/crates/ix-agent/src/skills/assumption_graph.rs
+++ b/crates/ix-agent/src/skills/assumption_graph.rs
@@ -1,0 +1,119 @@
+//! Assumption-graph MCP skills — the agent-facing navigation surface for the
+//! temporal assumption graph (`crates/ix-assumption-graph`).
+//!
+//! - `assumption.query` (→ `ix_assumption_query`): scan the workspace's `@ai:`
+//!   annotations (optionally folding in a research-claims file), fuse, and
+//!   return the faceted view — counts by namespace / kind / domain, plus the
+//!   escalated (Contradictory) claims. This is the navigable structure a UI
+//!   (Prime Radiant, a dashboard) or an agent reads.
+//! - `assumption.belief_at` (→ `ix_assumption_belief_at`): reconstruct the
+//!   belief state at a point in time from a `belief-events.jsonl` log.
+//!
+//! Both are stateless reads (a full scan / log replay per call), like
+//! `governance.graph`.
+
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use ix_assumption_graph::{AssumptionGraph, BeliefLog, ResearchClaim};
+use ix_skill_macros::ix_skill;
+use serde_json::{json, Value};
+
+fn workspace_root() -> PathBuf {
+    if let Ok(root) = std::env::var("IX_ROOT") {
+        return PathBuf::from(root);
+    }
+    if let Ok(manifest) = std::env::var("CARGO_MANIFEST_DIR") {
+        return Path::new(&manifest).join("../..");
+    }
+    PathBuf::from(".")
+}
+
+fn assumption_query_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "workspace": {
+                "type": "string",
+                "description": "Workspace dir to scan for @ai: annotations (default: auto-detect)"
+            },
+            "research": {
+                "type": "string",
+                "description": "Optional path to a research-claims.json file to fold into the graph"
+            }
+        }
+    })
+}
+
+/// Build the unified assumption graph for a workspace and return its faceted
+/// navigation view (counts by namespace / kind / domain + escalated claims).
+#[ix_skill(
+    domain = "assumption",
+    name = "assumption.query",
+    governance = "safety,deterministic",
+    schema_fn = "crate::skills::assumption_graph::assumption_query_schema"
+)]
+pub fn assumption_query(params: Value) -> Result<Value, String> {
+    let workspace = params
+        .get("workspace")
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from)
+        .unwrap_or_else(workspace_root);
+
+    let research: Vec<ResearchClaim> = match params.get("research").and_then(|v| v.as_str()) {
+        Some(p) => {
+            let text = std::fs::read_to_string(p).map_err(|e| format!("read {p}: {e}"))?;
+            serde_json::from_str(&text).map_err(|e| format!("parse {p}: {e}"))?
+        }
+        None => Vec::new(),
+    };
+
+    let graph = AssumptionGraph::from_workspace_with_research(&workspace, research)
+        .map_err(|e| e.to_string())?;
+    let view = graph.view().map_err(|e| e.to_string())?;
+    serde_json::to_value(view).map_err(|e| e.to_string())
+}
+
+fn assumption_belief_at_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "log": {
+                "type": "string",
+                "description": "Path to belief-events.jsonl (default: state/assumptions/belief-events.jsonl)"
+            },
+            "at": {
+                "type": "string",
+                "description": "RFC3339 timestamp; default = now"
+            }
+        }
+    })
+}
+
+/// Reconstruct the belief state at a point in belief-time from a belief-event
+/// log: `{ at, beliefs: { <claim-id>: { truth_value, opinion, at } } }`.
+#[ix_skill(
+    domain = "assumption",
+    name = "assumption.belief_at",
+    governance = "safety,deterministic",
+    schema_fn = "crate::skills::assumption_graph::assumption_belief_at_schema"
+)]
+pub fn assumption_belief_at(params: Value) -> Result<Value, String> {
+    let log_path = params
+        .get("log")
+        .and_then(|v| v.as_str())
+        .unwrap_or("state/assumptions/belief-events.jsonl");
+
+    let contents = std::fs::read_to_string(log_path).map_err(|e| format!("read {log_path}: {e}"))?;
+    let log = BeliefLog::from_jsonl(&contents).map_err(|e| e.to_string())?;
+
+    let at = match params.get("at").and_then(|v| v.as_str()) {
+        Some(ts) => DateTime::parse_from_rfc3339(ts)
+            .map_err(|e| format!("invalid `at` timestamp: {e}"))?
+            .with_timezone(&Utc),
+        None => Utc::now(),
+    };
+
+    let beliefs = serde_json::to_value(log.belief_at(at)).map_err(|e| e.to_string())?;
+    Ok(json!({ "at": at.to_rfc3339(), "beliefs": beliefs }))
+}

--- a/crates/ix-agent/src/skills/mod.rs
+++ b/crates/ix-agent/src/skills/mod.rs
@@ -11,6 +11,7 @@
 //! matching entries from `tools.rs`. The 43-tool parity test enforces that
 //! every tool remains reachable during the transition.
 
+pub mod assumption_graph;
 pub mod batch1;
 pub mod batch2;
 pub mod batch3;

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -19,6 +19,8 @@ use std::collections::HashSet;
 /// PC-set algebra tools backed by ix-bracelet.
 const EXPECTED: &[&str] = &[
     "ix_adversarial_fgsm",
+    "ix_assumption_belief_at",
+    "ix_assumption_query",
     "ix_ast_query",
     "ix_autograd_run",
     "ix_bandit",
@@ -139,9 +141,11 @@ fn parity_expected_count() {
     // ix_autoresearch_run = 68. + ix_tsne (2026-04-29) = 69.
     // + ix_voicings_payload (2026-05-02, voicings -> Prime Radiant Phase 1) = 70.
     // + ix_sentrux_annotate (2026-05-24, sentrux structural-rules bridge) = 71.
+    // + ix_assumption_query + ix_assumption_belief_at (2026-05-31, temporal
+    //   assumption graph Phase 4) = 73.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 71);
+    assert_eq!(EXPECTED.len(), 73);
 }
 
 #[test]
@@ -272,8 +276,8 @@ fn parity_all_43_registry_backed() {
     // algorithm tools are registry-backed. ix_demo is manual.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 48,
-        "expected 48 registry skills, got {registry_count}"
+        registry_count, 50,
+        "expected 50 registry skills, got {registry_count}"
     );
 }
 

--- a/crates/ix-assumption-graph/Cargo.toml
+++ b/crates/ix-assumption-graph/Cargo.toml
@@ -12,6 +12,8 @@ description = "Builds a graph of assumptions from @ai: annotations and derives c
 [dependencies]
 ix-ai-annotations = { workspace = true }
 ix-pipeline = { workspace = true }
+ix-fuzzy = { workspace = true }
+ix-types = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/ix-assumption-graph/Cargo.toml
+++ b/crates/ix-assumption-graph/Cargo.toml
@@ -15,7 +15,10 @@ ix-pipeline = { workspace = true }
 ix-fuzzy = { workspace = true }
 ix-types = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
 thiserror = { workspace = true }
+sha2 = "0.10"
 
 [lib]
 path = "src/lib.rs"

--- a/crates/ix-assumption-graph/Cargo.toml
+++ b/crates/ix-assumption-graph/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ix-assumption-graph"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+categories = ["data-structures", "development-tools"]
+keywords = ["assumptions", "hexavalent", "argumentation", "belief", "governance"]
+description = "Builds a graph of assumptions from @ai: annotations and derives contradiction relations from opposing hexavalent truth values. Phase 1 of the temporal assumption graph (docs/contracts/2026-05-31-assumption-graph.contract.md): code-anchored nodes + contradiction detection, no new epistemics."
+
+[dependencies]
+ix-ai-annotations = { workspace = true }
+ix-pipeline = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "ix-assumption-graph-report"
+path = "src/bin/report.rs"

--- a/crates/ix-assumption-graph/Cargo.toml
+++ b/crates/ix-assumption-graph/Cargo.toml
@@ -26,3 +26,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "ix-assumption-graph-report"
 path = "src/bin/report.rs"
+
+[[bin]]
+name = "ix-assumption-graph-loop"
+path = "src/bin/loop_runner.rs"

--- a/crates/ix-assumption-graph/src/bin/loop_runner.rs
+++ b/crates/ix-assumption-graph/src/bin/loop_runner.rs
@@ -85,7 +85,10 @@ fn run() -> Result<(), Box<dyn Error>> {
             .map(|h| h.to_string())
             .unwrap_or_else(|| "-".to_string());
         let short = &e.node_id[..e.node_id.len().min(19)];
-        println!("  ↻ {short}… : {from} -> {}  [{}]", e.to_truth_value, e.trigger);
+        println!(
+            "  ↻ {short}… : {from} -> {}  [{}]",
+            e.to_truth_value, e.trigger
+        );
     }
     Ok(())
 }

--- a/crates/ix-assumption-graph/src/bin/loop_runner.rs
+++ b/crates/ix-assumption-graph/src/bin/loop_runner.rs
@@ -1,0 +1,98 @@
+//! Autonomous-loop runner — one turn of the longitudinal belief loop.
+//!
+//! Ingests the workspace's `@ai:` annotations plus (optionally) research claims
+//! from a JSON file, loads the persistent belief log, calls
+//! [`ix_assumption_graph::AssumptionGraph::revise`], and writes the log back.
+//! Scheduling this on an interval (and producing the research-claims file from a
+//! `/deep-research` run) is the `assumption-graph-loop` skill's job.
+//!
+//! ```text
+//! ix-assumption-graph-loop [--workspace DIR] [--research FILE.json]
+//!     [--log FILE.jsonl] [--trigger LABEL]
+//! ```
+//! Defaults: workspace `.`, log `state/assumptions/belief-events.jsonl`,
+//! trigger `loop`.
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+
+use chrono::Utc;
+use ix_assumption_graph::{AssumptionGraph, BeliefLog, ResearchClaim};
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<(), Box<dyn Error>> {
+    let mut workspace = ".".to_string();
+    let mut research_path: Option<String> = None;
+    let mut log_path = "state/assumptions/belief-events.jsonl".to_string();
+    let mut trigger = "loop".to_string();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--workspace" => workspace = next(&args, &mut i)?,
+            "--research" => research_path = Some(next(&args, &mut i)?),
+            "--log" => log_path = next(&args, &mut i)?,
+            "--trigger" => trigger = next(&args, &mut i)?,
+            "-h" | "--help" => {
+                println!("ix-assumption-graph-loop [--workspace DIR] [--research FILE.json] [--log FILE.jsonl] [--trigger LABEL]");
+                return Ok(());
+            }
+            other => return Err(format!("unknown argument: {other}").into()),
+        }
+        i += 1;
+    }
+
+    let research: Vec<ResearchClaim> = match &research_path {
+        Some(p) => serde_json::from_str(&fs::read_to_string(p)?)?,
+        None => Vec::new(),
+    };
+
+    let graph = AssumptionGraph::from_workspace_with_research(Path::new(&workspace), research)?;
+
+    let mut log = match fs::read_to_string(&log_path) {
+        Ok(s) => BeliefLog::from_jsonl(&s)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => BeliefLog::new(),
+        Err(e) => return Err(e.into()),
+    };
+
+    let appended = graph.revise(&mut log, Utc::now(), &trigger)?;
+
+    if let Some(parent) = Path::new(&log_path).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+    fs::write(&log_path, log.to_jsonl())?;
+
+    println!("assumption-graph loop ({trigger})");
+    println!("  nodes:          {}", graph.node_count());
+    println!(
+        "  belief events:  {} (+{} this run)",
+        log.len(),
+        appended.len()
+    );
+    for e in &appended {
+        let from = e
+            .from_truth_value
+            .map(|h| h.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let short = &e.node_id[..e.node_id.len().min(19)];
+        println!("  ↻ {short}… : {from} -> {}  [{}]", e.to_truth_value, e.trigger);
+    }
+    Ok(())
+}
+
+fn next(args: &[String], i: &mut usize) -> Result<String, Box<dyn Error>> {
+    *i += 1;
+    args.get(*i)
+        .cloned()
+        .ok_or_else(|| Box::<dyn Error>::from("missing value for flag"))
+}

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -23,7 +23,12 @@ fn main() {
         graph.contradictions().len()
     );
     for c in graph.contradictions() {
-        println!("    ⚠ \"{}\": {} vs {}", c.claim, c.a_truth.as_str(), c.b_truth.as_str());
+        println!(
+            "    ⚠ \"{}\": {} vs {}",
+            c.claim,
+            c.a_truth.as_str(),
+            c.b_truth.as_str()
+        );
     }
 
     // Phase 4: faceted navigation view (by namespace / kind / domain).
@@ -35,7 +40,11 @@ fn main() {
             println!("  by namespace:");
             for (ns, claims) in &view.by_namespace {
                 let esc = claims.iter().filter(|c| c.escalated).count();
-                let flag = if esc > 0 { format!("  ⚠ {esc} escalated") } else { String::new() };
+                let flag = if esc > 0 {
+                    format!("  ⚠ {esc} escalated")
+                } else {
+                    String::new()
+                };
                 println!("    {:<24} {} claims{}", ns, claims.len(), flag);
             }
 

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -26,22 +26,32 @@ fn main() {
         println!("    ⚠ \"{}\": {} vs {}", c.claim, c.a_truth.as_str(), c.b_truth.as_str());
     }
 
-    // Phase 2: independence-aware fused verdicts.
-    match graph.fuse() {
-        Ok(fused) => {
-            let escalated: Vec<_> = fused.iter().filter(|f| f.escalated).collect();
-            println!("  fused claims:           {}", fused.len());
-            println!(
-                "  escalated to C:         {}  (Phase 2: independent sources disagree)",
-                escalated.len()
-            );
-            for f in escalated {
+    // Phase 4: faceted navigation view (by namespace / kind / domain).
+    match graph.view() {
+        Ok(view) => {
+            println!("  fused claims:           {}", view.claim_count);
+            println!("  escalated to C:         {}", view.escalated_count);
+
+            println!("  by namespace:");
+            for (ns, claims) in &view.by_namespace {
+                let esc = claims.iter().filter(|c| c.escalated).count();
+                let flag = if esc > 0 { format!("  ⚠ {esc} escalated") } else { String::new() };
+                println!("    {:<24} {} claims{}", ns, claims.len(), flag);
+            }
+
+            print!("  by domain:   ");
+            for (d, n) in &view.by_domain {
+                print!("{d}={n}  ");
+            }
+            println!();
+
+            for c in &view.escalations {
                 println!(
-                    "    ⚠ ESCALATE \"{}\": verdict {} ({} sources, {} contradictions)",
-                    f.claim, f.verdict, f.source_count, f.contradiction_count
+                    "    ⚠ ESCALATE [{}] \"{}\": verdict {} ({} sources, {} contradictions)",
+                    c.namespace, c.claim, c.verdict, c.source_count, c.contradiction_count
                 );
             }
         }
-        Err(e) => eprintln!("fuse error: {e}"),
+        Err(e) => eprintln!("view error: {e}"),
     }
 }

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -17,15 +17,31 @@ fn main() {
     };
 
     println!("assumption graph for {dir}");
-    println!("  nodes:          {}", graph.node_count());
-    println!("  contradictions: {}", graph.contradictions().len());
-
+    println!("  nodes:                  {}", graph.node_count());
+    println!(
+        "  structural conflicts:   {}  (Phase 1: any opposing polarity)",
+        graph.contradictions().len()
+    );
     for c in graph.contradictions() {
-        println!(
-            "  ⚠ \"{}\": {} vs {}",
-            c.claim,
-            c.a_truth.as_str(),
-            c.b_truth.as_str()
-        );
+        println!("    ⚠ \"{}\": {} vs {}", c.claim, c.a_truth.as_str(), c.b_truth.as_str());
+    }
+
+    // Phase 2: independence-aware fused verdicts.
+    match graph.fuse() {
+        Ok(fused) => {
+            let escalated: Vec<_> = fused.iter().filter(|f| f.escalated).collect();
+            println!("  fused claims:           {}", fused.len());
+            println!(
+                "  escalated to C:         {}  (Phase 2: independent sources disagree)",
+                escalated.len()
+            );
+            for f in escalated {
+                println!(
+                    "    ⚠ ESCALATE \"{}\": verdict {} ({} sources, {} contradictions)",
+                    f.claim, f.verdict, f.source_count, f.contradiction_count
+                );
+            }
+        }
+        Err(e) => eprintln!("fuse error: {e}"),
     }
 }

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -1,0 +1,31 @@
+//! Build the assumption graph for a workspace and print a summary.
+//!
+//! Usage: `ix-assumption-graph-report [workspace_dir]` (defaults to ".").
+
+use std::path::PathBuf;
+
+use ix_assumption_graph::AssumptionGraph;
+
+fn main() {
+    let dir = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    let graph = match AssumptionGraph::from_workspace(&PathBuf::from(&dir)) {
+        Ok(g) => g,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    println!("assumption graph for {dir}");
+    println!("  nodes:          {}", graph.node_count());
+    println!("  contradictions: {}", graph.contradictions().len());
+
+    for c in graph.contradictions() {
+        println!(
+            "  ⚠ \"{}\": {} vs {}",
+            c.claim,
+            c.a_truth.as_str(),
+            c.b_truth.as_str()
+        );
+    }
+}

--- a/crates/ix-assumption-graph/src/fusion.rs
+++ b/crates/ix-assumption-graph/src/fusion.rs
@@ -1,0 +1,214 @@
+//! Phase 2 — per-claim evidence fusion via `ix-fuzzy`'s CRDT observation merge.
+//!
+//! Each assumption node becomes a [`HexObservation`]; nodes sharing a normalized
+//! claim are fused into a single verdict. This deliberately *reuses*
+//! [`ix_fuzzy::observations::merge_all`] (Belnap `C` synthesis, six proven CRDT
+//! obligations) rather than reimplementing fusion.
+//!
+//! The independence guard from contract §7.1 comes for free: `merge` only
+//! synthesizes a contradiction between **distinct sources**, so two annotations
+//! by the same author disagreeing about a claim do NOT escalate to `C` here
+//! (that self-inconsistency is still surfaced by Phase 1's structural
+//! [`crate::AssumptionGraph::contradictions`]). Phase 1 = "any opposing
+//! polarity"; Phase 2 = "independent sources disagree → escalate".
+
+use std::collections::BTreeMap;
+
+use ix_fuzzy::hexavalent::{escalation_triggered, hexavalent_argmax};
+use ix_fuzzy::observations::{merge_all, HexObservation};
+use ix_fuzzy::FuzzyError;
+use ix_types::Hexavalent;
+use serde::Serialize;
+
+use crate::graph::{normalize_claim, AssumptionGraph};
+use crate::opinion::to_hexavalent;
+
+/// The fused epistemic state of all assumptions sharing one normalized claim.
+#[derive(Debug, Clone, Serialize)]
+pub struct FusedClaim {
+    /// The claim text (from the first contributing node).
+    pub claim: String,
+    /// Tiebreak-aware argmax of the fused distribution (priority `C>U>D>P>T>F`).
+    pub verdict: Hexavalent,
+    /// Mass on the winning verdict, in `[0, 1]`.
+    pub confidence: f64,
+    /// `true` iff `C` mass exceeds the Demerzel escalation threshold (`0.3`).
+    pub escalated: bool,
+    /// Distinct sources (independence classes) contributing to this claim.
+    pub source_count: usize,
+    /// Synthesized cross-source contradictions on this claim.
+    pub contradiction_count: usize,
+}
+
+/// Floor applied to a node's confidence so a zero-confidence observation still
+/// registers its variant (and the group never degenerates to an empty merge).
+const WEIGHT_FLOOR: f64 = 1e-6;
+
+impl AssumptionGraph {
+    /// Fuse evidence per claim. Nodes are grouped by normalized claim (the same
+    /// key Phase 1 uses), each group merged via [`ix_fuzzy::observations`].
+    /// Returns one [`FusedClaim`] per distinct claim, in normalized-claim order.
+    pub fn fuse(&self) -> Result<Vec<FusedClaim>, FuzzyError> {
+        let mut groups: BTreeMap<String, Vec<&crate::node::AssumptionNode>> = BTreeMap::new();
+        for node in self.nodes() {
+            groups
+                .entry(normalize_claim(&node.claim))
+                .or_default()
+                .push(node);
+        }
+
+        let mut out = Vec::with_capacity(groups.len());
+        for (claim_key, nodes) in groups {
+            let observations: Vec<HexObservation> = nodes
+                .iter()
+                .enumerate()
+                .map(|(i, n)| HexObservation {
+                    source: n.source.author.clone(),
+                    diagnosis_id: n.id.clone(),
+                    round: 0,
+                    ordinal: i as u32,
+                    claim_key: claim_key.clone(),
+                    variant: to_hexavalent(n.truth_value),
+                    weight: n.confidence.max(WEIGHT_FLOOR),
+                    evidence: None,
+                })
+                .collect();
+
+            let merged = merge_all(&observations)?;
+            let verdict = hexavalent_argmax(&merged.distribution);
+
+            let mut sources: Vec<&str> = nodes.iter().map(|n| n.source.author.as_str()).collect();
+            sources.sort_unstable();
+            sources.dedup();
+
+            out.push(FusedClaim {
+                claim: nodes[0].claim.clone(),
+                verdict,
+                confidence: merged.distribution.get(&verdict),
+                escalated: escalation_triggered(&merged.distribution),
+                source_count: sources.len(),
+                contradiction_count: merged.contradictions.len(),
+            });
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::AssumptionGraph;
+    use ix_ai_annotations::types::annotation_id;
+    use ix_ai_annotations::{
+        Annotation, AnnotationKind, Certainty, Location, Source, TruthValue, SCHEMA_VERSION,
+    };
+    use ix_types::Hexavalent;
+
+    fn ann(
+        author: &str,
+        path: &str,
+        line: u32,
+        claim: &str,
+        tv: TruthValue,
+        conf: f64,
+    ) -> Annotation {
+        let kind = AnnotationKind::Assumption;
+        Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id(path, line, kind, claim),
+            kind,
+            claim: claim.to_string(),
+            truth_value: tv,
+            certainty: Certainty::Assumed,
+            confidence: conf,
+            source: Source {
+                author: author.to_string(),
+                model: None,
+                evidence: None,
+            },
+            location: Location {
+                path: path.to_string(),
+                line_start: line,
+                line_end: line,
+            },
+            created_at: "2026-05-31T00:00:00Z".to_string(),
+            updated_at: "2026-05-31T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        }
+    }
+
+    #[test]
+    fn single_source_single_claim_fuses_to_its_value() {
+        let g = AssumptionGraph::from_annotations(vec![ann(
+            "claude", "a.rs", 1, "buffer flushed", TruthValue::T, 0.9,
+        )])
+        .unwrap();
+        let fused = g.fuse().unwrap();
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].verdict, Hexavalent::True);
+        assert!(!fused[0].escalated);
+        assert_eq!(fused[0].source_count, 1);
+        assert_eq!(fused[0].contradiction_count, 0);
+    }
+
+    #[test]
+    fn cross_source_disagreement_escalates_to_contradictory() {
+        // Independent sources (claude vs sentrux) disagree on the same claim.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "lock held on entry", TruthValue::T, 1.0),
+            ann("sentrux", "b.rs", 2, "lock held on entry", TruthValue::F, 1.0),
+        ])
+        .unwrap();
+        let fused = g.fuse().unwrap();
+        assert_eq!(fused.len(), 1);
+        assert_eq!(fused[0].verdict, Hexavalent::Contradictory);
+        assert!(fused[0].escalated);
+        assert_eq!(fused[0].source_count, 2);
+        assert!(fused[0].contradiction_count >= 1);
+    }
+
+    #[test]
+    fn same_source_disagreement_does_not_escalate() {
+        // §7.1 independence guard: one author contradicting itself is NOT a
+        // cross-source contradiction — no C synthesis, no escalation.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "leak free", TruthValue::T, 1.0),
+            ann("claude", "b.rs", 2, "leak free", TruthValue::F, 1.0),
+        ])
+        .unwrap();
+        let fused = g.fuse().unwrap();
+        assert_eq!(fused.len(), 1);
+        assert!(!fused[0].escalated);
+        assert_eq!(fused[0].contradiction_count, 0);
+    }
+
+    #[test]
+    fn cross_source_agreement_does_not_escalate() {
+        // claude T + human P — both lean true. No contradiction.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "sorted ascending", TruthValue::T, 0.9),
+            ann("human", "b.rs", 2, "sorted ascending", TruthValue::P, 0.7),
+        ])
+        .unwrap();
+        let fused = g.fuse().unwrap();
+        assert_eq!(fused.len(), 1);
+        assert!(!fused[0].escalated);
+        assert_eq!(fused[0].contradiction_count, 0);
+        assert!(matches!(
+            fused[0].verdict,
+            Hexavalent::True | Hexavalent::Probable
+        ));
+        assert_eq!(fused[0].source_count, 2);
+    }
+
+    #[test]
+    fn distinct_claims_fuse_independently() {
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "claim one", TruthValue::T, 0.9),
+            ann("claude", "b.rs", 2, "claim two", TruthValue::F, 0.9),
+        ])
+        .unwrap();
+        let fused = g.fuse().unwrap();
+        assert_eq!(fused.len(), 2);
+    }
+}

--- a/crates/ix-assumption-graph/src/fusion.rs
+++ b/crates/ix-assumption-graph/src/fusion.rs
@@ -149,7 +149,12 @@ mod tests {
     #[test]
     fn single_source_single_claim_fuses_to_its_value() {
         let g = AssumptionGraph::from_annotations(vec![ann(
-            "claude", "a.rs", 1, "buffer flushed", TruthValue::T, 0.9,
+            "claude",
+            "a.rs",
+            1,
+            "buffer flushed",
+            TruthValue::T,
+            0.9,
         )])
         .unwrap();
         let fused = g.fuse().unwrap();
@@ -164,8 +169,22 @@ mod tests {
     fn cross_source_disagreement_escalates_to_contradictory() {
         // Independent sources (claude vs sentrux) disagree on the same claim.
         let g = AssumptionGraph::from_annotations(vec![
-            ann("claude", "a.rs", 1, "lock held on entry", TruthValue::T, 1.0),
-            ann("sentrux", "b.rs", 2, "lock held on entry", TruthValue::F, 1.0),
+            ann(
+                "claude",
+                "a.rs",
+                1,
+                "lock held on entry",
+                TruthValue::T,
+                1.0,
+            ),
+            ann(
+                "sentrux",
+                "b.rs",
+                2,
+                "lock held on entry",
+                TruthValue::F,
+                1.0,
+            ),
         ])
         .unwrap();
         let fused = g.fuse().unwrap();

--- a/crates/ix-assumption-graph/src/fusion.rs
+++ b/crates/ix-assumption-graph/src/fusion.rs
@@ -75,7 +75,16 @@ impl AssumptionGraph {
                 .collect();
 
             let merged = merge_all(&observations)?;
-            let verdict = hexavalent_argmax(&merged.distribution);
+            let escalated = escalation_triggered(&merged.distribution);
+            // §7.2 discipline: an active contradiction (C above the escalation
+            // threshold) IS the verdict — a higher-confidence dissenting source
+            // must not let the argmax paper over it. Otherwise the tiebreak-aware
+            // argmax wins.
+            let verdict = if escalated {
+                Hexavalent::Contradictory
+            } else {
+                hexavalent_argmax(&merged.distribution)
+            };
 
             let mut sources: Vec<&str> = nodes.iter().map(|n| n.source.author.as_str()).collect();
             sources.sort_unstable();
@@ -85,7 +94,7 @@ impl AssumptionGraph {
                 claim: nodes[0].claim.clone(),
                 verdict,
                 confidence: merged.distribution.get(&verdict),
-                escalated: escalation_triggered(&merged.distribution),
+                escalated,
                 source_count: sources.len(),
                 contradiction_count: merged.contradictions.len(),
             });

--- a/crates/ix-assumption-graph/src/graph.rs
+++ b/crates/ix-assumption-graph/src/graph.rs
@@ -69,7 +69,10 @@ impl AssumptionGraph {
             dag.add_node(id, node)?;
         }
         let contradictions = derive_contradictions(&dag);
-        Ok(Self { dag, contradictions })
+        Ok(Self {
+            dag,
+            contradictions,
+        })
     }
 
     /// Walk a workspace, extract `@ai:` annotations, and build the graph.
@@ -123,7 +126,11 @@ pub fn conflicts(a: TruthValue, b: TruthValue) -> bool {
 
 /// Collapse whitespace and case so trivially-different claim spellings group together.
 pub(crate) fn normalize_claim(claim: &str) -> String {
-    claim.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+    claim
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 fn derive_contradictions(dag: &Dag<AssumptionNode>) -> Vec<Contradiction> {
@@ -208,9 +215,30 @@ mod tests {
     #[test]
     fn builds_one_node_per_distinct_annotation() {
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Invariant, "arr is sorted", TruthValue::T, 0.95),
-            ann("b.rs", 2, AnnotationKind::Assumption, "caller holds lock", TruthValue::P, 0.7),
-            ann("c.rs", 3, AnnotationKind::Hypothesis, "race-free", TruthValue::U, 0.4),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Invariant,
+                "arr is sorted",
+                TruthValue::T,
+                0.95,
+            ),
+            ann(
+                "b.rs",
+                2,
+                AnnotationKind::Assumption,
+                "caller holds lock",
+                TruthValue::P,
+                0.7,
+            ),
+            ann(
+                "c.rs",
+                3,
+                AnnotationKind::Hypothesis,
+                "race-free",
+                TruthValue::U,
+                0.4,
+            ),
         ])
         .unwrap();
         assert_eq!(g.node_count(), 3);
@@ -220,8 +248,22 @@ mod tests {
     #[test]
     fn detects_contradiction_on_opposing_polarity() {
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Invariant, "buffer is flushed", TruthValue::T, 0.9),
-            ann("b.rs", 9, AnnotationKind::Invariant, "buffer is flushed", TruthValue::F, 0.8),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Invariant,
+                "buffer is flushed",
+                TruthValue::T,
+                0.9,
+            ),
+            ann(
+                "b.rs",
+                9,
+                AnnotationKind::Invariant,
+                "buffer is flushed",
+                TruthValue::F,
+                0.8,
+            ),
         ])
         .unwrap();
         assert_eq!(g.node_count(), 2);
@@ -237,8 +279,22 @@ mod tests {
     fn normalizes_claim_spelling_before_grouping() {
         // Different whitespace/case, same claim — must still group + contradict.
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Assumption, "Caller   holds the Lock", TruthValue::P, 0.7),
-            ann("b.rs", 2, AnnotationKind::Assumption, "caller holds the lock", TruthValue::D, 0.6),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Assumption,
+                "Caller   holds the Lock",
+                TruthValue::P,
+                0.7,
+            ),
+            ann(
+                "b.rs",
+                2,
+                AnnotationKind::Assumption,
+                "caller holds the lock",
+                TruthValue::D,
+                0.6,
+            ),
         ])
         .unwrap();
         assert_eq!(g.contradictions().len(), 1);
@@ -247,8 +303,22 @@ mod tests {
     #[test]
     fn same_polarity_is_not_a_contradiction() {
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Invariant, "x positive", TruthValue::T, 0.9),
-            ann("b.rs", 2, AnnotationKind::Invariant, "x positive", TruthValue::P, 0.7),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Invariant,
+                "x positive",
+                TruthValue::T,
+                0.9,
+            ),
+            ann(
+                "b.rs",
+                2,
+                AnnotationKind::Invariant,
+                "x positive",
+                TruthValue::P,
+                0.7,
+            ),
         ])
         .unwrap();
         assert!(g.contradictions().is_empty());
@@ -258,8 +328,22 @@ mod tests {
     fn unknown_does_not_contradict_false() {
         // U is neutral — no evidential direction, so no conflict with F.
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Hypothesis, "leak free", TruthValue::U, 0.4),
-            ann("b.rs", 2, AnnotationKind::Hypothesis, "leak free", TruthValue::F, 0.8),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Hypothesis,
+                "leak free",
+                TruthValue::U,
+                0.4,
+            ),
+            ann(
+                "b.rs",
+                2,
+                AnnotationKind::Hypothesis,
+                "leak free",
+                TruthValue::F,
+                0.8,
+            ),
         ])
         .unwrap();
         assert!(g.contradictions().is_empty());
@@ -269,8 +353,22 @@ mod tests {
     fn duplicate_id_is_deduped() {
         // Same path:line:kind:claim ⇒ same id ⇒ one node.
         let g = AssumptionGraph::from_annotations(vec![
-            ann("a.rs", 1, AnnotationKind::Invariant, "sorted", TruthValue::T, 0.9),
-            ann("a.rs", 1, AnnotationKind::Invariant, "sorted", TruthValue::T, 0.9),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Invariant,
+                "sorted",
+                TruthValue::T,
+                0.9,
+            ),
+            ann(
+                "a.rs",
+                1,
+                AnnotationKind::Invariant,
+                "sorted",
+                TruthValue::T,
+                0.9,
+            ),
         ])
         .unwrap();
         assert_eq!(g.node_count(), 1);

--- a/crates/ix-assumption-graph/src/graph.rs
+++ b/crates/ix-assumption-graph/src/graph.rs
@@ -100,7 +100,7 @@ pub fn conflicts(a: TruthValue, b: TruthValue) -> bool {
 }
 
 /// Collapse whitespace and case so trivially-different claim spellings group together.
-fn normalize_claim(claim: &str) -> String {
+pub(crate) fn normalize_claim(claim: &str) -> String {
     claim.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
 }
 

--- a/crates/ix-assumption-graph/src/graph.rs
+++ b/crates/ix-assumption-graph/src/graph.rs
@@ -8,7 +8,7 @@ use ix_ai_annotations::{Annotation, TruthValue};
 use ix_pipeline::dag::Dag;
 use serde::Serialize;
 
-use crate::node::{polarity, AssumptionNode, Polarity};
+use crate::node::{polarity, AssumptionNode, Polarity, ResearchClaim};
 
 /// Errors raised while building the graph.
 #[derive(Debug, thiserror::Error)]
@@ -38,12 +38,30 @@ pub struct AssumptionGraph {
 }
 
 impl AssumptionGraph {
-    /// Build from a list of annotations. Duplicate ids (same
-    /// `path:line:kind:claim`) are de-duplicated — first occurrence wins.
+    /// Build from a list of annotations (each promoted to a node).
     pub fn from_annotations(annotations: Vec<Annotation>) -> Result<Self, BuildError> {
+        Self::build(annotations.into_iter().map(AssumptionNode::from).collect())
+    }
+
+    /// Build the **unified** graph from both dev annotations AND research
+    /// claims. A research claim sharing a normalized claim with a dev
+    /// annotation participates in fusion exactly like any other source — so a
+    /// `/deep-research` finding that contradicts a code assumption escalates.
+    pub fn from_parts(
+        annotations: Vec<Annotation>,
+        research: Vec<ResearchClaim>,
+    ) -> Result<Self, BuildError> {
+        let mut nodes: Vec<AssumptionNode> =
+            annotations.into_iter().map(AssumptionNode::from).collect();
+        nodes.extend(research.into_iter().map(AssumptionNode::from));
+        Self::build(nodes)
+    }
+
+    /// Core builder: de-duplicates nodes by id (first occurrence wins), then
+    /// derives contradictions.
+    fn build(nodes: Vec<AssumptionNode>) -> Result<Self, BuildError> {
         let mut dag: Dag<AssumptionNode> = Dag::new();
-        for ann in annotations {
-            let node: AssumptionNode = ann.into();
+        for node in nodes {
             if dag.get(&node.id).is_some() {
                 continue;
             }
@@ -51,16 +69,20 @@ impl AssumptionGraph {
             dag.add_node(id, node)?;
         }
         let contradictions = derive_contradictions(&dag);
-        Ok(Self {
-            dag,
-            contradictions,
-        })
+        Ok(Self { dag, contradictions })
     }
 
     /// Walk a workspace, extract `@ai:` annotations, and build the graph.
     pub fn from_workspace(workspace: &Path) -> Result<Self, BuildError> {
-        let annotations = ix_ai_annotations::extract_workspace(workspace)?;
-        Self::from_annotations(annotations)
+        Self::from_parts(ix_ai_annotations::extract_workspace(workspace)?, Vec::new())
+    }
+
+    /// Walk a workspace and combine its `@ai:` annotations with research claims.
+    pub fn from_workspace_with_research(
+        workspace: &Path,
+        research: Vec<ResearchClaim>,
+    ) -> Result<Self, BuildError> {
+        Self::from_parts(ix_ai_annotations::extract_workspace(workspace)?, research)
     }
 
     /// Number of assumption nodes.
@@ -252,6 +274,43 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(g.node_count(), 1);
+    }
+
+    #[test]
+    fn research_claim_contradicting_a_dev_assumption_escalates() {
+        use crate::node::ResearchClaim;
+        use ix_types::Hexavalent;
+
+        // A code assumption says latency is under budget (T); a /deep-research
+        // finding refutes it (F). Distinct sources ⇒ fusion escalates to C.
+        // graph-test `ann` hardcodes author "claude".
+        let annotations = vec![ann(
+            "perf.rs",
+            10,
+            AnnotationKind::Invariant,
+            "p99 latency under 5ms",
+            TruthValue::T,
+            0.9,
+        )];
+        let research = vec![ResearchClaim {
+            claim: "p99 latency under 5ms".to_string(),
+            truth_value: TruthValue::F,
+            confidence: 0.85,
+            source: "deep-research".to_string(),
+            evidence: Some("bench-2026-05".to_string()),
+        }];
+
+        let g = AssumptionGraph::from_parts(annotations, research).unwrap();
+        assert_eq!(g.node_count(), 2);
+
+        let fused = g.fuse().unwrap();
+        let latency = fused
+            .iter()
+            .find(|f| f.claim.to_lowercase().contains("latency"))
+            .expect("latency claim present");
+        assert_eq!(latency.verdict, Hexavalent::Contradictory);
+        assert!(latency.escalated);
+        assert_eq!(latency.source_count, 2);
     }
 
     #[test]

--- a/crates/ix-assumption-graph/src/graph.rs
+++ b/crates/ix-assumption-graph/src/graph.rs
@@ -1,0 +1,272 @@
+//! Builds a `Dag<AssumptionNode>` from `@ai:` annotations and derives
+//! `contradicts` relations from opposing hexavalent truth values.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use ix_ai_annotations::{Annotation, TruthValue};
+use ix_pipeline::dag::Dag;
+use serde::Serialize;
+
+use crate::node::{polarity, AssumptionNode, Polarity};
+
+/// Errors raised while building the graph.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildError {
+    #[error("annotation extraction failed: {0}")]
+    Extract(#[from] ix_ai_annotations::Error),
+    #[error("dag construction failed: {0}")]
+    Dag(#[from] ix_pipeline::dag::DagError),
+}
+
+/// A derived contradiction: two nodes asserting opposing polarity about the
+/// same (normalized) claim. Stored outside the DAG because `contradicts` is
+/// symmetric and may cycle. `a`/`b` are ordered by id for deterministic output.
+#[derive(Debug, Clone, Serialize)]
+pub struct Contradiction {
+    pub a: String,
+    pub b: String,
+    pub claim: String,
+    pub a_truth: TruthValue,
+    pub b_truth: TruthValue,
+}
+
+/// A graph of assumptions plus the contradictions derived from them.
+pub struct AssumptionGraph {
+    dag: Dag<AssumptionNode>,
+    contradictions: Vec<Contradiction>,
+}
+
+impl AssumptionGraph {
+    /// Build from a list of annotations. Duplicate ids (same
+    /// `path:line:kind:claim`) are de-duplicated — first occurrence wins.
+    pub fn from_annotations(annotations: Vec<Annotation>) -> Result<Self, BuildError> {
+        let mut dag: Dag<AssumptionNode> = Dag::new();
+        for ann in annotations {
+            let node: AssumptionNode = ann.into();
+            if dag.get(&node.id).is_some() {
+                continue;
+            }
+            let id = node.id.clone();
+            dag.add_node(id, node)?;
+        }
+        let contradictions = derive_contradictions(&dag);
+        Ok(Self {
+            dag,
+            contradictions,
+        })
+    }
+
+    /// Walk a workspace, extract `@ai:` annotations, and build the graph.
+    pub fn from_workspace(workspace: &Path) -> Result<Self, BuildError> {
+        let annotations = ix_ai_annotations::extract_workspace(workspace)?;
+        Self::from_annotations(annotations)
+    }
+
+    /// Number of assumption nodes.
+    pub fn node_count(&self) -> usize {
+        self.dag.node_count()
+    }
+
+    /// Look up a node by id.
+    pub fn get(&self, id: &str) -> Option<&AssumptionNode> {
+        self.dag.get(id)
+    }
+
+    /// The derived contradictions, in deterministic order.
+    pub fn contradictions(&self) -> &[Contradiction] {
+        &self.contradictions
+    }
+
+    /// The underlying node container (for future acyclic edges / traversal).
+    pub fn dag(&self) -> &Dag<AssumptionNode> {
+        &self.dag
+    }
+
+    /// Iterate nodes in insertion order.
+    pub fn nodes(&self) -> impl Iterator<Item = &AssumptionNode> {
+        self.dag.node_ids().iter().filter_map(|id| self.dag.get(id))
+    }
+}
+
+/// Two truth values conflict iff one leans true and the other leans false.
+///
+// @ai:invariant conflicts() is symmetric: conflicts(a,b) == conflicts(b,a) [T:test conf:0.95 src:graph.rs::tests::conflicts_is_symmetric]
+pub fn conflicts(a: TruthValue, b: TruthValue) -> bool {
+    matches!(
+        (polarity(a), polarity(b)),
+        (Polarity::Positive, Polarity::Negative) | (Polarity::Negative, Polarity::Positive)
+    )
+}
+
+/// Collapse whitespace and case so trivially-different claim spellings group together.
+fn normalize_claim(claim: &str) -> String {
+    claim.split_whitespace().collect::<Vec<_>>().join(" ").to_lowercase()
+}
+
+fn derive_contradictions(dag: &Dag<AssumptionNode>) -> Vec<Contradiction> {
+    // Group node ids by normalized claim.
+    let mut by_claim: HashMap<String, Vec<&str>> = HashMap::new();
+    for id in dag.node_ids() {
+        if let Some(node) = dag.get(id) {
+            by_claim
+                .entry(normalize_claim(&node.claim))
+                .or_default()
+                .push(id.as_str());
+        }
+    }
+
+    let mut out = Vec::new();
+    for ids in by_claim.values() {
+        for (i, &id_a) in ids.iter().enumerate() {
+            for &id_b in &ids[i + 1..] {
+                let (na, nb) = (dag.get(id_a).unwrap(), dag.get(id_b).unwrap());
+                if conflicts(na.truth_value, nb.truth_value) {
+                    // Canonical order: smaller id first.
+                    let (lo, hi) = if na.id <= nb.id { (na, nb) } else { (nb, na) };
+                    out.push(Contradiction {
+                        a: lo.id.clone(),
+                        b: hi.id.clone(),
+                        claim: lo.claim.clone(),
+                        a_truth: lo.truth_value,
+                        b_truth: hi.truth_value,
+                    });
+                }
+            }
+        }
+    }
+    // Deterministic regardless of HashMap iteration order.
+    out.sort_by(|x, y| (&x.a, &x.b).cmp(&(&y.a, &y.b)));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ix_ai_annotations::types::annotation_id;
+    use ix_ai_annotations::{
+        Annotation, AnnotationKind, Certainty, Location, Source, TruthValue, SCHEMA_VERSION,
+    };
+
+    /// Build an annotation with a realistic wire shape (matches what the
+    /// extractor actually emits — see feedback on real-data-shape tests).
+    fn ann(
+        path: &str,
+        line: u32,
+        kind: AnnotationKind,
+        claim: &str,
+        tv: TruthValue,
+        conf: f64,
+    ) -> Annotation {
+        Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id(path, line, kind, claim),
+            kind,
+            claim: claim.to_string(),
+            truth_value: tv,
+            certainty: Certainty::Assumed,
+            confidence: conf,
+            source: Source {
+                author: "claude".to_string(),
+                model: Some("claude-opus-4-8".to_string()),
+                evidence: None,
+            },
+            location: Location {
+                path: path.to_string(),
+                line_start: line,
+                line_end: line,
+            },
+            created_at: "2026-05-31T00:00:00Z".to_string(),
+            updated_at: "2026-05-31T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        }
+    }
+
+    #[test]
+    fn builds_one_node_per_distinct_annotation() {
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Invariant, "arr is sorted", TruthValue::T, 0.95),
+            ann("b.rs", 2, AnnotationKind::Assumption, "caller holds lock", TruthValue::P, 0.7),
+            ann("c.rs", 3, AnnotationKind::Hypothesis, "race-free", TruthValue::U, 0.4),
+        ])
+        .unwrap();
+        assert_eq!(g.node_count(), 3);
+        assert!(g.contradictions().is_empty());
+    }
+
+    #[test]
+    fn detects_contradiction_on_opposing_polarity() {
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Invariant, "buffer is flushed", TruthValue::T, 0.9),
+            ann("b.rs", 9, AnnotationKind::Invariant, "buffer is flushed", TruthValue::F, 0.8),
+        ])
+        .unwrap();
+        assert_eq!(g.node_count(), 2);
+        let c = g.contradictions();
+        assert_eq!(c.len(), 1);
+        assert_eq!(c[0].claim, "buffer is flushed");
+        // a/b ordered by id; truths are the opposing pair {T, F}.
+        let truths = [c[0].a_truth, c[0].b_truth];
+        assert!(truths.contains(&TruthValue::T) && truths.contains(&TruthValue::F));
+    }
+
+    #[test]
+    fn normalizes_claim_spelling_before_grouping() {
+        // Different whitespace/case, same claim — must still group + contradict.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Assumption, "Caller   holds the Lock", TruthValue::P, 0.7),
+            ann("b.rs", 2, AnnotationKind::Assumption, "caller holds the lock", TruthValue::D, 0.6),
+        ])
+        .unwrap();
+        assert_eq!(g.contradictions().len(), 1);
+    }
+
+    #[test]
+    fn same_polarity_is_not_a_contradiction() {
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Invariant, "x positive", TruthValue::T, 0.9),
+            ann("b.rs", 2, AnnotationKind::Invariant, "x positive", TruthValue::P, 0.7),
+        ])
+        .unwrap();
+        assert!(g.contradictions().is_empty());
+    }
+
+    #[test]
+    fn unknown_does_not_contradict_false() {
+        // U is neutral — no evidential direction, so no conflict with F.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Hypothesis, "leak free", TruthValue::U, 0.4),
+            ann("b.rs", 2, AnnotationKind::Hypothesis, "leak free", TruthValue::F, 0.8),
+        ])
+        .unwrap();
+        assert!(g.contradictions().is_empty());
+    }
+
+    #[test]
+    fn duplicate_id_is_deduped() {
+        // Same path:line:kind:claim ⇒ same id ⇒ one node.
+        let g = AssumptionGraph::from_annotations(vec![
+            ann("a.rs", 1, AnnotationKind::Invariant, "sorted", TruthValue::T, 0.9),
+            ann("a.rs", 1, AnnotationKind::Invariant, "sorted", TruthValue::T, 0.9),
+        ])
+        .unwrap();
+        assert_eq!(g.node_count(), 1);
+    }
+
+    #[test]
+    fn conflicts_is_symmetric() {
+        use TruthValue::*;
+        for &a in &[T, P, U, D, F, C] {
+            for &b in &[T, P, U, D, F, C] {
+                assert_eq!(conflicts(a, b), conflicts(b, a), "asymmetry at {a:?},{b:?}");
+            }
+        }
+        // Spot-check the truth table.
+        assert!(conflicts(T, F));
+        assert!(conflicts(P, D));
+        assert!(!conflicts(T, P));
+        assert!(!conflicts(U, F));
+        assert!(!conflicts(C, T)); // C is flagged at source, not re-derived pairwise
+    }
+}

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -22,11 +22,13 @@ pub mod fusion;
 pub mod graph;
 pub mod node;
 pub mod opinion;
+pub mod temporal;
 
 pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
 pub use node::{polarity, AssumptionNode, Polarity};
 pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
+pub use temporal::{claim_id, BeliefChange, BeliefEvent, BeliefLog, BeliefSnapshot};
 
 // Re-export the reused vocabulary so consumers don't need direct dependencies
 // on ix-ai-annotations / ix-types for the common case.

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -26,7 +26,7 @@ pub mod temporal;
 
 pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
-pub use node::{polarity, AssumptionNode, Polarity};
+pub use node::{polarity, AssumptionNode, Polarity, ResearchClaim};
 pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
 pub use temporal::{claim_id, BeliefChange, BeliefEvent, BeliefLog, BeliefSnapshot};
 

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -1,0 +1,29 @@
+//! Temporal assumption graph — Phase 1.
+//!
+//! Composes existing IX primitives into a graph of *assumptions*:
+//!
+//! - **nodes** come from [`ix_ai_annotations`] (`@ai:invariant`, `@ai:assumption`,
+//!   `@ai:hypothesis`, …) — each already carries a hexavalent truth value
+//!   (T/P/U/D/F/C) and certainty, so ingest is free;
+//! - the node container is [`ix_pipeline::dag::Dag`] (cycle-checked), holding the
+//!   acyclic structure (`depends_on` / `refined_from` edges arrive in a later phase);
+//! - **contradictions** are derived structurally — two nodes asserting *opposing
+//!   polarity* about the same claim (one leans true, the other leans false). This
+//!   is the reconciler's `C`-promotion signal, surfaced as a relation.
+//!
+//! Contradictions are deliberately stored *outside* the [`Dag`] because the
+//! `contradicts` relation is symmetric and may form cycles, which the DAG forbids.
+//! Acceptability semantics over this relation (ABA dispute derivations), the
+//! subjective-logic `opinion`, the `belief_time` axis, and JSONL persistence are
+//! defined in `docs/contracts/2026-05-31-assumption-graph.contract.md` and land in
+//! Phase 2/3 — this crate is the substrate they build on.
+
+pub mod graph;
+pub mod node;
+
+pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
+pub use node::{polarity, AssumptionNode, Polarity};
+
+// Re-export the reused annotation vocabulary so consumers don't need a direct
+// dependency on ix-ai-annotations for the common case.
+pub use ix_ai_annotations::{AnnotationKind, Certainty, Location, Source, TruthValue};

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -23,12 +23,14 @@ pub mod graph;
 pub mod node;
 pub mod opinion;
 pub mod temporal;
+pub mod view;
 
 pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
-pub use node::{polarity, AssumptionNode, Polarity, ResearchClaim};
+pub use node::{polarity, AssumptionNode, NodeCertainty, NodeKind, Polarity, ResearchClaim};
 pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
 pub use temporal::{claim_id, BeliefChange, BeliefEvent, BeliefLog, BeliefSnapshot};
+pub use view::{namespace_of, ClaimView, FacetedView};
 
 // Re-export the reused vocabulary so consumers don't need direct dependencies
 // on ix-ai-annotations / ix-types for the common case.

--- a/crates/ix-assumption-graph/src/lib.rs
+++ b/crates/ix-assumption-graph/src/lib.rs
@@ -18,12 +18,17 @@
 //! defined in `docs/contracts/2026-05-31-assumption-graph.contract.md` and land in
 //! Phase 2/3 — this crate is the substrate they build on.
 
+pub mod fusion;
 pub mod graph;
 pub mod node;
+pub mod opinion;
 
+pub use fusion::FusedClaim;
 pub use graph::{conflicts, AssumptionGraph, BuildError, Contradiction};
 pub use node::{polarity, AssumptionNode, Polarity};
+pub use opinion::{from_hexavalent, to_hexavalent, Opinion, DEFAULT_BASE_RATE};
 
-// Re-export the reused annotation vocabulary so consumers don't need a direct
-// dependency on ix-ai-annotations for the common case.
+// Re-export the reused vocabulary so consumers don't need direct dependencies
+// on ix-ai-annotations / ix-types for the common case.
 pub use ix_ai_annotations::{AnnotationKind, Certainty, Location, Source, TruthValue};
+pub use ix_types::Hexavalent;

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -1,0 +1,67 @@
+//! The assumption-graph node — a superset of an `@ai:` annotation.
+
+use ix_ai_annotations::{Annotation, AnnotationKind, Certainty, Location, Source, TruthValue};
+use serde::{Deserialize, Serialize};
+
+/// A node in the temporal assumption graph.
+///
+/// Phase 1 carries exactly the epistemic state an `@ai:` annotation already
+/// provides — no new epistemics. The subjective-logic `opinion`, the
+/// `belief_time` axis, and the JSONL wire form defined in
+/// `docs/contracts/2026-05-31-assumption-graph.contract.md` arrive in Phase 2/3.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AssumptionNode {
+    /// Deterministic SHA-256 id, identical to the source annotation's id
+    /// (`sha256:…` over `path:line_start:kind:claim`) so an annotation and its
+    /// graph node share identity.
+    pub id: String,
+    pub kind: AnnotationKind,
+    pub claim: String,
+    pub truth_value: TruthValue,
+    pub certainty: Certainty,
+    pub confidence: f64,
+    pub source: Source,
+    /// Present for code-anchored assumptions; `None` for research claims (Phase 3).
+    pub location: Option<Location>,
+}
+
+impl From<Annotation> for AssumptionNode {
+    fn from(a: Annotation) -> Self {
+        Self {
+            id: a.id,
+            kind: a.kind,
+            claim: a.claim,
+            truth_value: a.truth_value,
+            certainty: a.certainty,
+            confidence: a.confidence,
+            source: a.source,
+            location: Some(a.location),
+        }
+    }
+}
+
+/// Evidential polarity of a hexavalent truth value — the axis along which two
+/// claims about the same thing can contradict.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    /// Leans true: `T` (True) or `P` (Probable).
+    Positive,
+    /// Leans false: `D` (Doubtful) or `F` (False).
+    Negative,
+    /// No evidential direction: `U` (Unknown).
+    Neutral,
+    /// Already contradictory: `C` — flagged at the source, not re-derived pairwise.
+    Contradictory,
+}
+
+/// Map a hexavalent truth value to its evidential polarity.
+///
+// @ai:invariant every TruthValue maps to exactly one Polarity (total match) [T:formal-proof conf:0.95 src:exhaustive match, compiler-checked]
+pub fn polarity(tv: TruthValue) -> Polarity {
+    match tv {
+        TruthValue::T | TruthValue::P => Polarity::Positive,
+        TruthValue::D | TruthValue::F => Polarity::Negative,
+        TruthValue::U => Polarity::Neutral,
+        TruthValue::C => Polarity::Contradictory,
+    }
+}

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -2,6 +2,7 @@
 
 use ix_ai_annotations::{Annotation, AnnotationKind, Certainty, Location, Source, TruthValue};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 /// A node in the temporal assumption graph.
 ///
@@ -40,6 +41,77 @@ impl From<Annotation> for AssumptionNode {
     }
 }
 
+impl AssumptionNode {
+    /// Build a research-claim node (no code location) — e.g. a verified finding
+    /// from a `/deep-research` run.
+    ///
+    /// NOTE: the reused annotation vocabulary ([`AnnotationKind`]) has no
+    /// dedicated `research-claim` variant, so a research claim is represented as
+    /// a [`AnnotationKind::Hypothesis`] with `certainty = Inferred`; the
+    /// originating run is identified by `source.author` (conventionally
+    /// `"deep-research"`). Splitting the node enums from the annotation enums —
+    /// so the contract's `research-claim` kind and `adversarial-panel` certainty
+    /// become first-class — is a Phase 4 item. Id is `sha256` over
+    /// `research:<author>:<normalized claim>` per the contract.
+    pub fn research_claim(
+        claim: impl Into<String>,
+        truth_value: TruthValue,
+        confidence: f64,
+        source_author: impl Into<String>,
+        evidence: Option<String>,
+    ) -> Self {
+        let claim = claim.into();
+        let author = source_author.into();
+        let key = format!("research:{}:{}", author, crate::graph::normalize_claim(&claim));
+        let id = format!("sha256:{:x}", Sha256::digest(key.as_bytes()));
+        Self {
+            id,
+            kind: AnnotationKind::Hypothesis,
+            claim,
+            truth_value,
+            certainty: Certainty::Inferred,
+            confidence,
+            source: Source {
+                author,
+                model: None,
+                evidence,
+            },
+            location: None,
+        }
+    }
+
+    /// `true` iff this node originated from a research run (`source.author`
+    /// is `"deep-research"`), as opposed to a code-anchored `@ai:` annotation.
+    pub fn is_research_claim(&self) -> bool {
+        self.source.author == "deep-research"
+    }
+}
+
+/// A research-domain claim in the small JSON shape the loop runner ingests.
+/// The truth-value/confidence *judgment* (mapping a verified finding to a
+/// hexavalent value) is the adapter's job — see the `assumption-graph-loop`
+/// skill — so this crate stays unopinionated about `/deep-research`'s output.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResearchClaim {
+    pub claim: String,
+    pub truth_value: TruthValue,
+    pub confidence: f64,
+    #[serde(default = "default_research_source")]
+    pub source: String,
+    #[serde(default)]
+    pub evidence: Option<String>,
+}
+
+fn default_research_source() -> String {
+    "deep-research".to_string()
+}
+
+impl From<ResearchClaim> for AssumptionNode {
+    fn from(r: ResearchClaim) -> Self {
+        AssumptionNode::research_claim(r.claim, r.truth_value, r.confidence, r.source, r.evidence)
+    }
+}
+
 /// Evidential polarity of a hexavalent truth value — the axis along which two
 /// claims about the same thing can contradict.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -63,5 +135,51 @@ pub fn polarity(tv: TruthValue) -> Polarity {
         TruthValue::D | TruthValue::F => Polarity::Negative,
         TruthValue::U => Polarity::Neutral,
         TruthValue::C => Polarity::Contradictory,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn research_claim_id_is_stable_and_claim_normalized() {
+        let a = AssumptionNode::research_claim("Latency  under 5ms", TruthValue::P, 0.8, "deep-research", None);
+        let b = AssumptionNode::research_claim("latency under 5ms", TruthValue::P, 0.8, "deep-research", None);
+        assert_eq!(a.id, b.id, "normalized claim ⇒ same id");
+        assert!(a.id.starts_with("sha256:"));
+        assert!(a.location.is_none());
+        assert_eq!(a.kind, AnnotationKind::Hypothesis);
+        assert!(a.is_research_claim());
+    }
+
+    #[test]
+    fn different_source_gives_different_id() {
+        let a = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "deep-research", None);
+        let b = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "manual-review", None);
+        assert_ne!(a.id, b.id);
+    }
+
+    #[test]
+    fn research_claim_from_struct_carries_fields() {
+        let r = ResearchClaim {
+            claim: "buffer is flushed".to_string(),
+            truth_value: TruthValue::F,
+            confidence: 0.7,
+            source: "deep-research".to_string(),
+            evidence: Some("arxiv:2510.11822".to_string()),
+        };
+        let n: AssumptionNode = r.into();
+        assert_eq!(n.truth_value, TruthValue::F);
+        assert_eq!(n.source.author, "deep-research");
+        assert_eq!(n.source.evidence.as_deref(), Some("arxiv:2510.11822"));
+    }
+
+    #[test]
+    fn research_claim_json_defaults_source() {
+        let r: ResearchClaim =
+            serde_json::from_str(r#"{"claim":"x","truth_value":"P","confidence":0.6}"#).unwrap();
+        assert_eq!(r.source, "deep-research");
+        assert!(r.evidence.is_none());
     }
 }

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -137,7 +137,11 @@ impl AssumptionNode {
     ) -> Self {
         let claim = claim.into();
         let author = source_author.into();
-        let key = format!("research:{}:{}", author, crate::graph::normalize_claim(&claim));
+        let key = format!(
+            "research:{}:{}",
+            author,
+            crate::graph::normalize_claim(&claim)
+        );
         let id = format!("sha256:{:x}", Sha256::digest(key.as_bytes()));
         Self {
             id,
@@ -227,8 +231,20 @@ mod tests {
 
     #[test]
     fn research_claim_id_is_stable_and_claim_normalized() {
-        let a = AssumptionNode::research_claim("Latency  under 5ms", TruthValue::P, 0.8, "deep-research", None);
-        let b = AssumptionNode::research_claim("latency under 5ms", TruthValue::P, 0.8, "deep-research", None);
+        let a = AssumptionNode::research_claim(
+            "Latency  under 5ms",
+            TruthValue::P,
+            0.8,
+            "deep-research",
+            None,
+        );
+        let b = AssumptionNode::research_claim(
+            "latency under 5ms",
+            TruthValue::P,
+            0.8,
+            "deep-research",
+            None,
+        );
         assert_eq!(a.id, b.id, "normalized claim ⇒ same id");
         assert!(a.id.starts_with("sha256:"));
         assert!(a.location.is_none());
@@ -246,7 +262,10 @@ mod tests {
 
     #[test]
     fn annotation_kind_and_certainty_map_to_node_enums() {
-        assert_eq!(NodeKind::from(AnnotationKind::Invariant), NodeKind::Invariant);
+        assert_eq!(
+            NodeKind::from(AnnotationKind::Invariant),
+            NodeKind::Invariant
+        );
         assert_eq!(NodeKind::from(AnnotationKind::HotPath), NodeKind::HotPath);
         assert_eq!(
             NodeCertainty::from(Certainty::DetectedBySentrux),

--- a/crates/ix-assumption-graph/src/node.rs
+++ b/crates/ix-assumption-graph/src/node.rs
@@ -4,25 +4,107 @@ use ix_ai_annotations::{Annotation, AnnotationKind, Certainty, Location, Source,
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
+/// Kind of assumption node. A superset of the nine `@ai:` annotation kinds plus
+/// `ResearchClaim` — first-class as of Phase 4 (the annotation enum has no such
+/// variant, so the node model owns its own kind). Matches the contract's node
+/// `kind` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeKind {
+    Invariant,
+    Assumption,
+    Hypothesis,
+    Contract,
+    Smell,
+    Decision,
+    Hint,
+    BusinessValue,
+    HotPath,
+    /// Ingested from a research run (e.g. `/deep-research`).
+    ResearchClaim,
+}
+
+impl NodeKind {
+    /// Kebab-case wire name (matches the serde representation).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NodeKind::Invariant => "invariant",
+            NodeKind::Assumption => "assumption",
+            NodeKind::Hypothesis => "hypothesis",
+            NodeKind::Contract => "contract",
+            NodeKind::Smell => "smell",
+            NodeKind::Decision => "decision",
+            NodeKind::Hint => "hint",
+            NodeKind::BusinessValue => "business-value",
+            NodeKind::HotPath => "hot-path",
+            NodeKind::ResearchClaim => "research-claim",
+        }
+    }
+}
+
+impl From<AnnotationKind> for NodeKind {
+    fn from(k: AnnotationKind) -> Self {
+        match k {
+            AnnotationKind::Invariant => NodeKind::Invariant,
+            AnnotationKind::Assumption => NodeKind::Assumption,
+            AnnotationKind::Hypothesis => NodeKind::Hypothesis,
+            AnnotationKind::Contract => NodeKind::Contract,
+            AnnotationKind::Smell => NodeKind::Smell,
+            AnnotationKind::Decision => NodeKind::Decision,
+            AnnotationKind::Hint => NodeKind::Hint,
+            AnnotationKind::BusinessValue => NodeKind::BusinessValue,
+            AnnotationKind::HotPath => NodeKind::HotPath,
+        }
+    }
+}
+
+/// How a node's truth value was reached. A superset of the eight `@ai:`
+/// certainty markers plus `AdversarialPanel` — a multi-judge verdict, first-class
+/// as of Phase 4. Matches the contract's node `certainty` enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum NodeCertainty {
+    Test,
+    FormalProof,
+    ManuallyReviewed,
+    Assumed,
+    Uncertain,
+    Inferred,
+    Dismissed,
+    DetectedBySentrux,
+    /// Verdict reached by a multi-judge adversarial panel — treated as a
+    /// fail-closed gate, not a truth oracle (contract §7.2).
+    AdversarialPanel,
+}
+
+impl From<Certainty> for NodeCertainty {
+    fn from(c: Certainty) -> Self {
+        match c {
+            Certainty::Test => NodeCertainty::Test,
+            Certainty::FormalProof => NodeCertainty::FormalProof,
+            Certainty::ManuallyReviewed => NodeCertainty::ManuallyReviewed,
+            Certainty::Assumed => NodeCertainty::Assumed,
+            Certainty::Uncertain => NodeCertainty::Uncertain,
+            Certainty::Inferred => NodeCertainty::Inferred,
+            Certainty::Dismissed => NodeCertainty::Dismissed,
+            Certainty::DetectedBySentrux => NodeCertainty::DetectedBySentrux,
+        }
+    }
+}
+
 /// A node in the temporal assumption graph.
-///
-/// Phase 1 carries exactly the epistemic state an `@ai:` annotation already
-/// provides — no new epistemics. The subjective-logic `opinion`, the
-/// `belief_time` axis, and the JSONL wire form defined in
-/// `docs/contracts/2026-05-31-assumption-graph.contract.md` arrive in Phase 2/3.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssumptionNode {
-    /// Deterministic SHA-256 id, identical to the source annotation's id
-    /// (`sha256:…` over `path:line_start:kind:claim`) so an annotation and its
-    /// graph node share identity.
+    /// Deterministic SHA-256 id. Dev nodes share the source annotation's id;
+    /// research nodes hash `research:<author>:<normalized claim>`.
     pub id: String,
-    pub kind: AnnotationKind,
+    pub kind: NodeKind,
     pub claim: String,
     pub truth_value: TruthValue,
-    pub certainty: Certainty,
+    pub certainty: NodeCertainty,
     pub confidence: f64,
     pub source: Source,
-    /// Present for code-anchored assumptions; `None` for research claims (Phase 3).
+    /// Present for code-anchored assumptions; `None` for research claims.
     pub location: Option<Location>,
 }
 
@@ -30,10 +112,10 @@ impl From<Annotation> for AssumptionNode {
     fn from(a: Annotation) -> Self {
         Self {
             id: a.id,
-            kind: a.kind,
+            kind: a.kind.into(),
             claim: a.claim,
             truth_value: a.truth_value,
-            certainty: a.certainty,
+            certainty: a.certainty.into(),
             confidence: a.confidence,
             source: a.source,
             location: Some(a.location),
@@ -43,16 +125,9 @@ impl From<Annotation> for AssumptionNode {
 
 impl AssumptionNode {
     /// Build a research-claim node (no code location) — e.g. a verified finding
-    /// from a `/deep-research` run.
-    ///
-    /// NOTE: the reused annotation vocabulary ([`AnnotationKind`]) has no
-    /// dedicated `research-claim` variant, so a research claim is represented as
-    /// a [`AnnotationKind::Hypothesis`] with `certainty = Inferred`; the
-    /// originating run is identified by `source.author` (conventionally
-    /// `"deep-research"`). Splitting the node enums from the annotation enums —
-    /// so the contract's `research-claim` kind and `adversarial-panel` certainty
-    /// become first-class — is a Phase 4 item. Id is `sha256` over
-    /// `research:<author>:<normalized claim>` per the contract.
+    /// from a `/deep-research` run. Kind is [`NodeKind::ResearchClaim`] and
+    /// certainty is [`NodeCertainty::AdversarialPanel`] (the panel verdict). Id
+    /// is `sha256` over `research:<author>:<normalized claim>` per the contract.
     pub fn research_claim(
         claim: impl Into<String>,
         truth_value: TruthValue,
@@ -66,10 +141,10 @@ impl AssumptionNode {
         let id = format!("sha256:{:x}", Sha256::digest(key.as_bytes()));
         Self {
             id,
-            kind: AnnotationKind::Hypothesis,
+            kind: NodeKind::ResearchClaim,
             claim,
             truth_value,
-            certainty: Certainty::Inferred,
+            certainty: NodeCertainty::AdversarialPanel,
             confidence,
             source: Source {
                 author,
@@ -80,10 +155,18 @@ impl AssumptionNode {
         }
     }
 
-    /// `true` iff this node originated from a research run (`source.author`
-    /// is `"deep-research"`), as opposed to a code-anchored `@ai:` annotation.
+    /// `true` iff this node is a research claim (vs a code-anchored assumption).
     pub fn is_research_claim(&self) -> bool {
-        self.source.author == "deep-research"
+        matches!(self.kind, NodeKind::ResearchClaim)
+    }
+
+    /// Coarse domain facet: `"research"` or `"dev"`.
+    pub fn domain(&self) -> &'static str {
+        if self.is_research_claim() {
+            "research"
+        } else {
+            "dev"
+        }
     }
 }
 
@@ -149,8 +232,9 @@ mod tests {
         assert_eq!(a.id, b.id, "normalized claim ⇒ same id");
         assert!(a.id.starts_with("sha256:"));
         assert!(a.location.is_none());
-        assert_eq!(a.kind, AnnotationKind::Hypothesis);
+        assert_eq!(a.kind, NodeKind::ResearchClaim);
         assert!(a.is_research_claim());
+        assert_eq!(a.domain(), "research");
     }
 
     #[test]
@@ -158,6 +242,25 @@ mod tests {
         let a = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "deep-research", None);
         let b = AssumptionNode::research_claim("x", TruthValue::P, 0.8, "manual-review", None);
         assert_ne!(a.id, b.id);
+    }
+
+    #[test]
+    fn annotation_kind_and_certainty_map_to_node_enums() {
+        assert_eq!(NodeKind::from(AnnotationKind::Invariant), NodeKind::Invariant);
+        assert_eq!(NodeKind::from(AnnotationKind::HotPath), NodeKind::HotPath);
+        assert_eq!(
+            NodeCertainty::from(Certainty::DetectedBySentrux),
+            NodeCertainty::DetectedBySentrux
+        );
+        // New first-class variants serialize to the contract's kebab names.
+        assert_eq!(
+            serde_json::to_string(&NodeKind::ResearchClaim).unwrap(),
+            "\"research-claim\""
+        );
+        assert_eq!(
+            serde_json::to_string(&NodeCertainty::AdversarialPanel).unwrap(),
+            "\"adversarial-panel\""
+        );
     }
 
     #[test]
@@ -171,6 +274,7 @@ mod tests {
         };
         let n: AssumptionNode = r.into();
         assert_eq!(n.truth_value, TruthValue::F);
+        assert_eq!(n.kind, NodeKind::ResearchClaim);
         assert_eq!(n.source.author, "deep-research");
         assert_eq!(n.source.evidence.as_deref(), Some("arxiv:2510.11822"));
     }

--- a/crates/ix-assumption-graph/src/opinion.rs
+++ b/crates/ix-assumption-graph/src/opinion.rs
@@ -1,0 +1,162 @@
+//! Subjective-logic opinion (Jøsang) — the per-claim certainty carrier — and
+//! the bridge between `ix-ai-annotations`' [`TruthValue`] and the canonical
+//! [`ix_types::Hexavalent`].
+
+use ix_ai_annotations::TruthValue;
+use ix_types::Hexavalent;
+use serde::{Deserialize, Serialize};
+
+/// A binomial subjective-logic opinion: belief / disbelief / uncertainty / base rate.
+///
+/// Invariant: `b + d + u == 1` (within tolerance). Projected probability is
+/// `E = b + a·u` ([`Opinion::projected`]). See the design doc §5 and contract §4.
+///
+/// `C` (Contradictory) lies OUTSIDE this simplex — it needs both high belief
+/// and high disbelief, which `b + d + u = 1` cannot express — so
+/// [`Opinion::from_truth`] returns `None` for `C`. Contradiction is represented
+/// by *fusion* of conflicting opinions (see [`crate::fusion`]), not by a single
+/// point opinion.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Opinion {
+    /// Belief mass.
+    pub b: f64,
+    /// Disbelief mass.
+    pub d: f64,
+    /// Uncertainty mass.
+    pub u: f64,
+    /// Base rate (prior).
+    pub a: f64,
+}
+
+/// Default base rate (prior) when none is known — maximally non-committal.
+pub const DEFAULT_BASE_RATE: f64 = 0.5;
+
+impl Opinion {
+    /// Projected probability `E = b + a·u`. The scalar used for ranking and
+    /// promotion thresholds.
+    pub fn projected(&self) -> f64 {
+        self.b + self.a * self.u
+    }
+
+    /// Build the certainty carrier from a hexavalent truth value + confidence.
+    ///
+    /// Direction (belief vs disbelief) comes from the truth value's polarity;
+    /// magnitude is `confidence × verification_weight`, where verified values
+    /// (T/F) commit fully and leaning values (P/D) commit partially — so `P`
+    /// carries more residual uncertainty than `T` at equal confidence (the
+    /// verified-vs-probable distinction the `certainty` field also records). `U`
+    /// is total uncertainty. `C` is not representable and returns `None`.
+    ///
+    // @ai:invariant b+d+u == 1 for every non-C truth value [T:test conf:0.95 src:opinion.rs::tests::masses_sum_to_one]
+    pub fn from_truth(tv: TruthValue, confidence: f64) -> Option<Self> {
+        let c = confidence.clamp(0.0, 1.0);
+        // (directed magnitude, sign): +1 belief side, -1 disbelief side, 0 vacuous.
+        let (directed, sign) = match tv {
+            TruthValue::T => (c, 1.0),
+            TruthValue::P => (c * 0.6, 1.0),
+            TruthValue::D => (c * 0.6, -1.0),
+            TruthValue::F => (c, -1.0),
+            TruthValue::U => (0.0, 0.0),
+            TruthValue::C => return None,
+        };
+        let (b, d) = match sign {
+            s if s > 0.0 => (directed, 0.0),
+            s if s < 0.0 => (0.0, directed),
+            _ => (0.0, 0.0),
+        };
+        Some(Opinion {
+            b,
+            d,
+            u: 1.0 - b - d,
+            a: DEFAULT_BASE_RATE,
+        })
+    }
+}
+
+/// Bridge: `ix-ai-annotations` [`TruthValue`] → canonical [`ix_types::Hexavalent`].
+pub fn to_hexavalent(tv: TruthValue) -> Hexavalent {
+    match tv {
+        TruthValue::T => Hexavalent::True,
+        TruthValue::P => Hexavalent::Probable,
+        TruthValue::U => Hexavalent::Unknown,
+        TruthValue::D => Hexavalent::Doubtful,
+        TruthValue::F => Hexavalent::False,
+        TruthValue::C => Hexavalent::Contradictory,
+    }
+}
+
+/// Bridge: canonical [`ix_types::Hexavalent`] → `ix-ai-annotations` [`TruthValue`].
+pub fn from_hexavalent(h: Hexavalent) -> TruthValue {
+    match h {
+        Hexavalent::True => TruthValue::T,
+        Hexavalent::Probable => TruthValue::P,
+        Hexavalent::Unknown => TruthValue::U,
+        Hexavalent::Doubtful => TruthValue::D,
+        Hexavalent::False => TruthValue::F,
+        Hexavalent::Contradictory => TruthValue::C,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(x: f64, y: f64) -> bool {
+        (x - y).abs() < 1e-9
+    }
+
+    #[test]
+    fn true_is_high_belief_low_uncertainty() {
+        let o = Opinion::from_truth(TruthValue::T, 0.9).unwrap();
+        assert!(approx(o.b, 0.9) && approx(o.d, 0.0) && approx(o.u, 0.1));
+        assert!(approx(o.projected(), 0.95));
+    }
+
+    #[test]
+    fn false_is_high_disbelief_low_projection() {
+        let o = Opinion::from_truth(TruthValue::F, 0.9).unwrap();
+        assert!(approx(o.b, 0.0) && approx(o.d, 0.9) && approx(o.u, 0.1));
+        assert!(approx(o.projected(), 0.05));
+    }
+
+    #[test]
+    fn probable_carries_more_uncertainty_than_true() {
+        let t = Opinion::from_truth(TruthValue::T, 0.9).unwrap();
+        let p = Opinion::from_truth(TruthValue::P, 0.9).unwrap();
+        assert!(p.b < t.b, "P should commit less belief than T");
+        assert!(p.u > t.u, "P should retain more uncertainty than T");
+        assert!(p.projected() > 0.5, "P still leans true");
+    }
+
+    #[test]
+    fn unknown_is_total_uncertainty_at_base_rate() {
+        let o = Opinion::from_truth(TruthValue::U, 0.9).unwrap();
+        assert!(approx(o.b, 0.0) && approx(o.d, 0.0) && approx(o.u, 1.0));
+        assert!(approx(o.projected(), DEFAULT_BASE_RATE));
+    }
+
+    #[test]
+    fn contradictory_is_outside_the_simplex() {
+        assert!(Opinion::from_truth(TruthValue::C, 0.9).is_none());
+    }
+
+    #[test]
+    fn masses_sum_to_one() {
+        use TruthValue::*;
+        for &tv in &[T, P, U, D, F] {
+            for &conf in &[0.0, 0.3, 0.5, 0.7, 1.0] {
+                let o = Opinion::from_truth(tv, conf).unwrap();
+                assert!(approx(o.b + o.d + o.u, 1.0), "sum!=1 for {tv:?}@{conf}");
+                assert!(o.b >= 0.0 && o.d >= 0.0 && o.u >= 0.0);
+            }
+        }
+    }
+
+    #[test]
+    fn hexavalent_bridge_round_trips() {
+        use TruthValue::*;
+        for &tv in &[T, P, U, D, F, C] {
+            assert_eq!(from_hexavalent(to_hexavalent(tv)), tv);
+        }
+    }
+}

--- a/crates/ix-assumption-graph/src/temporal.rs
+++ b/crates/ix-assumption-graph/src/temporal.rs
@@ -235,7 +235,14 @@ mod tests {
         s.parse().expect("rfc3339")
     }
 
-    fn ann(author: &str, path: &str, line: u32, claim: &str, tv: TruthValue, conf: f64) -> Annotation {
+    fn ann(
+        author: &str,
+        path: &str,
+        line: u32,
+        claim: &str,
+        tv: TruthValue,
+        conf: f64,
+    ) -> Annotation {
         let kind = AnnotationKind::Assumption;
         Annotation {
             schema_version: SCHEMA_VERSION,
@@ -245,8 +252,16 @@ mod tests {
             truth_value: tv,
             certainty: Certainty::Assumed,
             confidence: conf,
-            source: Source { author: author.to_string(), model: None, evidence: None },
-            location: Location { path: path.to_string(), line_start: line, line_end: line },
+            source: Source {
+                author: author.to_string(),
+                model: None,
+                evidence: None,
+            },
+            location: Location {
+                path: path.to_string(),
+                line_start: line,
+                line_end: line,
+            },
             created_at: "2026-05-31T00:00:00Z".to_string(),
             updated_at: "2026-05-31T00:00:00Z".to_string(),
             stale: false,
@@ -256,7 +271,10 @@ mod tests {
 
     #[test]
     fn claim_id_is_stable_and_normalized() {
-        assert_eq!(claim_id("Caller  Holds  Lock"), claim_id("caller holds lock"));
+        assert_eq!(
+            claim_id("Caller  Holds  Lock"),
+            claim_id("caller holds lock")
+        );
         assert!(claim_id("x").starts_with("sha256:"));
         assert_ne!(claim_id("a"), claim_id("b"));
     }
@@ -265,11 +283,31 @@ mod tests {
     fn belief_at_returns_latest_event_before_t() {
         let id = claim_id("x");
         let mut log = BeliefLog::new();
-        log.record(BeliefEvent::new(id.clone(), ts("2026-01-01T00:00:00Z"), None, Hexavalent::Probable, None, "init"));
-        log.record(BeliefEvent::new(id.clone(), ts("2026-03-01T00:00:00Z"), Some(Hexavalent::Probable), Hexavalent::False, None, "test"));
+        log.record(BeliefEvent::new(
+            id.clone(),
+            ts("2026-01-01T00:00:00Z"),
+            None,
+            Hexavalent::Probable,
+            None,
+            "init",
+        ));
+        log.record(BeliefEvent::new(
+            id.clone(),
+            ts("2026-03-01T00:00:00Z"),
+            Some(Hexavalent::Probable),
+            Hexavalent::False,
+            None,
+            "test",
+        ));
 
-        assert_eq!(log.belief_at(ts("2026-02-01T00:00:00Z"))[&id].truth_value, Hexavalent::Probable);
-        assert_eq!(log.belief_at(ts("2026-04-01T00:00:00Z"))[&id].truth_value, Hexavalent::False);
+        assert_eq!(
+            log.belief_at(ts("2026-02-01T00:00:00Z"))[&id].truth_value,
+            Hexavalent::Probable
+        );
+        assert_eq!(
+            log.belief_at(ts("2026-04-01T00:00:00Z"))[&id].truth_value,
+            Hexavalent::False
+        );
         // Before any event: empty.
         assert!(log.belief_at(ts("2025-01-01T00:00:00Z")).is_empty());
     }
@@ -278,8 +316,22 @@ mod tests {
     fn diff_reports_flips_between_times() {
         let id = claim_id("x");
         let mut log = BeliefLog::new();
-        log.record(BeliefEvent::new(id.clone(), ts("2026-01-01T00:00:00Z"), None, Hexavalent::True, None, "init"));
-        log.record(BeliefEvent::new(id.clone(), ts("2026-03-01T00:00:00Z"), Some(Hexavalent::True), Hexavalent::False, None, "refuted"));
+        log.record(BeliefEvent::new(
+            id.clone(),
+            ts("2026-01-01T00:00:00Z"),
+            None,
+            Hexavalent::True,
+            None,
+            "init",
+        ));
+        log.record(BeliefEvent::new(
+            id.clone(),
+            ts("2026-03-01T00:00:00Z"),
+            Some(Hexavalent::True),
+            Hexavalent::False,
+            None,
+            "refuted",
+        ));
 
         let changes = log.diff(ts("2026-02-01T00:00:00Z"), ts("2026-04-01T00:00:00Z"));
         assert_eq!(changes.len(), 1);

--- a/crates/ix-assumption-graph/src/temporal.rs
+++ b/crates/ix-assumption-graph/src/temporal.rs
@@ -1,0 +1,342 @@
+//! Phase 3 — the belief-time axis.
+//!
+//! An append-only [`BeliefLog`] of [`BeliefEvent`]s records how a claim's fused
+//! verdict changes over *belief-time* (the design doc §5 / contract §5 third
+//! axis). Point-in-time reconstruction is [`BeliefLog::belief_at`]; what changed
+//! between two times is [`BeliefLog::diff`]. This is the "semantic story over a
+//! long period" substrate — longitudinal revision, not snapshot storage.
+//!
+//! [`AssumptionGraph::revise`] is one turn of the loop: fuse current evidence,
+//! and append a [`BeliefEvent`] for every claim whose verdict differs from the
+//! log's latest belief. The autonomous evidence-gathering loop (scheduled
+//! `/deep-research` re-verification, test re-runs) is the orchestration that
+//! *drives* `revise` repeatedly over time — it lives outside this crate.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use chrono::{DateTime, Utc};
+use ix_types::Hexavalent;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::graph::{normalize_claim, AssumptionGraph};
+use crate::opinion::{from_hexavalent, Opinion};
+
+/// Schema version of the `belief_event` record (contract §2.3).
+pub const BELIEF_EVENT_SCHEMA_VERSION: u32 = 1;
+
+/// Stable id for a *claim-level* belief — the fused-verdict identity, distinct
+/// from a single annotation's node id. `sha256:` over the normalized claim, so
+/// the same claim tracks one belief timeline regardless of how many annotations
+/// assert it.
+pub fn claim_id(claim: &str) -> String {
+    let key = format!("claim:{}", normalize_claim(claim));
+    format!("sha256:{:x}", Sha256::digest(key.as_bytes()))
+}
+
+/// One append-only revision of a claim's epistemic state at a belief-time.
+/// Matches the `belief_event` record in `assumption-graph.schema.json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct BeliefEvent {
+    pub schema_version: u32,
+    /// Always `"belief_event"` — the JSONL record discriminator.
+    pub record: String,
+    /// Claim-level id (see [`claim_id`]).
+    pub node_id: String,
+    /// Belief-time of this revision.
+    pub at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub from_truth_value: Option<Hexavalent>,
+    pub to_truth_value: Hexavalent,
+    /// `None` when the verdict is `C` (Contradictory) — it lies outside the
+    /// subjective-logic simplex (see [`Opinion`]).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub to_opinion: Option<Opinion>,
+    /// What caused the revision (e.g. `"deep-research-reverify"`, `"test-run"`).
+    pub trigger: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub evidence: Option<String>,
+}
+
+impl BeliefEvent {
+    /// Construct a well-formed event (sets `schema_version` + `record`).
+    pub fn new(
+        node_id: String,
+        at: DateTime<Utc>,
+        from_truth_value: Option<Hexavalent>,
+        to_truth_value: Hexavalent,
+        to_opinion: Option<Opinion>,
+        trigger: impl Into<String>,
+    ) -> Self {
+        Self {
+            schema_version: BELIEF_EVENT_SCHEMA_VERSION,
+            record: "belief_event".to_string(),
+            node_id,
+            at,
+            from_truth_value,
+            to_truth_value,
+            to_opinion,
+            trigger: trigger.into(),
+            evidence: None,
+        }
+    }
+}
+
+/// The epistemic state of one claim at a point in belief-time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BeliefSnapshot {
+    pub truth_value: Hexavalent,
+    pub opinion: Option<Opinion>,
+    pub at: DateTime<Utc>,
+}
+
+/// A change in a claim's verdict between two belief-times.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BeliefChange {
+    pub node_id: String,
+    pub from: Option<Hexavalent>,
+    pub to: Hexavalent,
+    pub at: DateTime<Utc>,
+}
+
+/// Append-only log of belief revisions. Kept sorted by `(at, node_id)` so
+/// replay is deterministic.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct BeliefLog {
+    events: Vec<BeliefEvent>,
+}
+
+impl BeliefLog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append an event, keeping the log sorted for deterministic replay.
+    pub fn record(&mut self, event: BeliefEvent) {
+        self.events.push(event);
+        self.events
+            .sort_by(|a, b| a.at.cmp(&b.at).then_with(|| a.node_id.cmp(&b.node_id)));
+    }
+
+    pub fn events(&self) -> &[BeliefEvent] {
+        &self.events
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Reconstruct the belief state at time `t`: for each claim, the latest
+    /// event with `at <= t` wins. Events are sorted ascending, so iterating in
+    /// order and overwriting yields the most recent applicable state.
+    pub fn belief_at(&self, t: DateTime<Utc>) -> BTreeMap<String, BeliefSnapshot> {
+        let mut state = BTreeMap::new();
+        for e in &self.events {
+            if e.at <= t {
+                state.insert(
+                    e.node_id.clone(),
+                    BeliefSnapshot {
+                        truth_value: e.to_truth_value,
+                        opinion: e.to_opinion,
+                        at: e.at,
+                    },
+                );
+            }
+        }
+        state
+    }
+
+    /// Claims whose verdict differs between `t1` and `t2` — the "what flipped,
+    /// and when" view. Ordered by claim id.
+    pub fn diff(&self, t1: DateTime<Utc>, t2: DateTime<Utc>) -> Vec<BeliefChange> {
+        let s1 = self.belief_at(t1);
+        let s2 = self.belief_at(t2);
+        let keys: BTreeSet<&String> = s1.keys().chain(s2.keys()).collect();
+
+        let mut out = Vec::new();
+        for k in keys {
+            let from = s1.get(k).map(|s| s.truth_value);
+            match s2.get(k) {
+                Some(snap) if Some(snap.truth_value) != from => out.push(BeliefChange {
+                    node_id: k.clone(),
+                    from,
+                    to: snap.truth_value,
+                    at: snap.at,
+                }),
+                _ => {}
+            }
+        }
+        out
+    }
+
+    /// Serialize to JSONL (one event per line).
+    pub fn to_jsonl(&self) -> String {
+        self.events
+            .iter()
+            .map(|e| serde_json::to_string(e).expect("BeliefEvent serializes"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// Parse from JSONL (blank lines ignored). Re-sorts for deterministic replay.
+    pub fn from_jsonl(s: &str) -> Result<Self, serde_json::Error> {
+        let mut log = BeliefLog::new();
+        for line in s.lines().filter(|l| !l.trim().is_empty()) {
+            log.events.push(serde_json::from_str(line)?);
+        }
+        log.events
+            .sort_by(|a, b| a.at.cmp(&b.at).then_with(|| a.node_id.cmp(&b.node_id)));
+        Ok(log)
+    }
+}
+
+impl AssumptionGraph {
+    /// One turn of the longitudinal loop. Fuses current evidence and appends a
+    /// [`BeliefEvent`] to `log` for every claim whose fused verdict differs from
+    /// the log's latest belief as of `at`. Returns the events appended (empty if
+    /// nothing changed — so repeated calls on unchanged evidence are no-ops).
+    pub fn revise(
+        &self,
+        log: &mut BeliefLog,
+        at: DateTime<Utc>,
+        trigger: &str,
+    ) -> Result<Vec<BeliefEvent>, ix_fuzzy::FuzzyError> {
+        let prior = log.belief_at(at);
+        let mut appended = Vec::new();
+        for fc in self.fuse()? {
+            let id = claim_id(&fc.claim);
+            let prior_tv = prior.get(&id).map(|s| s.truth_value);
+            if prior_tv != Some(fc.verdict) {
+                let opinion = Opinion::from_truth(from_hexavalent(fc.verdict), fc.confidence);
+                let event =
+                    BeliefEvent::new(id, at, prior_tv, fc.verdict, opinion, trigger.to_string());
+                log.record(event.clone());
+                appended.push(event);
+            }
+        }
+        Ok(appended)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AssumptionGraph;
+    use ix_ai_annotations::types::annotation_id;
+    use ix_ai_annotations::{
+        Annotation, AnnotationKind, Certainty, Location, Source, TruthValue, SCHEMA_VERSION,
+    };
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        s.parse().expect("rfc3339")
+    }
+
+    fn ann(author: &str, path: &str, line: u32, claim: &str, tv: TruthValue, conf: f64) -> Annotation {
+        let kind = AnnotationKind::Assumption;
+        Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id(path, line, kind, claim),
+            kind,
+            claim: claim.to_string(),
+            truth_value: tv,
+            certainty: Certainty::Assumed,
+            confidence: conf,
+            source: Source { author: author.to_string(), model: None, evidence: None },
+            location: Location { path: path.to_string(), line_start: line, line_end: line },
+            created_at: "2026-05-31T00:00:00Z".to_string(),
+            updated_at: "2026-05-31T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        }
+    }
+
+    #[test]
+    fn claim_id_is_stable_and_normalized() {
+        assert_eq!(claim_id("Caller  Holds  Lock"), claim_id("caller holds lock"));
+        assert!(claim_id("x").starts_with("sha256:"));
+        assert_ne!(claim_id("a"), claim_id("b"));
+    }
+
+    #[test]
+    fn belief_at_returns_latest_event_before_t() {
+        let id = claim_id("x");
+        let mut log = BeliefLog::new();
+        log.record(BeliefEvent::new(id.clone(), ts("2026-01-01T00:00:00Z"), None, Hexavalent::Probable, None, "init"));
+        log.record(BeliefEvent::new(id.clone(), ts("2026-03-01T00:00:00Z"), Some(Hexavalent::Probable), Hexavalent::False, None, "test"));
+
+        assert_eq!(log.belief_at(ts("2026-02-01T00:00:00Z"))[&id].truth_value, Hexavalent::Probable);
+        assert_eq!(log.belief_at(ts("2026-04-01T00:00:00Z"))[&id].truth_value, Hexavalent::False);
+        // Before any event: empty.
+        assert!(log.belief_at(ts("2025-01-01T00:00:00Z")).is_empty());
+    }
+
+    #[test]
+    fn diff_reports_flips_between_times() {
+        let id = claim_id("x");
+        let mut log = BeliefLog::new();
+        log.record(BeliefEvent::new(id.clone(), ts("2026-01-01T00:00:00Z"), None, Hexavalent::True, None, "init"));
+        log.record(BeliefEvent::new(id.clone(), ts("2026-03-01T00:00:00Z"), Some(Hexavalent::True), Hexavalent::False, None, "refuted"));
+
+        let changes = log.diff(ts("2026-02-01T00:00:00Z"), ts("2026-04-01T00:00:00Z"));
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].from, Some(Hexavalent::True));
+        assert_eq!(changes[0].to, Hexavalent::False);
+    }
+
+    #[test]
+    fn jsonl_round_trips() {
+        let id = claim_id("buffer flushed");
+        let mut log = BeliefLog::new();
+        log.record(BeliefEvent::new(
+            id,
+            ts("2026-05-31T00:00:00Z"),
+            None,
+            Hexavalent::True,
+            Opinion::from_truth(TruthValue::T, 0.9),
+            "test-run",
+        ));
+        let jsonl = log.to_jsonl();
+        assert!(jsonl.contains("\"record\":\"belief_event\""));
+        let back = BeliefLog::from_jsonl(&jsonl).unwrap();
+        assert_eq!(back.events(), log.events());
+    }
+
+    #[test]
+    fn revise_records_only_on_change() {
+        // t1: cross-source agreement → leans true.
+        let g1 = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "lock held", TruthValue::T, 0.9),
+            ann("human", "b.rs", 2, "lock held", TruthValue::P, 0.7),
+        ])
+        .unwrap();
+        let mut log = BeliefLog::new();
+        let t1 = ts("2026-01-01T00:00:00Z");
+        let first = g1.revise(&mut log, t1, "init").unwrap();
+        assert_eq!(first.len(), 1, "first observation records an event");
+
+        // Same evidence again at t1 → no change, no new event (idempotent).
+        let repeat = g1.revise(&mut log, t1, "init").unwrap();
+        assert!(repeat.is_empty(), "unchanged verdict appends nothing");
+
+        // t2: an independent source now refutes it → escalates to C.
+        let g2 = AssumptionGraph::from_annotations(vec![
+            ann("claude", "a.rs", 1, "lock held", TruthValue::T, 1.0),
+            ann("sentrux", "c.rs", 3, "lock held", TruthValue::F, 1.0),
+        ])
+        .unwrap();
+        let t2 = ts("2026-03-01T00:00:00Z");
+        let revised = g2.revise(&mut log, t2, "deep-research-reverify").unwrap();
+        assert_eq!(revised.len(), 1);
+        assert_eq!(revised[0].to_truth_value, Hexavalent::Contradictory);
+        assert!(revised[0].to_opinion.is_none(), "C has no point opinion");
+
+        // The story over time: the claim flipped from a positive lean to C.
+        let changes = log.diff(t1, t2);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].to, Hexavalent::Contradictory);
+    }
+}

--- a/crates/ix-assumption-graph/src/temporal.rs
+++ b/crates/ix-assumption-graph/src/temporal.rs
@@ -83,7 +83,7 @@ impl BeliefEvent {
 }
 
 /// The epistemic state of one claim at a point in belief-time.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct BeliefSnapshot {
     pub truth_value: Hexavalent,
     pub opinion: Option<Opinion>,

--- a/crates/ix-assumption-graph/src/view.rs
+++ b/crates/ix-assumption-graph/src/view.rs
@@ -38,7 +38,10 @@ fn namespace_from_path(path: &str) -> String {
             return (*crate_name).to_string();
         }
     }
-    parts.first().map(|s| (*s).to_string()).unwrap_or_else(|| "(unknown)".to_string())
+    parts
+        .first()
+        .map(|s| (*s).to_string())
+        .unwrap_or_else(|| "(unknown)".to_string())
 }
 
 /// One claim's fused state, with its navigation facets.
@@ -98,7 +101,10 @@ impl AssumptionGraph {
         };
 
         for node in self.nodes() {
-            *view.by_kind.entry(node.kind.as_str().to_string()).or_default() += 1;
+            *view
+                .by_kind
+                .entry(node.kind.as_str().to_string())
+                .or_default() += 1;
             *view.by_domain.entry(node.domain().to_string()).or_default() += 1;
         }
 
@@ -106,8 +112,7 @@ impl AssumptionGraph {
             let Some(f) = by_norm.get(norm) else { continue };
 
             let namespace = primary_namespace(nodes);
-            let mut domains: Vec<String> =
-                nodes.iter().map(|n| n.domain().to_string()).collect();
+            let mut domains: Vec<String> = nodes.iter().map(|n| n.domain().to_string()).collect();
             domains.sort_unstable();
             domains.dedup();
 
@@ -167,8 +172,16 @@ mod tests {
             truth_value: tv,
             certainty: Certainty::Test,
             confidence: 0.9,
-            source: Source { author: "claude".to_string(), model: None, evidence: None },
-            location: Location { path: path.to_string(), line_start: line, line_end: line },
+            source: Source {
+                author: "claude".to_string(),
+                model: None,
+                evidence: None,
+            },
+            location: Location {
+                path: path.to_string(),
+                line_start: line,
+                line_end: line,
+            },
             created_at: "2026-05-31T00:00:00Z".to_string(),
             updated_at: "2026-05-31T00:00:00Z".to_string(),
             stale: false,
@@ -178,8 +191,14 @@ mod tests {
 
     #[test]
     fn namespace_derives_crate_from_path() {
-        assert_eq!(namespace_from_path("crates/ix-search/src/binary.rs"), "ix-search");
-        assert_eq!(namespace_from_path("crates\\ix-fuzzy\\src\\ops.rs"), "ix-fuzzy");
+        assert_eq!(
+            namespace_from_path("crates/ix-search/src/binary.rs"),
+            "ix-search"
+        );
+        assert_eq!(
+            namespace_from_path("crates\\ix-fuzzy\\src\\ops.rs"),
+            "ix-fuzzy"
+        );
         assert_eq!(namespace_from_path("README.md"), "README.md");
     }
 
@@ -216,7 +235,12 @@ mod tests {
     fn view_surfaces_escalations() {
         // A research claim refutes a code assumption on the same claim.
         let g = AssumptionGraph::from_parts(
-            vec![ann("crates/ix-x/src/a.rs", 1, "fast path is safe", TruthValue::T)],
+            vec![ann(
+                "crates/ix-x/src/a.rs",
+                1,
+                "fast path is safe",
+                TruthValue::T,
+            )],
             vec![ResearchClaim {
                 claim: "fast path is safe".to_string(),
                 truth_value: TruthValue::F,

--- a/crates/ix-assumption-graph/src/view.rs
+++ b/crates/ix-assumption-graph/src/view.rs
@@ -1,0 +1,236 @@
+//! Phase 4 — faceted navigation over the assumption graph.
+//!
+//! Answers "how is the graph structured?" along **both** axes:
+//! - **namespace** (project/module) — derived from a code-anchored node's path
+//!   (`crates/<crate>/…` → `<crate>`); research claims bucket under `research`;
+//! - **kind** (invariant / assumption / hypothesis / … / research-claim) and
+//!   **domain** (`dev` vs `research`).
+//!
+//! [`AssumptionGraph::view`] produces a [`FacetedView`] — the serializable data
+//! model a UI (Prime Radiant, a dashboard) or the `ix_assumption_query` MCP tool
+//! renders. Escalated (Contradictory) claims are surfaced separately for triage.
+
+use std::collections::BTreeMap;
+
+use ix_fuzzy::FuzzyError;
+use ix_types::Hexavalent;
+use serde::Serialize;
+
+use crate::graph::{normalize_claim, AssumptionGraph};
+use crate::node::AssumptionNode;
+
+/// Namespace facet for a node: its crate (or top path segment) for code-anchored
+/// nodes, `"research"` for research claims.
+pub fn namespace_of(node: &AssumptionNode) -> String {
+    match &node.location {
+        Some(loc) => namespace_from_path(&loc.path),
+        None => "research".to_string(),
+    }
+}
+
+/// `crates/<crate>/src/…` → `<crate>`; otherwise the first path segment;
+/// `(unknown)` if empty.
+fn namespace_from_path(path: &str) -> String {
+    let norm = path.replace('\\', "/");
+    let parts: Vec<&str> = norm.split('/').filter(|s| !s.is_empty()).collect();
+    if let Some(i) = parts.iter().position(|&s| s == "crates") {
+        if let Some(crate_name) = parts.get(i + 1) {
+            return (*crate_name).to_string();
+        }
+    }
+    parts.first().map(|s| (*s).to_string()).unwrap_or_else(|| "(unknown)".to_string())
+}
+
+/// One claim's fused state, with its navigation facets.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimView {
+    pub claim: String,
+    pub verdict: Hexavalent,
+    pub escalated: bool,
+    pub namespace: String,
+    pub domains: Vec<String>,
+    pub source_count: usize,
+    pub contradiction_count: usize,
+}
+
+/// Faceted snapshot of the whole graph — the UI / MCP data model.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FacetedView {
+    pub node_count: usize,
+    pub claim_count: usize,
+    pub escalated_count: usize,
+    /// Claim views grouped under their primary namespace.
+    pub by_namespace: BTreeMap<String, Vec<ClaimView>>,
+    /// Node counts per kind (kebab name).
+    pub by_kind: BTreeMap<String, usize>,
+    /// Node counts per domain (`dev` / `research`).
+    pub by_domain: BTreeMap<String, usize>,
+    /// Just the escalated (Contradictory) claims, for quick triage.
+    pub escalations: Vec<ClaimView>,
+}
+
+impl AssumptionGraph {
+    /// Build the faceted navigation view. Groups nodes by normalized claim,
+    /// joins each with its fused verdict, and buckets by namespace / kind /
+    /// domain. A claim's *primary namespace* is the most common namespace among
+    /// its contributing nodes (ties broken alphabetically; `research`-only
+    /// claims land under `research`).
+    pub fn view(&self) -> Result<FacetedView, FuzzyError> {
+        // claim (normalized) -> contributing nodes
+        let mut groups: BTreeMap<String, Vec<&AssumptionNode>> = BTreeMap::new();
+        for node in self.nodes() {
+            groups
+                .entry(normalize_claim(&node.claim))
+                .or_default()
+                .push(node);
+        }
+
+        // normalized claim -> fused verdict
+        let fused = self.fuse()?;
+        let by_norm: BTreeMap<String, &crate::FusedClaim> = fused
+            .iter()
+            .map(|f| (normalize_claim(&f.claim), f))
+            .collect();
+
+        let mut view = FacetedView {
+            node_count: self.node_count(),
+            ..Default::default()
+        };
+
+        for node in self.nodes() {
+            *view.by_kind.entry(node.kind.as_str().to_string()).or_default() += 1;
+            *view.by_domain.entry(node.domain().to_string()).or_default() += 1;
+        }
+
+        for (norm, nodes) in &groups {
+            let Some(f) = by_norm.get(norm) else { continue };
+
+            let namespace = primary_namespace(nodes);
+            let mut domains: Vec<String> =
+                nodes.iter().map(|n| n.domain().to_string()).collect();
+            domains.sort_unstable();
+            domains.dedup();
+
+            let cv = ClaimView {
+                claim: f.claim.clone(),
+                verdict: f.verdict,
+                escalated: f.escalated,
+                namespace: namespace.clone(),
+                domains,
+                source_count: f.source_count,
+                contradiction_count: f.contradiction_count,
+            };
+
+            if cv.escalated {
+                view.escalations.push(cv.clone());
+            }
+            view.by_namespace.entry(namespace).or_default().push(cv);
+        }
+
+        view.claim_count = groups.len();
+        view.escalated_count = view.escalations.len();
+        // Deterministic escalation order.
+        view.escalations.sort_by(|a, b| a.claim.cmp(&b.claim));
+        Ok(view)
+    }
+}
+
+/// Most common namespace among a claim's nodes (ties → alphabetical first).
+fn primary_namespace(nodes: &[&AssumptionNode]) -> String {
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for n in nodes {
+        *counts.entry(namespace_of(n)).or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+        .map(|(ns, _)| ns)
+        .unwrap_or_else(|| "(unknown)".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::ResearchClaim;
+    use ix_ai_annotations::types::annotation_id;
+    use ix_ai_annotations::{
+        Annotation, AnnotationKind, Certainty, Location, Source, TruthValue, SCHEMA_VERSION,
+    };
+
+    fn ann(path: &str, line: u32, claim: &str, tv: TruthValue) -> Annotation {
+        let kind = AnnotationKind::Invariant;
+        Annotation {
+            schema_version: SCHEMA_VERSION,
+            id: annotation_id(path, line, kind, claim),
+            kind,
+            claim: claim.to_string(),
+            truth_value: tv,
+            certainty: Certainty::Test,
+            confidence: 0.9,
+            source: Source { author: "claude".to_string(), model: None, evidence: None },
+            location: Location { path: path.to_string(), line_start: line, line_end: line },
+            created_at: "2026-05-31T00:00:00Z".to_string(),
+            updated_at: "2026-05-31T00:00:00Z".to_string(),
+            stale: false,
+            reconciliation: None,
+        }
+    }
+
+    #[test]
+    fn namespace_derives_crate_from_path() {
+        assert_eq!(namespace_from_path("crates/ix-search/src/binary.rs"), "ix-search");
+        assert_eq!(namespace_from_path("crates\\ix-fuzzy\\src\\ops.rs"), "ix-fuzzy");
+        assert_eq!(namespace_from_path("README.md"), "README.md");
+    }
+
+    #[test]
+    fn view_buckets_by_namespace_and_domain() {
+        let g = AssumptionGraph::from_parts(
+            vec![
+                ann("crates/ix-search/src/a.rs", 1, "alpha holds", TruthValue::T),
+                ann("crates/ix-fuzzy/src/b.rs", 2, "beta holds", TruthValue::T),
+            ],
+            vec![ResearchClaim {
+                claim: "gamma is settled".to_string(),
+                truth_value: TruthValue::P,
+                confidence: 0.8,
+                source: "deep-research".to_string(),
+                evidence: None,
+            }],
+        )
+        .unwrap();
+
+        let view = g.view().unwrap();
+        assert_eq!(view.node_count, 3);
+        assert_eq!(view.claim_count, 3);
+        assert!(view.by_namespace.contains_key("ix-search"));
+        assert!(view.by_namespace.contains_key("ix-fuzzy"));
+        assert!(view.by_namespace.contains_key("research"));
+        assert_eq!(view.by_domain.get("dev"), Some(&2));
+        assert_eq!(view.by_domain.get("research"), Some(&1));
+        assert_eq!(view.by_kind.get("research-claim"), Some(&1));
+        assert_eq!(view.escalated_count, 0);
+    }
+
+    #[test]
+    fn view_surfaces_escalations() {
+        // A research claim refutes a code assumption on the same claim.
+        let g = AssumptionGraph::from_parts(
+            vec![ann("crates/ix-x/src/a.rs", 1, "fast path is safe", TruthValue::T)],
+            vec![ResearchClaim {
+                claim: "fast path is safe".to_string(),
+                truth_value: TruthValue::F,
+                confidence: 0.9,
+                source: "deep-research".to_string(),
+                evidence: None,
+            }],
+        )
+        .unwrap();
+
+        let view = g.view().unwrap();
+        assert_eq!(view.escalated_count, 1);
+        assert_eq!(view.escalations[0].verdict, Hexavalent::Contradictory);
+        // The claim touches both domains.
+        assert_eq!(view.escalations[0].domains, vec!["dev", "research"]);
+    }
+}

--- a/crates/ix-skill/tests/cli.rs
+++ b/crates/ix-skill/tests/cli.rs
@@ -25,10 +25,11 @@ fn list_skills_returns_all_entries() {
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     let count = value["count"].as_u64().expect("count is number");
-    // 48 = batch1 (6) + batch2 (28) + batch3 (10 + context.walk +
-    // session.flywheel_export + fuzzy.eval) + prime_radiant (2).
+    // 50 = batch1 (6) + batch2 (28) + batch3 (10 + context.walk +
+    // session.flywheel_export + fuzzy.eval) + prime_radiant (2) +
+    // assumption_graph (2: assumption.query + assumption.belief_at).
     // If this drifts, update the assertion alongside the batch changes.
-    assert_eq!(count, 48, "expected 48 registry skills, got {count}");
+    assert_eq!(count, 50, "expected 50 registry skills, got {count}");
 }
 
 #[test]

--- a/docs/contracts/2026-05-31-assumption-graph.contract.md
+++ b/docs/contracts/2026-05-31-assumption-graph.contract.md
@@ -1,8 +1,8 @@
 # Temporal Assumption Graph — Cross-Repo Contract
 
-**Version:** 0.4.0 (Phases 1–4 implemented — **freeze-candidate**, pending operator sign-off)
+**Version:** 1.0.0 (**FROZEN** — Phases 1–4 shipped; operator sign-off 2026-05-31)
 **Schema version:** 1
-**Status:** Phases 1–4 shipped in `ix-assumption-graph` (graph + fusion + belief-time + MCP). The `node`/`edge`/`belief_event` records, the reused enums, and the `opinion` shape are stable. Freeze (→ v1.0.0, locking the one-way-door fields) is a **one-way door requiring operator sign-off** — NOT done unilaterally.
+**Status:** **FROZEN.** The `node`/`edge`/`belief_event` records, the `id` scheme, the `truth_value` / `kind` / `certainty` enums, and the `opinion` shape are locked. Post-freeze changes follow the additive-only rule (§10): new *optional* fields and new enum *variants* are additive; renames, removals, or required-field changes bump `schema_version` and require cross-repo coordination.
 **Producers:** `ix-assumption-graph` builder (`from_workspace`/`from_parts`), `ix-ai-annotations` (via node promotion), `/deep-research` (research-claim nodes via the `assumption-graph-loop` skill), the `revise` loop
 **Consumers:** `ix-assumption-graph` fusion/`view`/`belief_at`, the MCP tools `ix_assumption_query` + `ix_assumption_belief_at`, Demerzel promotion gate, (later) Prime Radiant / dashboard visualization
 **Schema file:** `docs/contracts/assumption-graph.schema.json`
@@ -146,7 +146,7 @@ The "do multi-LLM panels improve correctness or amplify shared bias?" question i
 - **Phase 1:** `ix-assumption-graph` crate — build `Dag<AssumptionNode>` from `@ai:` annotations; derive `contradicts` from `contrary`.
 - **Phase 2:** opinion fusion + Belnap `C` synthesis + the §4 bridge (reuses `ix-fuzzy`, `hari`).
 - **Phase 3:** belief-event log + `belief_at(t)` / `diff(t1,t2)`; the longitudinal loop ( `/deep-research` → research-claim nodes; scheduled re-verify; Demerzel promotion gate).
-- **Phase 4 (shipped):** node enums split from the annotation enums — `research-claim` kind and `adversarial-panel` certainty are now first-class (`NodeKind`/`NodeCertainty`); faceted navigation `view()` (by namespace / kind / domain + escalations); MCP tools `ix_assumption_query` (faceted view) and `ix_assumption_belief_at` (point-in-time belief state). **Freeze (→ v1.0.0) pending operator sign-off.**
+- **Phase 4 (shipped):** node enums split from the annotation enums — `research-claim` kind and `adversarial-panel` certainty are now first-class (`NodeKind`/`NodeCertainty`); faceted navigation `view()` (by namespace / kind / domain + escalations); MCP tools `ix_assumption_query` (faceted view) and `ix_assumption_belief_at` (point-in-time belief state). **Frozen at v1.0.0 (operator sign-off 2026-05-31).**
 
 ### Navigation & structure
 
@@ -163,9 +163,10 @@ on annotations — not currently modeled. Humans navigate via the
 
 ## 10. Versioning
 
-`v0.1.0` (draft). The `record` discriminator, the reused enums, and the `opinion` shape are intended to be stable from Phase 1. `schema_version` bumps only on a field rename/removal or an enum widening that consumers must opt into; new optional fields are additive.
+**v1.0.0 — FROZEN.** The `record` discriminator, the `id` scheme, the `truth_value` / `kind` / `certainty` enums, and the `opinion` shape are locked. Post-freeze, `schema_version` bumps only on a field rename/removal or a required-field change (which require cross-repo coordination); new *optional* fields and new enum *variants* are additive and do not bump it.
 
 ### Changelog
+- **v1.0.0 (2026-05-31, schema_version 1)** — **frozen** with operator sign-off after Phases 1–4 shipped in `ix-assumption-graph` (graph + fusion + belief-time + faceted navigation + MCP `ix_assumption_query` / `ix_assumption_belief_at`). No schema change from v0.1.0 — the records proved stable through implementation; this entry locks them.
 - **v0.1.0 (2026-05-31, schema_version 1)** — initial draft: `node` / `edge` / `belief_event` records; reuses `@ai:` annotation vocabulary; adds subjective-logic `opinion`, ABA `contrary` + edges, `belief_time` axis, and the `adversarial-panel` certainty + `independence_class` fusion tag.
 
-**One-way-door note:** the `id` scheme and the `truth_value` enum align with the `@ai:` annotation contract and Demerzel — changing them is a one-way door requiring cross-repo sign-off. Everything else in this draft is two-way until Phase 4.
+**One-way-door note:** the `id` scheme and the `truth_value` enum align with the `@ai:` annotation contract and Demerzel — changing them is a one-way door requiring cross-repo sign-off.

--- a/docs/contracts/2026-05-31-assumption-graph.contract.md
+++ b/docs/contracts/2026-05-31-assumption-graph.contract.md
@@ -1,10 +1,10 @@
 # Temporal Assumption Graph — Cross-Repo Contract
 
-**Version:** 0.1.0 (draft, Phase 0 — schema only)
+**Version:** 0.4.0 (Phases 1–4 implemented — **freeze-candidate**, pending operator sign-off)
 **Schema version:** 1
-**Status:** Draft (Phase 0 of the `assumption-graph` campaign, 2026-05-31). Drafts are not frozen; freeze milestone is end of Phase 4 (per ecosystem convention).
-**Producers (planned):** `ix-assumption-graph` builder, `ix-ai-annotations` (via node promotion), `/deep-research` workflow (research-claim nodes), the longitudinal verify→revise loop
-**Consumers (planned):** `ix-assumption-graph` acceptability/query engine, `belief_at(t)` time-travel query, Demerzel promotion gate, (later) an MCP tool `ix_assumption_query`
+**Status:** Phases 1–4 shipped in `ix-assumption-graph` (graph + fusion + belief-time + MCP). The `node`/`edge`/`belief_event` records, the reused enums, and the `opinion` shape are stable. Freeze (→ v1.0.0, locking the one-way-door fields) is a **one-way door requiring operator sign-off** — NOT done unilaterally.
+**Producers:** `ix-assumption-graph` builder (`from_workspace`/`from_parts`), `ix-ai-annotations` (via node promotion), `/deep-research` (research-claim nodes via the `assumption-graph-loop` skill), the `revise` loop
+**Consumers:** `ix-assumption-graph` fusion/`view`/`belief_at`, the MCP tools `ix_assumption_query` + `ix_assumption_belief_at`, Demerzel promotion gate, (later) Prime Radiant / dashboard visualization
 **Schema file:** `docs/contracts/assumption-graph.schema.json`
 **Design doc:** `docs/plans/2026-05-31-temporal-assumption-graph.md`
 
@@ -146,7 +146,18 @@ The "do multi-LLM panels improve correctness or amplify shared bias?" question i
 - **Phase 1:** `ix-assumption-graph` crate — build `Dag<AssumptionNode>` from `@ai:` annotations; derive `contradicts` from `contrary`.
 - **Phase 2:** opinion fusion + Belnap `C` synthesis + the §4 bridge (reuses `ix-fuzzy`, `hari`).
 - **Phase 3:** belief-event log + `belief_at(t)` / `diff(t1,t2)`; the longitudinal loop ( `/deep-research` → research-claim nodes; scheduled re-verify; Demerzel promotion gate).
-- **Phase 4:** MCP exposure + freeze.
+- **Phase 4 (shipped):** node enums split from the annotation enums — `research-claim` kind and `adversarial-panel` certainty are now first-class (`NodeKind`/`NodeCertainty`); faceted navigation `view()` (by namespace / kind / domain + escalations); MCP tools `ix_assumption_query` (faceted view) and `ix_assumption_belief_at` (point-in-time belief state). **Freeze (→ v1.0.0) pending operator sign-off.**
+
+### Navigation & structure
+
+The graph is navigable along two axes (`AssumptionGraph::view` → `FacetedView`):
+- **namespace** — code-anchored nodes by crate (`crates/<crate>/…` → `<crate>`); research claims under `research`;
+- **domain / kind** — `dev` vs `research`; and the node `kind`.
+
+Finer "functional area" grouping (below crate/module) would need explicit tags
+on annotations — not currently modeled. Humans navigate via the
+`ix-assumption-graph-report` CLI or (future) Prime Radiant; agents via
+`ix_assumption_query`.
 
 ---
 

--- a/docs/contracts/2026-05-31-assumption-graph.contract.md
+++ b/docs/contracts/2026-05-31-assumption-graph.contract.md
@@ -1,0 +1,160 @@
+# Temporal Assumption Graph — Cross-Repo Contract
+
+**Version:** 0.1.0 (draft, Phase 0 — schema only)
+**Schema version:** 1
+**Status:** Draft (Phase 0 of the `assumption-graph` campaign, 2026-05-31). Drafts are not frozen; freeze milestone is end of Phase 4 (per ecosystem convention).
+**Producers (planned):** `ix-assumption-graph` builder, `ix-ai-annotations` (via node promotion), `/deep-research` workflow (research-claim nodes), the longitudinal verify→revise loop
+**Consumers (planned):** `ix-assumption-graph` acceptability/query engine, `belief_at(t)` time-travel query, Demerzel promotion gate, (later) an MCP tool `ix_assumption_query`
+**Schema file:** `docs/contracts/assumption-graph.schema.json`
+**Design doc:** `docs/plans/2026-05-31-temporal-assumption-graph.md`
+
+---
+
+## 1. Why This Contract Exists
+
+The `@ai:` annotation contract (`docs/contracts/ai-annotation.schema.json`) captures a line-local claim with a hexavalent truth value — but each annotation is **isolated and static**. It does not relate to other claims (no support/contradiction structure), and it does not track *how a belief changed over time* or *why*. Research output (`/deep-research`, `seldon-research`) has the same problem one level up: a report's conclusions are a snapshot that cannot later tell you one of its load-bearing claims has since been contradicted.
+
+This contract defines the records for a **unified, longitudinal assumption graph** spanning both **dev assumptions** (promoted from `@ai:` annotations) and **research claims** (ingested from `/deep-research`), where each node carries epistemic state that is **revised over belief-time** as evidence accumulates. It is the data layer for "a semantic story that runs over a long period," not a snapshot.
+
+It deliberately **reuses** the `@ai:` annotation vocabulary (truth-value enum, certainty markers, confidence thresholds, `source` block, deterministic SHA-256 id) so a dev annotation promotes into a graph node without re-encoding, and adds exactly four things the annotation layer lacks:
+
+1. **A subjective-logic opinion** `(b, d, u, a)` — a fusable certainty carrier (Jøsang).
+2. **An ABA `contrary`** + **edges** (`contradicts` / `supports` / `depends_on` / `refined_from`) — relational structure.
+3. **A belief-time axis** — `asserted_at` / `revised_at`, distinct from record bookkeeping and from domain valid-time.
+4. **A belief-event log** — append-only revision history (Phase 3).
+
+The formal grounding for each of these is in the design doc §3 (ABA, ATMS, subjective logic, belief-time bitemporal — externally verified) and is **not re-derived here**.
+
+---
+
+## 2. Record Types
+
+The graph is stored as JSONL, one record per line. Every record has `schema_version` and a `record` discriminator: `node` | `edge` | `belief_event`.
+
+### 2.1 Node — an assumption or claim
+A superset of an `@ai:` annotation. Reused fields keep identical semantics. New fields: `opinion`, `contrary`, `origin`, `belief_time`.
+
+```json
+{
+  "schema_version": 1,
+  "record": "node",
+  "id": "sha256:f3b1c2...",
+  "kind": "assumption",
+  "claim": "caller holds the lock",
+  "truth_value": "P",
+  "certainty": "assumed",
+  "confidence": 0.7,
+  "opinion": { "b": 0.7, "d": 0.0, "u": 0.3, "a": 0.5 },
+  "contrary": null,
+  "origin": { "annotation_id": "sha256:f3b1c2...", "research_run": null },
+  "source": { "author": "claude", "model": "claude-opus-4-8", "independence_class": "human-review" },
+  "location": { "path": "crates/ix-x/src/y.rs", "line_start": 88, "line_end": 88 },
+  "belief_time": { "asserted_at": "2026-05-31T00:00:00Z", "revised_at": "2026-05-31T00:00:00Z" },
+  "created_at": "2026-05-31T00:00:00Z",
+  "updated_at": "2026-05-31T00:00:00Z"
+}
+```
+
+### 2.2 Edge — a relation between nodes
+```json
+{ "schema_version": 1, "record": "edge", "id": "sha256:...", "type": "contradicts",
+  "from": "sha256:<conclusion>", "to": "sha256:<assumption>", "weight": 0.8,
+  "created_at": "2026-05-31T00:00:00Z" }
+```
+`contradicts` carries ABA attack semantics; the acceptability decision uses **only** the `contradicts` sublattice in v1 (see §6). The other edge types are provenance/propagation hints, excluded from the formal computation.
+
+### 2.3 Belief-event — an append-only revision (Phase 3)
+```json
+{ "schema_version": 1, "record": "belief_event", "node_id": "sha256:...",
+  "at": "2026-06-15T00:00:00Z", "from_truth_value": "P", "to_truth_value": "F",
+  "to_opinion": { "b": 0.05, "d": 0.9, "u": 0.05, "a": 0.5 },
+  "trigger": "test-run", "evidence": "tests/lock_test.rs:31" }
+```
+Replaying belief-events reconstructs `belief_at(t)`.
+
+---
+
+## 3. Reused Vocabulary (see `ai-annotation.schema.json` for full tables)
+
+- **`truth_value`** — hexavalent `T/P/U/D/F/C`, identical to the annotation contract and Demerzel `hexavalent-distribution.schema.json`.
+- **`certainty`** — the eight annotation markers, plus **`adversarial-panel`** (verdict from a multi-judge panel; see §7).
+- **`confidence`** — `0.0–1.0`, Demerzel thresholds (≥0.9 / ≥0.7 / ≥0.5 / ≥0.3 / <0.3).
+- **`source.author`** — the annotation authors, plus **`deep-research`**.
+- **`id`** — deterministic SHA-256; dev nodes use the annotation scheme (`path:line_start:kind:claim`) so an annotation and its node share identity; research nodes hash `normalized(source_url + ':' + claim)`.
+
+---
+
+## 4. The Opinion ↔ Truth-Value Bridge
+
+`opinion` is the math carrier; `truth_value` is the governance/human-readable label. They are kept consistent by the producer via the projection table (design doc §5). Summary: `b` high & `u` low → `T`; `b>d`, moderate `u` → `P`; high `u` → `U`; `d>b` → `D`; `d` high → `F`; **`b` and `d` both high from _conflicting_ fused evidence → `C`** (which is outside the `b+d+u=1` simplex — Belnap supplies `C`, subjective logic supplies the rest). Projected probability `E = b + a·u` is the scalar for ranking and promotion thresholds.
+
+---
+
+## 5. Belief-Time vs Other Time Axes
+
+| axis | meaning | where |
+|---|---|---|
+| `created_at` / `updated_at` | record bookkeeping (when the JSONL line was written) | every record |
+| `belief_time.asserted_at` / `revised_at` | **when we first held / last changed this belief** | node |
+| `valid_time` (future) | when the claim is true in the domain | deferred |
+
+The `belief_time` axis is what the 2015 belief-based bitemporal model calls "belief time," distinct from transaction time (design doc §3). It is the axis `belief_at(t)` queries.
+
+---
+
+## 6. Acceptability (v1 scope)
+
+Promote/demote decisions follow ABA dispute-derivation semantics over the `contradicts` sublattice only. Support edges are **deliberately excluded** from the formal acceptability computation in v1, because support pushes the framework into non-flat / bipolar argumentation where Dung's semantics do not all transfer (design doc §6, caution 2). Support/depends_on/refined_from are retained for provenance and for human/agent navigation.
+
+---
+
+## 7. Fusion Discipline & Panel Discipline (load-bearing)
+
+Evidence accumulates by **subjective-logic fusion** over the per-node `opinion`. The rules below are grounded in externally-verified findings (design doc §6, and the panel mini-survey 2026-05-31).
+
+### 7.1 Fusion
+**Cumulative (additive) fusion only across distinct `independence_class` values.** Cumulative fusion assumes independent evidence; summing correlated sources over-counts and **overstates certainty**. Observations sharing a class (same model lineage, repeated runs of one agent) must use **averaging** fusion.
+
+### 7.2 The `adversarial-panel` certainty: fail-closed gate, NOT a truth oracle
+The "do multi-LLM panels improve correctness or amplify shared bias?" question is now **resolved** (it was the one fully-failed angle of the first research run; a focused, source-verified re-run settled it). The answer is asymmetric and consequential:
+
+- **Panels confirm well, reject poorly.** LLM judges show ~96% true-positive but **<25% true-negative** rates, and **majority voting does not fix this** (Jain et al. 2025, arXiv:2510.11822). A panel is reliable at *agreeing something looks valid*, unreliable at *catching invalidity*.
+- **Independence is the mechanism, not panel size.** A diverse panel beats a single judge *only* when models are disjoint families (Verga et al. 2024, arXiv:2404.18796). Same-family debate/aggregation *amplifies* shared errors — "belief entrenchment" (arXiv:2503.16814), and debate can *decrease* accuracy even when strong models outnumber weak ones (arXiv:2509.05396).
+- Single-judge biases (position, verbosity, self-preference) persist at panel level; self-preference is a perplexity/familiarity effect, so same-family panels do **not** cancel it (arXiv:2306.05685, arXiv:2410.21819).
+
+**Mandatory discipline for any `adversarial-panel` verdict driving promote/demote:**
+1. **Asymmetric gate.** Require panel consensus to **promote** toward `T`; let **any single credible dissent** force `U`/`D`/`C` rather than promotion. Never let majority-approve override a substantive minority refutation.
+2. **Map disagreement to hexavalent values — do not collapse to a vote.** Unanimous + high per-judge confidence → `T`/`F`; split or low-confidence → `U`/`P`; active contradiction between judges → `C`. This preserves the dissent signal a majority vote destroys.
+3. **Mandate + measure judge independence.** Panel must span genuinely different pretraining lineages (distinct `independence_class`). Operationalize decorrelation (e.g. a focal-diversity metric, arXiv:2410.03953) or track per-judge error correlation on a gold set; if errors are correlated, agreement is illusory — discount it.
+4. **Fail closed.** When a judge errors/abstains, never default to "survived" (`feedback_workflow_schema_catch_green_but_dead`).
+5. **Guardrail metric = TNR, not agreement.** Hold out a labeled set of assumptions with known T/P/U/D/F/C verdicts and report the panel's **true-negative rate** (catch-rate on bad claims). A panel that agrees 95% of the time but has <30% TNR is "green but dead" for a demotion gate.
+
+---
+
+## 8. Storage Layout (planned)
+
+| file | producer | consumer |
+|---|---|---|
+| `state/assumptions/graph.jsonl` | `ix-assumption-graph build` | acceptability/query engine, dashboard |
+| `state/assumptions/belief-events.jsonl` | revise loop (Phase 3) | `belief_at(t)` / `diff(t1,t2)` |
+
+---
+
+## 9. Phase Plan (this contract = Phase 0)
+
+- **Phase 0 (this artifact):** contract + JSON schema. **No code.**
+- **Phase 1:** `ix-assumption-graph` crate — build `Dag<AssumptionNode>` from `@ai:` annotations; derive `contradicts` from `contrary`.
+- **Phase 2:** opinion fusion + Belnap `C` synthesis + the §4 bridge (reuses `ix-fuzzy`, `hari`).
+- **Phase 3:** belief-event log + `belief_at(t)` / `diff(t1,t2)`; the longitudinal loop ( `/deep-research` → research-claim nodes; scheduled re-verify; Demerzel promotion gate).
+- **Phase 4:** MCP exposure + freeze.
+
+---
+
+## 10. Versioning
+
+`v0.1.0` (draft). The `record` discriminator, the reused enums, and the `opinion` shape are intended to be stable from Phase 1. `schema_version` bumps only on a field rename/removal or an enum widening that consumers must opt into; new optional fields are additive.
+
+### Changelog
+- **v0.1.0 (2026-05-31, schema_version 1)** — initial draft: `node` / `edge` / `belief_event` records; reuses `@ai:` annotation vocabulary; adds subjective-logic `opinion`, ABA `contrary` + edges, `belief_time` axis, and the `adversarial-panel` certainty + `independence_class` fusion tag.
+
+**One-way-door note:** the `id` scheme and the `truth_value` enum align with the `@ai:` annotation contract and Demerzel — changing them is a one-way door requiring cross-repo sign-off. Everything else in this draft is two-way until Phase 4.

--- a/docs/contracts/assumption-graph.schema.json
+++ b/docs/contracts/assumption-graph.schema.json
@@ -144,8 +144,8 @@
     "belief_event": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Append-only revision record: the audit trail of how a node's epistemic state changed over belief-time. The temporal index (belief_at(t), diff(t1,t2)) is reconstructed by replaying these. Deferred to Phase 3 — defined here so the JSONL schema is forward-stable.",
-      "required": ["schema_version", "record", "node_id", "at", "to_truth_value", "to_opinion"],
+      "description": "Append-only revision record: the audit trail of how a node's epistemic state changed over belief-time. The temporal index (belief_at(t), diff(t1,t2)) is reconstructed by replaying these. Implemented in Phase 3 (ix-assumption-graph::temporal). `node_id` is the claim-level id (sha256 over the normalized claim). `to_opinion` is OPTIONAL — absent when to_truth_value is C, which lies outside the subjective-logic simplex.",
+      "required": ["schema_version", "record", "node_id", "at", "to_truth_value"],
       "properties": {
         "schema_version": { "type": "integer", "enum": [1] },
         "record": { "const": "belief_event" },

--- a/docs/contracts/assumption-graph.schema.json
+++ b/docs/contracts/assumption-graph.schema.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GuitarAlchemist/ix/contracts/assumption-graph-v1.json",
+  "title": "Temporal Assumption Graph Record",
+  "description": "One JSONL record of the temporal assumption graph: a node (an assumption/claim with a hexavalent truth value + subjective-logic opinion), an edge (ABA-style relation between nodes), or a belief-event (an append-only revision of a node's epistemic state over belief-time). Reuses the truth_value / certainty / confidence / source vocabulary of the @ai: annotation contract (docs/contracts/ai-annotation.schema.json) so dev annotations promote into nodes without re-encoding. See docs/contracts/2026-05-31-assumption-graph.contract.md and docs/plans/2026-05-31-temporal-assumption-graph.md.",
+  "type": "object",
+  "required": ["schema_version", "record"],
+  "properties": {
+    "schema_version": { "type": "integer", "enum": [1] },
+    "record": { "type": "string", "enum": ["node", "edge", "belief_event"] }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/node" },
+    { "$ref": "#/$defs/edge" },
+    { "$ref": "#/$defs/belief_event" }
+  ],
+  "$defs": {
+    "hexavalent": {
+      "type": "string",
+      "enum": ["T", "P", "U", "D", "F", "C"],
+      "description": "Hexavalent truth value per Demerzel hexavalent-distribution.schema.json. T True / P Probable / U Unknown / D Doubtful / F False / C Contradictory."
+    },
+    "opinion": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Subjective-logic (Josang) binomial opinion: the certainty carrier. INVARIANT (producer-enforced, not expressible in plain JSON Schema): b + d + u == 1 (within tolerance). Projected probability E = b + a*u. Mapping to truth_value is the projection table in the contract (e.g. b high & u low -> T; u high -> U; b & d both high from conflicting fused evidence -> C, which is OUTSIDE this simplex and signals escalation).",
+      "required": ["b", "d", "u", "a"],
+      "properties": {
+        "b": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "belief mass" },
+        "d": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "disbelief mass" },
+        "u": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "uncertainty mass" },
+        "a": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "base rate (prior)" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["author"],
+      "description": "Reuses the @ai: annotation source block, widened with `deep-research` for research-claim provenance.",
+      "properties": {
+        "author": {
+          "type": "string",
+          "enum": ["claude", "codex", "gemini", "junie", "auggie", "human", "auto", "sentrux", "product-owner", "telemetry", "deep-research"]
+        },
+        "model": { "type": "string", "description": "Optional model id e.g. claude-opus-4-8." },
+        "evidence": { "type": "string", "description": "Optional evidence reference: test path:line, PR#, MIRI run id, or a confirmed-real source URL." },
+        "independence_class": {
+          "type": "string",
+          "description": "Source-independence tag used by the fusion layer. Cumulative (additive) fusion is only valid ACROSS distinct classes; observations sharing a class (same model lineage, repeated runs of one agent) must be combined with averaging fusion to avoid over-counting / certainty overstatement. See contract section 7.",
+          "examples": ["test-suite", "sentrux", "human-review", "llm:anthropic", "llm:openai", "llm:google", "deep-research-panel"]
+        }
+      }
+    },
+    "node": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "record", "id", "kind", "claim", "truth_value", "certainty", "confidence", "opinion", "source", "created_at", "updated_at"],
+      "properties": {
+        "schema_version": { "type": "integer", "enum": [1] },
+        "record": { "const": "node" },
+        "id": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$",
+          "description": "Deterministic SHA-256. For dev nodes: same scheme as @ai: annotations (path:line_start:kind:claim) so an annotation and its graph node share identity. For research-claim nodes: sha256 over normalized(source_url + ':' + claim)."
+        },
+        "kind": {
+          "type": "string",
+          "enum": ["invariant", "assumption", "hypothesis", "contract", "smell", "decision", "hint", "business-value", "hot-path", "research-claim"],
+          "description": "Reuses the nine @ai: annotation kinds, plus `research-claim` for nodes ingested from /deep-research."
+        },
+        "claim": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "truth_value": { "$ref": "#/$defs/hexavalent" },
+        "certainty": {
+          "type": "string",
+          "enum": ["test", "formal-proof", "manually-reviewed", "assumed", "uncertain", "inferred", "dismissed", "detected-by-sentrux", "adversarial-panel"],
+          "description": "Reuses the @ai: certainty markers, plus `adversarial-panel` for a verdict reached by a multi-judge panel (treated as a fail-closed gate, NOT a truth oracle — see contract section 7)."
+        },
+        "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0 },
+        "opinion": { "$ref": "#/$defs/opinion" },
+        "contrary": {
+          "type": ["string", "null"],
+          "description": "ABA contrary: the node id whose acceptance attacks this assumption. Drives a `contradicts` edge. Null if no contrary declared."
+        },
+        "origin": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Where this node came from. Exactly one of annotation_id / research_run is expected to be non-null.",
+          "properties": {
+            "annotation_id": { "type": ["string", "null"], "description": "sha256 id of the source @ai: annotation, if this node was promoted from one." },
+            "research_run": { "type": ["string", "null"], "description": "Identifier of the /deep-research run that produced this claim, if any." }
+          }
+        },
+        "source": { "$ref": "#/$defs/source" },
+        "location": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Optional — present for dev nodes anchored to code; absent for research claims.",
+          "required": ["path", "line_start", "line_end"],
+          "properties": {
+            "path": { "type": "string" },
+            "line_start": { "type": "integer", "minimum": 1 },
+            "line_end": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "belief_time": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The longitudinal axis. asserted_at = when this belief was first held; revised_at = when its truth_value/opinion last changed. Distinct from created_at/updated_at (record bookkeeping) and from any valid_time (when the claim is true in the domain).",
+          "required": ["asserted_at", "revised_at"],
+          "properties": {
+            "asserted_at": { "type": "string", "format": "date-time" },
+            "revised_at": { "type": "string", "format": "date-time" }
+          }
+        },
+        "stale": { "type": "boolean", "default": false },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "edge": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "record", "id", "type", "from", "to", "created_at"],
+      "properties": {
+        "schema_version": { "type": "integer", "enum": [1] },
+        "record": { "const": "edge" },
+        "id": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$", "description": "sha256 over from:type:to." },
+        "type": {
+          "type": "string",
+          "enum": ["supports", "contradicts", "depends_on", "refined_from"],
+          "description": "`contradicts` carries formal ABA attack semantics (the acceptability decision uses ONLY the contradicts sublattice in v1). `supports`/`depends_on`/`refined_from` are provenance/propagation hints — adding them moves the graph into non-flat/bipolar territory where Dung semantics do not all hold, so they are deliberately excluded from the acceptability computation in v1."
+        },
+        "from": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "to": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "weight": {
+          "type": "number",
+          "minimum": 0.0,
+          "maximum": 1.0,
+          "description": "Optional graded strength (possibilistic alpha-ATMS style necessity lower bound) for support/attack."
+        },
+        "created_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "belief_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Append-only revision record: the audit trail of how a node's epistemic state changed over belief-time. The temporal index (belief_at(t), diff(t1,t2)) is reconstructed by replaying these. Deferred to Phase 3 — defined here so the JSONL schema is forward-stable.",
+      "required": ["schema_version", "record", "node_id", "at", "to_truth_value", "to_opinion"],
+      "properties": {
+        "schema_version": { "type": "integer", "enum": [1] },
+        "record": { "const": "belief_event" },
+        "node_id": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "at": { "type": "string", "format": "date-time", "description": "Belief-time of this revision." },
+        "from_truth_value": { "$ref": "#/$defs/hexavalent" },
+        "to_truth_value": { "$ref": "#/$defs/hexavalent" },
+        "to_opinion": { "$ref": "#/$defs/opinion" },
+        "trigger": {
+          "type": "string",
+          "description": "What caused the revision.",
+          "examples": ["test-run", "sentrux-scan", "deep-research-reverify", "manual-review", "contradiction-detected", "fusion-merge"]
+        },
+        "evidence": { "type": "string", "description": "Evidence reference for this specific revision." }
+      }
+    }
+  }
+}

--- a/docs/plans/2026-05-31-temporal-assumption-graph.md
+++ b/docs/plans/2026-05-31-temporal-assumption-graph.md
@@ -1,0 +1,206 @@
+# Temporal Assumption Graph — Architecture Spec + Build-vs-Buy Verdict
+
+- **Date:** 2026-05-31
+- **Branch context:** `feat/adversarial-llm-panel`
+- **Status:** Design spec (no code yet). Decision doc per CLAUDE.md "Log one-way doors".
+- **Author:** Claude (Opus 4.8) with operator Stephane Pareilleux
+- **Method:** internal prior-art sweep (Explore agent over the IX workspace) + external `/deep-research` fan-out (106 agents, 24 sources, 25 claims adversarially verified, 17 confirmed). Research-quality caveats are in §8.
+
+---
+
+## 0. TL;DR / The decision
+
+**Build, don't buy. And mostly *compose*, don't build.**
+
+The system you described — extract and maintain over time a unified graph of *assumptions* (both code-level dev assumptions and research-domain claims), each carrying a hexavalent truth value + certainty, promoted/demoted as evidence accumulates — is **~70% already present in IX as unconnected primitives**. The missing 30% is one thin crate (`ix-assumption-graph`), a time-travel query, and a longitudinal loop where `/deep-research` is the evidence arm.
+
+**graphify and understand-anything are orthogonal** — they are snapshot GraphRAG *comprehension* tools (Tree-sitter + LLM extraction, token compression), with no truth values and no temporal belief revision. They solve "make my codebase cheaply queryable," not "track what we believe and why, over time." **You do not need either to build this.** (Optional, narrow reuse noted in §3.)
+
+The external literature says: **don't invent the epistemics — assemble four settled formalisms** (ABA, possibilistic ATMS, subjective logic, belief-time bitemporal modeling) and map each onto a primitive you already have.
+
+---
+
+## 1. Problem frame (who is in pain, what changes)
+
+**Today:** IX/GA development generates assumptions constantly — `@ai:invariant`, `@ai:hypothesis`, `@ai:assumption` annotations in code; design decisions in `docs/plans/`; research conclusions in `state/knowledge/`. They are **write-once and decay silently.** Nothing tracks "we believed X with certainty 0.7 on 2026-04-01; a test on 2026-05-01 refuted it; what downstream claims depended on X?" Research output is a *snapshot report* — it cannot tell you later that one of its load-bearing claims has since been contradicted.
+
+**The pain:** "green-but-dead" beliefs. An assumption that was once true (or once *asserted*) is treated as still-true forever, with no mechanism to flip it to `D`/`F`/`C` when evidence arrives, and no record of *why* it flipped. This is precisely the failure class your memory keeps flagging (`feedback_green_but_dead`, `feedback_completion_bias`).
+
+**What changes for whom:**
+- *Developers:* `@ai:` assumptions become living nodes — a test run can promote `U→P→T` or refute `P→D→F`, and contradictions (`C`) escalate automatically per Demerzel thresholds.
+- *Research (`/deep-research`, `seldon-research`):* a report's claims persist as graph nodes; a later run re-verifies them, and the graph shows which past conclusions have weakened. "A semantic story that runs over a long period" = the belief-time axis of this graph.
+- *Governance:* assumptions crossing certainty thresholds become candidates for promotion to invariants / policy, with a full derivation trail.
+
+---
+
+## 2. Build-vs-buy verdict on the two products
+
+> **Provenance flag:** the `/deep-research` workflow produced **no verified claims** on this angle (verifier sub-agents died — see §8). This verdict rests on direct page fetches I performed (graphify.net 403'd; GitHub + WebSearch + understand-anything.com succeeded) plus their READMEs. Confidence: medium-high on *what they are*, high on *that they're orthogonal*.
+
+| | **graphify** ([safishamsi/graphify](https://github.com/safishamsi/graphify)) | **understand-anything** ([Lum1104/Understand-Anything](https://github.com/Lum1104/Understand-Anything)) | **What we need** |
+|---|---|---|---|
+| Job | Codebase+docs → queryable knowledge graph for AI coding assistants | Code → business-context knowledge graph (anti-"hairball") | Assumption graph with epistemic state |
+| Extraction | Tree-sitter AST + LLM semantic + vision for diagrams | Tree-sitter + LLM, 26+ file types | N/A — we ingest `@ai:` annotations + research claims |
+| Time model | **Snapshot** | **Snapshot** | **Belief-time + valid-time (bitemporal+)** |
+| Truth model | None (concept/symbol nodes) | None | **Hexavalent T/P/U/D/F/C + certainty** |
+| Verification | None | None | **Adversarial → promote/demote** |
+| Headline | ~71.5× token compression vs raw-file reading | "god nodes", "surprising connections", "why" extraction | belief revision + derivation provenance |
+| License | Open source (skill) | MIT | (internal crate) |
+
+**Verdict: orthogonal comprehension tools — not building blocks for the temporal assumption graph. Do not adopt for this purpose.**
+
+**The one defensible narrow reuse** (optional, low priority): graphify/understand-anything's *Tree-sitter+LLM extraction layer* is a mature pattern for turning prose/code into candidate nodes. But IX already has `ix-code::semantic` (call-graph/AST) and `ix-ai-annotations` (the `@ai:` extractor), so even this is **duplication, not gap-fill.** If anything, graphify is a useful *comparator* for the comprehension/RAG side of GA's chatbot — a separate concern from this spec.
+
+---
+
+## 3. Prior-art map: external formalism → IX primitive you already have
+
+This is the core finding. Each row is a verified external formalism mapped to an existing Rust primitive. **The architecture is the union of these rows.**
+
+| External formalism (verified) | What it gives | IX primitive it maps onto | Confidence |
+|---|---|---|---|
+| **Assumption-Based Argumentation (ABA)** — framework `⟨L, R, A, ̄ ⟩`; attacks via the *contrary* relation, always directed at assumptions; `dispute derivations` are an operational proponent/opponent proof procedure for claim acceptability | The *edge semantics* (attack/contradiction) + an **algorithmic template for the promote/demote decision** | Attack edges in `ix-pipeline::dag::Dag<N>`; dispute-derivation loop as the acceptability checker | **High (3-0)** |
+| **ATMS** — node label = set of *environments* (consistent assumption sets that support it); inconsistent sets recorded as `NOGOOD`s and removed with all supersets; labels kept subset-minimal; updated **incrementally** | Support/contradiction **provenance over assumption sets** | `hari` derivation-provenance + `ix-fuzzy` contradiction synthesis; NOGOODs ≈ the `C` (Contradictory) synthesis path | **High (3-0)** |
+| **Possibilistic α-ATMS** — each assumption carries a numeric weight (necessity lower bound); tracks an inconsistency degree; allows ranked solutions | **Graded** certainty on provenance (not binary) | Confidence floats already on `@ai:` annotations + Demerzel thresholds | **High (3-0)** |
+| **Subjective Logic (Jøsang)** — binomial opinion `(b, d, u, a)`, `b+d+u=1`, projection `E = b + a·u`; `b=1`→TRUE, `d=1`→FALSE, `b+d<1`→uncertainty | **The formal bridge** between a discrete truth value and a continuous, *fusable* confidence | The certainty scalar on each node; see §5 for the hexavalent↔opinion bridge | **High (3-0)**; the *specific* 6-valued mapping is an interpretive bridge (medium) |
+| **Subjective-logic cumulative fusion** — vector-add of evidence ≡ Dirichlet posterior update; commutative+associative (a join semigroup) | Evidence accumulation over time as a **CRDT-friendly merge** | `ix-fuzzy::observations::merge()` (G-Set CRDT + Belnap synthesis) | **High (3-0)** |
+| **Belief-time bitemporal model** (Jiratanachit & Chittayasothorn 2015) — adds a **third axis, "belief time,"** distinct from transaction time; stores *multiple differing beliefs about the same fact over the same valid-time interval* | The temporal substrate for **genuine belief revision** (not snapshot storage) | The persistence layer (new) — a belief-time index over `state/` JSONL | **High (3-0)**; query mechanics unverified (paywalled) |
+| **BiTRDF** (Mathematics 2025) — uniformly bitemporal RDF | Confirms uniform temporalization is sound | reference only — **theory-only, no truth values, no revision** | High (3-0) but **low reusability** |
+| **OSTRICH** (JWS 2018) — RDF archive = intermittent full snapshots + independent delta chains; any version = 1 snapshot + 1 delta; **ordinal** versions, not timestamps | A concrete **versioned-store storage pattern** | Optional storage layout for the belief-time store | High (2-0); orthogonal to belief/valid time |
+
+**Closest production comparator (angle 5, not verified but known):** **Graphiti** (getzep) is a *bi-temporal* agent-memory graph — it tracks valid-time + ingestion-time per edge and does *edge invalidation* when facts change. That is the nearest shipped thing to "beliefs over time." But it **invalidates** facts (present/absent), it does **not** carry a truth-value lattice or do adjudicated promotion/demotion. So it confirms the bi-temporal substrate is the right call, and confirms the *epistemic* layer (hexavalent + adversarial verify) is our differentiator.
+
+---
+
+## 4. Architecture — `ix-assumption-graph`
+
+Three layers over existing primitives. The new code is the **wiring + the temporal index + the loop**, not the epistemics.
+
+```
+                 ┌─────────────────────────────────────────────────────┐
+   INGEST        │  dev side: ix-ai-annotations  →  @ai:assumption /     │
+   (existing)    │            invariant / hypothesis nodes (free)        │
+                 │  research side: /deep-research verified claims        │
+                 │            →  research-claim nodes (same schema)      │
+                 └───────────────────────────┬─────────────────────────┘
+                                              ▼
+                 ┌─────────────────────────────────────────────────────┐
+   GRAPH         │  ix-pipeline::dag::Dag<AssumptionNode>                │
+   (existing)    │  edges: Supports / Contradicts(=ABA contrary) /       │
+                 │         DependsOn / RefinedFrom                       │
+                 └───────────────────────────┬─────────────────────────┘
+                                              ▼
+                 ┌─────────────────────────────────────────────────────┐
+   BELIEF        │  ix-fuzzy::observations::merge  (CRDT + Belnap)        │
+   SUBSTRATE     │  hari: derivation provenance + trust-weighted         │
+   (existing)    │        consensus  (≈ ATMS environments/NOGOODs)       │
+                 │  certainty fusion = subjective-logic cumulative       │
+                 │        (GUARDED: independence check — see §6)         │
+                 └───────────────────────────┬─────────────────────────┘
+                                              ▼
+                 ┌─────────────────────────────────────────────────────┐
+   TEMPORAL      │  *** NEW *** belief-time index                        │
+   STORE         │  belief_at(t) → Dag<AssumptionNode>                   │
+   (gap #2)      │  diff(t1, t2) → what flipped & why                    │
+                 └─────────────────────────────────────────────────────┘
+```
+
+### 4.1 Node schema (`AssumptionNode`)
+```rust
+struct AssumptionNode {
+    id: Sha256,                 // stable identity — SAME scheme as @ai: annotations
+    claim: String,
+    kind: Kind,                 // DevInvariant | DevHypothesis | DevAssumption | ResearchClaim
+    truth: Hexavalent,          // ix-types::Hexavalent — T/P/U/D/F/C
+    opinion: Opinion,           // (b,d,u,a) subjective-logic — the certainty carrier
+    evidence: Vec<EvidenceRef>, // src path / test id / source URL + verify vote
+    contrary: Option<NodeId>,   // ABA contrary → drives Contradicts edges
+    created: BeliefTime,
+    updated: BeliefTime,
+}
+```
+- `truth` and `opinion` are **redundant by design** and kept consistent via the §5 bridge. `truth` is for governance gates / human reading; `opinion` is for fusion math.
+- `id` reuses the existing `SHA256(path:line:kind:claim)` so a dev assumption keeps identity across edits and across the temporal axis.
+
+### 4.2 Edge types
+- `Contradicts` ← **ABA contrary relation** (verified). The one we get formal semantics for free.
+- `Supports`, `DependsOn`, `RefinedFrom` — **CAUTION:** support edges push us out of flat-ABA / Dung into **non-flat ABA / bipolar argumentation**, where "all Dung semantics apply" no longer holds (verified 3-0). See §6.
+
+### 4.3 The longitudinal loop (gap #3 — where `/deep-research` plugs in)
+```
+hypothesis(U) ──gather evidence──▶ adversarial verify ──▶ fuse(opinion) ──▶ revise(truth)
+     ▲                                                                          │
+     └──────────────── re-check on schedule / on contradiction ◀───────────────┘
+```
+- "gather evidence" for research claims = a `/deep-research` run; for dev assumptions = a test run / sentrux scan / `ix-ai-annotations` reconcile.
+- "revise" follows the verified hexavalent transition rules (`U→P`, `P→T`, `D→F`; never `T→F` directly — must pass through `C` or `U`).
+
+---
+
+## 5. The hexavalent ↔ subjective-logic bridge (the formal glue)
+
+The research nailed the binary anchors (`b=1`→T, `d=1`→F, `b+d<1`→uncertainty, verified). Extending to all six values is a **design inference** (flagged medium-confidence) — propose this projection, to be ratified against `governance/demerzel/logic/hexavalent-logic.md`:
+
+| Hexavalent | Subjective-logic opinion region | Projected `E=b+a·u` |
+|---|---|---|
+| **T** True | `b` high, `d≈0`, `u` low | → 1 |
+| **P** Probable | `b > d`, `u` moderate | > 0.5 |
+| **U** Unknown | `u` high (`b+d→0`) | ≈ base rate `a` |
+| **D** Doubtful | `d > b`, `u` moderate | < 0.5 |
+| **F** False | `d` high, `b≈0`, `u` low | → 0 |
+| **C** Contradictory | **outside the simplex** — `b` *and* `d` both high from *conflicting* fused evidence | undefined → escalate |
+
+**Key insight:** subjective logic alone *cannot* represent `C` (its `b+d+u=1` simplex has no "both" corner — that's Belnap's contribution). So the model is **Belnap FOUR for the lattice structure (gives us `C`) + subjective logic for the certainty carrier (gives us fusable confidence)**. This matches what IX already does: `ix-fuzzy` uses a *Belnap-extended* weight table for contradiction synthesis. The bridge is: fuse opinions cumulatively; if fusion yields jointly-high `b` and `d` from sources that *disagree*, that's the `C` synthesis path → node truth = `C`, escalate.
+
+---
+
+## 6. Risks & cautions (load-bearing — do not skip)
+
+1. **Cumulative-fusion over-counting (verified 3-0, highest-priority trap).** Cumulative fusion assumes **independent** evidence. Summing **correlated** sources — e.g. the same agent re-run, or a multi-LLM panel sharing training bias — **overstates certainty.** This is the *same shared-bias amplification* that makes naive judge-panels unreliable. **Mitigation:** tag every `EvidenceRef` with a source-independence class; use cumulative fusion only across independent classes, averaging fusion within a class. **This directly affects the `feat/adversarial-llm-panel` branch** — the panel must not be wired as N independent votes if the models share lineage.
+2. **Support edges break flat-ABA guarantees (verified 3-0).** Adding `Supports` lands us in non-flat/bipolar argumentation. **Mitigation:** keep the *acceptability decision* (dispute derivation) on the attack/`Contradicts` sublattice only; treat `Supports`/`DependsOn` as provenance/propagation hints, not as inputs to the formal semantics — at least in v1.
+3. **The LLM-judge-panel question — RESOLVED 2026-05-31 (was unresolved in the first run).** A focused, source-verified re-run settled it: LLM judges have ~96% TPR but **<25% TNR** and majority voting does not fix this (arXiv:2510.11822); panel bias-reduction holds *only* for disjoint model families (arXiv:2404.18796); same-family debate amplifies shared errors (arXiv:2503.16814, 2509.05396). **Verdict:** treat the panel as a **fail-closed, asymmetric gate** — consensus required to promote toward `T`, any credible dissent forces `U`/`D`/`C`; map disagreement to hexavalent values rather than collapsing to a vote; mandate + measure judge independence; guardrail metric is **TNR**, not agreement rate. Full discipline encoded in the contract §7.2.
+4. **Green-but-dead verifiers (observed this very run).** ~half the verify sub-agents died "without calling StructuredOutput." Any automation built on the deep-research panel must **fail closed** when a verifier dies, never default to "survived."
+5. **Temporal-RDF prior art is thin.** BiTRDF is theory-only; the belief-time paper is paywalled. Don't over-index on RDF tooling — the belief-time axis is better served by an append-only JSONL event log in `state/` (consistent with `ix-autoresearch` / hari streaming) than by a triplestore.
+
+---
+
+## 7. Phased plan (composition-first)
+
+| Phase | Deliverable | Reuses | New code | One/two-way door |
+|---|---|---|---|---|
+| **0** | `AssumptionNode` schema + JSON contract (`docs/contracts/`) | Hexavalent, `@ai:` id scheme | schema only | schema hash = **one-way** → sign-off |
+| **1** | `ix-assumption-graph` crate: build `Dag<AssumptionNode>` from `@ai:` annotations; `Contradicts` from ABA contrary | `ix-ai-annotations`, `ix-pipeline::dag` | wiring | two-way |
+| **2** | Belief substrate: opinion fusion + Belnap `C` synthesis + the §5 bridge | `ix-fuzzy`, `hari` | bridge + independence tags | bridge math = revisit-on-evidence |
+| **3** | Belief-time index: `belief_at(t)`, `diff(t1,t2)` over append-only JSONL | `ix-autoresearch` event pattern | temporal index | storage layout = soft one-way |
+| **4** | Longitudinal loop: `/deep-research` → research-claim nodes; scheduled re-verify; Demerzel promotion gate | `/deep-research`, Demerzel thresholds | loop + scheduler | two-way |
+| **5** | (optional) MCP exposure: `ix_assumption_query`, `ix_belief_at` | `ix-agent` | tool handlers | two-way |
+
+**Smallest useful slice (proof-of-life):** Phase 0+1 only — turn the `@ai:` annotations already in the repo into a queryable graph with `Contradicts` edges. That alone closes the "assumptions decay silently" pain for dev work, and validates the schema before any temporal/fusion complexity.
+
+---
+
+## 8. Research-quality caveats (full honesty)
+
+- **Verified well (high confidence):** ABA, ATMS, possibilistic α-ATMS, subjective logic + cumulative fusion, belief-time bitemporal, BiTRDF, OSTRICH. These are settled, slow-moving fields on primary literature.
+- **UNRESOLVED — angle 4 (LLM-judge panels):** every claim killed; one source (`arXiv 2603.06612`) is a **fabricated/future-dated ID**. The PoLL claims (`arXiv 2404.18796`) scored 0-0 (verifiers abstained/died, *not* refuted on merits). **Re-research independently before relying on the adversarial panel as a correctness mechanism.**
+- **UNANSWERED — angle 6 (graphify/understand-anything):** workflow produced no verified claims; the §2 verdict is from my own fetches, not the panel.
+- **Thin — angle 3 query mechanics:** belief-time paper paywalled (representation verified, querying not); several provenance claims (PROV-STAR, live SPARQL-star reconstruction, OCDM) refuted/unverified.
+- **Interpretive bridges (not source quotes):** "subjective logic → hexavalent lattice," "cumulative fusion → CRDT merge," "ATMS → derivation provenance" are sound design inferences the verifiers endorsed, **not** claims the papers make about this architecture.
+- **Tooling:** ~half the verify sub-agents died (`StructuredOutput` failure). The 17 confirmed survived genuine 3-0 / 2-0 votes; the 8 "killed" are mostly *abstentions from dead agents*, not substantive refutations — treat "killed" as "unverified," not "false."
+
+---
+
+## 9. Open questions (carry forward)
+
+1. ~~When do adversarial multi-LLM panels improve correctness vs amplify shared bias?~~ **RESOLVED 2026-05-31** — see §6 caution 3 and contract §7.2. Verdict: fail-closed asymmetric gate, independence mandatory, TNR guardrail. Directly informs the `feat/adversarial-llm-panel` design.
+2. **Exact 6-valued ↔ `(b,d,u,a)` projection** — ratify §5 against `hexavalent-logic.md`; how do AGM revision postulates apply to a hexavalent lattice?
+3. **Source-dependence estimation** for fusion — how to classify independence of observations (multiple LLMs, repeated agent runs) in practice, to choose cumulative vs averaging fusion.
+4. **Does the belief-time axis belong in `hari` or in `ix-assumption-graph`?** hari already has per-round observation tracking + replay — possibly the temporal store is a hari graduation rather than new IX code.
+
+---
+
+## 10. Doors & revisit triggers
+
+- **One-way doors:** `AssumptionNode` schema hash (Phase 0); belief-time storage layout (Phase 3). Require explicit sign-off per CLAUDE.md.
+- **Two-way doors:** crate wiring, MCP exposure, the loop scheduler.
+- **Revisit triggers:** (a) re-check BiTRDF when its authors' 2026 implementation companion lands; (b) re-open angle 4 before the adversarial panel ships; (c) re-evaluate Graphiti as the substrate if the belief-time index proves heavy to maintain.


### PR DESCRIPTION
## Summary

A new crate `ix-assumption-graph` that extracts and maintains, **over time**, a unified graph of *assumptions* — both code-level (`@ai:` annotations) and research-domain claims — each carrying a hexavalent truth value (T/P/U/D/F/C) + certainty, revised as evidence accumulates. Composed entirely from existing IX primitives (no new dependencies; graphify/understand-anything evaluated and ruled out as orthogonal).

Design doc: `docs/plans/2026-05-31-temporal-assumption-graph.md` · contract: `docs/contracts/2026-05-31-assumption-graph.contract.md` (+schema).

## What it does (5 commits = 4 phases + loop)

1. **Graph from `@ai:` annotations** — `AssumptionNode: From<Annotation>` (reuses the id scheme/enums), `Dag<AssumptionNode>` container, structural contradiction detection (same claim + opposing polarity).
2. **Subjective-logic opinion + fusion** — Jøsang `(b,d,u,a)` bridge; `fuse()` delegates to `ix-fuzzy::observations::merge` (Belnap C synthesis, 6 proven CRDT obligations). Independence guard for free: C only synthesizes across *distinct sources*.
3. **Belief-time axis** — append-only `BeliefLog`, `belief_at(t)`, `diff(t1,t2)`, `revise()`. The "semantic story over a long period."
4. **Autonomous loop + research ingest** — `from_parts(annotations, research)` unifies dev + research claims; `ix-assumption-graph-loop` bin ingests → revises → persists; `assumption-graph-loop` skill schedules it and maps `/deep-research` output → claims (fail-closed panel discipline).
5. **MCP + faceted navigation** — `NodeKind`/`NodeCertainty` (research-claim & adversarial-panel first-class); `view()` structured by **namespace** (crate) **and** domain/kind; MCP tools `ix_assumption_query` + `ix_assumption_belief_at`.

## Verification
- **33 crate tests + 9 `ix-agent` parity tests** green; clippy clean (`--all-targets --all-features -- -D warnings`).
- Live on this workspace: 16 nodes across namespaces `docs` / `ix-ai-annotations` / `ix-assumption-graph`; a deep-research `F` refuting a code invariant (`T`) produces a persisted `T → C` flip.

## Navigation / UI
No graphical UI yet. Agents navigate via `ix_assumption_query`; humans via the `ix-assumption-graph-report` CLI (prints the faceted view). Graphical home = Prime Radiant (downstream consumer) — follow-up.

## Notes
- **Independent of `feat/adversarial-llm-panel`** (shares no files) — based directly on `main`. Supersedes/consolidates the stacked PRs #70–#73.
- Contract is **v0.4.0 freeze-candidate**; freeze → v1.0.0 (locking id/enum one-way-door fields) left for explicit operator sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)