### PR TITLE
feat(ix-assumption-graph): Prime Radiant graph emitter (IX-side enabler)

### DIFF
--- a/crates/ix-agent/src/skills/assumption_graph.rs
+++ b/crates/ix-agent/src/skills/assumption_graph.rs
@@ -40,13 +40,19 @@ fn assumption_query_schema() -> Value {
             "research": {
                 "type": "string",
                 "description": "Optional path to a research-claims.json file to fold into the graph"
+            },
+            "format": {
+                "type": "string",
+                "enum": ["view", "prime-radiant"],
+                "description": "`view` (default) = faceted navigation; `prime-radiant` = node+edge graph payload for the Prime Radiant 3D renderer"
             }
         }
     })
 }
 
-/// Build the unified assumption graph for a workspace and return its faceted
-/// navigation view (counts by namespace / kind / domain + escalated claims).
+/// Build the unified assumption graph for a workspace and return either its
+/// faceted navigation view (default) or a Prime-Radiant-compatible node+edge
+/// graph payload (`format = "prime-radiant"`).
 #[ix_skill(
     domain = "assumption",
     name = "assumption.query",
@@ -70,8 +76,14 @@ pub fn assumption_query(params: Value) -> Result<Value, String> {
 
     let graph = AssumptionGraph::from_workspace_with_research(&workspace, research)
         .map_err(|e| e.to_string())?;
-    let view = graph.view().map_err(|e| e.to_string())?;
-    serde_json::to_value(view).map_err(|e| e.to_string())
+
+    match params.get("format").and_then(|v| v.as_str()) {
+        Some("prime-radiant") => Ok(graph.prime_radiant_graph()),
+        _ => {
+            let view = graph.view().map_err(|e| e.to_string())?;
+            serde_json::to_value(view).map_err(|e| e.to_string())
+        }
+    }
 }
 
 fn assumption_belief_at_schema() -> Value {

--- a/crates/ix-assumption-graph/src/bin/report.rs
+++ b/crates/ix-assumption-graph/src/bin/report.rs
@@ -1,20 +1,77 @@
 //! Build the assumption graph for a workspace and print a summary.
 //!
-//! Usage: `ix-assumption-graph-report [workspace_dir]` (defaults to ".").
+//! Usage: `ix-assumption-graph-report [workspace_dir] [--prime-radiant-json PATH]`
+//! (workspace defaults to "."). With `--prime-radiant-json`, the
+//! Prime-Radiant-format node+edge graph is written to PATH (the JSON-on-disk
+//! source the ga Prime Radiant viz consumes).
 
 use std::path::PathBuf;
 
-use ix_assumption_graph::AssumptionGraph;
+use ix_assumption_graph::{AssumptionGraph, ResearchClaim};
 
 fn main() {
-    let dir = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
-    let graph = match AssumptionGraph::from_workspace(&PathBuf::from(&dir)) {
+    let mut dir = ".".to_string();
+    let mut prime_radiant_json: Option<String> = None;
+    let mut research_path: Option<String> = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--prime-radiant-json" => match args.next() {
+                Some(p) => prime_radiant_json = Some(p),
+                None => {
+                    eprintln!("error: --prime-radiant-json requires a path");
+                    std::process::exit(1);
+                }
+            },
+            "--research" => match args.next() {
+                Some(p) => research_path = Some(p),
+                None => {
+                    eprintln!("error: --research requires a path");
+                    std::process::exit(1);
+                }
+            },
+            other => dir = other.to_string(),
+        }
+    }
+
+    let research: Vec<ResearchClaim> = match &research_path {
+        Some(p) => match std::fs::read_to_string(p).map(|s| serde_json::from_str(&s)) {
+            Ok(Ok(claims)) => claims,
+            Ok(Err(e)) => {
+                eprintln!("error parsing {p}: {e}");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("error reading {p}: {e}");
+                std::process::exit(1);
+            }
+        },
+        None => Vec::new(),
+    };
+
+    let graph = match AssumptionGraph::from_workspace_with_research(&PathBuf::from(&dir), research)
+    {
         Ok(g) => g,
         Err(e) => {
             eprintln!("error: {e}");
             std::process::exit(1);
         }
     };
+
+    if let Some(path) = &prime_radiant_json {
+        let json = serde_json::to_string_pretty(&graph.prime_radiant_graph())
+            .expect("prime_radiant_graph serializes");
+        if let Some(parent) = PathBuf::from(path).parent() {
+            if !parent.as_os_str().is_empty() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+        if let Err(e) = std::fs::write(path, json) {
+            eprintln!("error writing {path}: {e}");
+            std::process::exit(1);
+        }
+        println!("wrote Prime Radiant graph → {path}");
+    }
 
     println!("assumption graph for {dir}");
     println!("  nodes:                  {}", graph.node_count());

--- a/crates/ix-assumption-graph/src/view.rs
+++ b/crates/ix-assumption-graph/src/view.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeMap;
 use ix_fuzzy::FuzzyError;
 use ix_types::Hexavalent;
 use serde::Serialize;
+use serde_json::{json, Value};
 
 use crate::graph::{normalize_claim, AssumptionGraph};
 use crate::node::AssumptionNode;
@@ -138,6 +139,61 @@ impl AssumptionGraph {
         view.escalations.sort_by(|a, b| a.claim.cmp(&b.claim));
         Ok(view)
     }
+
+    /// Emit a Prime-Radiant-compatible force-directed graph payload — the same
+    /// `{ total_nodes, total_edges, type_counts, nodes, edges }` envelope
+    /// `governance.graph` produces, so Prime Radiant's Three.js renderer can
+    /// consume it directly.
+    ///
+    /// Nodes are assumption nodes, `type`d by namespace (so the renderer colors
+    /// by crate); edges are the derived `contradicts` relations plus `same_claim`
+    /// links chaining nodes that share a normalized claim (so claim clusters are
+    /// visible). Deterministic ordering.
+    pub fn prime_radiant_graph(&self) -> Value {
+        let mut nodes = Vec::new();
+        let mut type_counts: BTreeMap<String, u64> = BTreeMap::new();
+        for n in self.nodes() {
+            let ns = namespace_of(n);
+            *type_counts.entry(ns.clone()).or_default() += 1;
+            nodes.push(json!({
+                "id": &n.id,
+                "type": ns,
+                "name": &n.claim,
+                "path": n.location.as_ref().map(|l| l.path.as_str()).unwrap_or(""),
+                "truth_value": n.truth_value.as_str(),
+                "kind": n.kind.as_str(),
+                "domain": n.domain(),
+            }));
+        }
+
+        let mut edges = Vec::new();
+        for c in self.contradictions() {
+            edges.push(json!({ "source": &c.a, "target": &c.b, "relation": "contradicts" }));
+        }
+        // same-claim cluster links (chain within each claim group)
+        let mut by_claim: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+        for n in self.nodes() {
+            by_claim
+                .entry(normalize_claim(&n.claim))
+                .or_default()
+                .push(n.id.as_str());
+        }
+        for ids in by_claim.values() {
+            for pair in ids.windows(2) {
+                edges.push(
+                    json!({ "source": pair[0], "target": pair[1], "relation": "same_claim" }),
+                );
+            }
+        }
+
+        json!({
+            "total_nodes": nodes.len(),
+            "total_edges": edges.len(),
+            "type_counts": type_counts,
+            "nodes": nodes,
+            "edges": edges,
+        })
+    }
 }
 
 /// Most common namespace among a claim's nodes (ties → alphabetical first).
@@ -256,5 +312,47 @@ mod tests {
         assert_eq!(view.escalations[0].verdict, Hexavalent::Contradictory);
         // The claim touches both domains.
         assert_eq!(view.escalations[0].domains, vec!["dev", "research"]);
+    }
+
+    #[test]
+    fn prime_radiant_graph_has_nodes_and_relation_edges() {
+        // Two annotations sharing a claim with opposing polarity → a contradicts
+        // edge + a same_claim edge; plus a third unrelated node.
+        let g = AssumptionGraph::from_parts(
+            vec![
+                ann("crates/ix-x/src/a.rs", 1, "shared claim", TruthValue::T),
+                ann("crates/ix-y/src/b.rs", 2, "shared claim", TruthValue::F),
+                ann("crates/ix-z/src/c.rs", 3, "lonely claim", TruthValue::U),
+            ],
+            vec![],
+        )
+        .unwrap();
+
+        let graph = g.prime_radiant_graph();
+        assert_eq!(graph["total_nodes"], 3);
+        // Envelope mirrors governance.graph.
+        assert!(graph["nodes"].is_array() && graph["edges"].is_array());
+        assert!(graph["type_counts"]["ix-x"] == 1);
+
+        let relations: Vec<&str> = graph["edges"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["relation"].as_str().unwrap())
+            .collect();
+        assert!(
+            relations.contains(&"contradicts"),
+            "expected a contradicts edge"
+        );
+        assert!(
+            relations.contains(&"same_claim"),
+            "expected a same_claim edge"
+        );
+
+        // Node carries the renderer's required fields + our facets.
+        let node = &graph["nodes"][0];
+        assert!(node["id"].as_str().unwrap().starts_with("sha256:"));
+        assert!(node["type"].is_string()); // namespace, for coloring
+        assert!(node["truth_value"].is_string());
     }
 }

--- a/state/assumptions/demo-research-claims.json
+++ b/state/assumptions/demo-research-claims.json
@@ -1,0 +1,16 @@
+[
+  {
+    "claim": "arr is sorted ascending",
+    "truth_value": "F",
+    "confidence": 0.85,
+    "source": "deep-research",
+    "evidence": "demo: a /deep-research finding refuting a code invariant (fuzz counterexample)"
+  },
+  {
+    "claim": "hexavalent fusion is associative",
+    "truth_value": "P",
+    "confidence": 0.7,
+    "source": "deep-research",
+    "evidence": "demo: ix-fuzzy CRDT proof obligations"
+  }
+]


### PR DESCRIPTION
## What

Follow-up to #74: emit the assumption graph in the **Prime Radiant** force-directed format so it can be visualized in PR's 3D viewer.

- `AssumptionGraph::prime_radiant_graph()` produces the **same envelope `governance.graph` already feeds Prime Radiant** — `{ total_nodes, total_edges, type_counts, nodes:[{id,type,name,path,…}], edges:[{source,target,relation}] }`. Nodes are assumption nodes `type`d by **namespace** (so PR colors by crate); edges are the derived **`contradicts`** relations plus **`same_claim`** cluster links.
- `ix_assumption_query` gains a `format` param: `"prime-radiant"` returns the graph payload; default still returns the faceted `view`. **No new MCP tool → parity test unaffected.**

## Verification
- 34 crate tests (+1 for the emitter: asserts the envelope, a `contradicts` edge, a `same_claim` edge, and node fields); fmt + clippy clean; `ix-agent` builds.

## Honest scope — this is the IX-side enabler only
It produces the **right payload**; it does **not** make the graph appear in Prime Radiant by itself. The rendering step lives in the **`ga` repo** (point Prime Radiant at `ix_assumption_query` with `format=prime-radiant`, or add an "assumption graph" source toggle to the PR UI). I can't verify the 3D render from this repo, so I've scoped this PR to the verifiable IX half and flagged the `ga` follow-up explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)