### PR TITLE
feat(ix-thinking-machine): embedding coverage gate — bge-base-en-v1.5 in-process, TF-IDF fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,8 @@ ix.lock
 # rows are per-environment runtime data, not a committed artifact. (Contrast
 # gaps.jsonl, the curated dogfood BACKLOG, which IS tracked.)
 state/thinking-machine/hits.jsonl
+
+# in-process embedding catalog cache (feature `embeddings`) — runtime data,
+# regenerated from the skill catalog on demand; cwd-relative so it can appear at
+# the repo root or under a crate dir during tests.
+embed-cache/

--- a/crates/ix-skill/Cargo.toml
+++ b/crates/ix-skill/Cargo.toml
@@ -58,6 +58,18 @@ blake3 = { workspace = true }
 # 2026-06-07.)
 sha2 = "0.10"
 
+# Embedding coverage gate (OPTIONAL, feature-gated): in-process fastembed-rs on
+# ONNX Runtime — inference-only pretrained tooling behind an optional-dep
+# boundary per the CLAUDE.md ML-framework carve-out. The pure-Rust TF-IDF gate
+# stays the default + graceful fallback. Deliberately NOT in default features,
+# so `cargo {build,test,clippy} --workspace` (the CI path) never pulls ONNX.
+# Build/run the spike locally with `--features embeddings`.
+fastembed = { version = "5", optional = true }
+
+[features]
+# Enables the in-process embedding coverage scorer + its offline ROC-sweep test.
+embeddings = ["dep:fastembed"]
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/crates/ix-skill/src/verbs/compile.rs
+++ b/crates/ix-skill/src/verbs/compile.rs
@@ -81,16 +81,12 @@ fn compile_inner(
     // 2026-06-06). `lower()` + governance check STRUCTURE, not coverage, so
     // we score intent↔catalog relevance with IX's own TF-IDF *before* calling
     // the LLM, and log a capability gap instead of confabulating.
-    let cov_min: f64 = std::env::var("IX_THINKER_COVERAGE_MIN")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0.08);
-    let (cov_max, cov_top) = coverage_score(sentence, &skills);
+    let (cov_max, cov_top, detector, cov_min) = score_coverage(sentence, &skills);
     if cov_max < cov_min {
         log_gap(
             sentence,
             "coverage",
-            &format!("no IX skill covers this intent (max TF-IDF cosine {cov_max:.3} < {cov_min}); nearest: {cov_top:?}"),
+            &format!("no IX skill covers this intent ({detector} score {cov_max:.3} < {cov_min}); nearest: {cov_top:?}"),
             0,
         );
         return emit_outcome(
@@ -99,7 +95,7 @@ fn compile_inner(
             cov_max,
             json!({
                 "status": "out_of_domain",
-                "detected_by": "tfidf-coverage",
+                "detected_by": detector,
                 "sentence": sentence,
                 "coverage_max": cov_max,
                 "coverage_threshold": cov_min,
@@ -440,7 +436,7 @@ fn call_anthropic(
 // ── Prompt construction ─────────────────────────────────────────────────
 
 /// Skills callable from a pipeline stage (arity-1, single JSON arg).
-fn pipeline_callable_skills() -> Vec<&'static ix_registry::SkillDescriptor> {
+pub(crate) fn pipeline_callable_skills() -> Vec<&'static ix_registry::SkillDescriptor> {
     let mut skills: Vec<&'static ix_registry::SkillDescriptor> =
         ix_registry::all().filter(|s| s.inputs.len() == 1).collect();
     skills.sort_by_key(|s| s.name);
@@ -461,6 +457,40 @@ fn catalog_value(skills: &[&'static ix_registry::SkillDescriptor]) -> Value {
         })
         .collect();
     json!(rows)
+}
+
+/// Coverage dispatcher: the in-process embedding scorer (bge-base-en-v1.5) when
+/// the `embeddings` feature is built AND the model loads, else the lexical
+/// TF-IDF pre-gate. The embedding tier raises OOD refusal ~4× at equal recall
+/// (`state/thinking-machine/embedding-sweep-rust-results.md`) but is OPTIONAL —
+/// TF-IDF is the always-available default + graceful fallback (set
+/// `IX_THINKER_DISABLE_EMBED` to force it). Thresholds: embedding ≈ 0.45
+/// (`IX_THINKER_EMBED_COVERAGE_MIN`), TF-IDF 0.08 (`IX_THINKER_COVERAGE_MIN`).
+/// Returns `(score, top-3 nearest, detector tag, threshold)`.
+fn score_coverage(
+    sentence: &str,
+    skills: &[&'static ix_registry::SkillDescriptor],
+) -> (f64, Vec<(String, f64)>, &'static str, f64) {
+    #[cfg(feature = "embeddings")]
+    {
+        if std::env::var_os("IX_THINKER_DISABLE_EMBED").is_none() {
+            if let Some(mut ec) = crate::verbs::embed_coverage::EmbeddingCoverage::load(skills) {
+                let (max, top) = ec.score(sentence);
+                let min: f64 = std::env::var("IX_THINKER_EMBED_COVERAGE_MIN")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(0.45);
+                return (max, top, "embedding-bge-base-en", min);
+            }
+            // model unavailable (offline / no ONNX) → fall through to TF-IDF.
+        }
+    }
+    let (max, top) = coverage_score(sentence, skills);
+    let min: f64 = std::env::var("IX_THINKER_COVERAGE_MIN")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0.08);
+    (max, top, "tfidf-coverage", min)
 }
 
 /// Executable semantic-coverage score: the max TF-IDF cosine between the

--- a/crates/ix-skill/src/verbs/compile.rs
+++ b/crates/ix-skill/src/verbs/compile.rs
@@ -1219,4 +1219,187 @@ mod tests {
             "error sits in the denominator, diluting yield (2/3), not vanishing: {s}"
         );
     }
+
+    // ── Embedding-gate validation SPIKE: which English embedder beats TF-IDF?
+    //    (run: cargo test -p ix-skill --features embeddings embedding_sweep
+    //     -- --nocapture) ──────────────────────────────────────────────────
+    //
+    // Feature-gated so CI (`--workspace`, default features) never pulls ONNX.
+    // Proves fastembed-rs/ort builds + runs here, and sweeps several built-in
+    // English retrieval embedders — each with ITS correct query/passage prefix
+    // scheme — over the 184-probe corpus, reporting AUC + the operating point at
+    // in-domain recall ≥ 0.99 (same methodology as the Python sweep). Go/no-go:
+    // at least one must out-refuse the lexical baseline (recall 0.99 / TNR 0.163)
+    // at equal recall. First run downloads each model (~270–670 MB).
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn embedding_sweep_english_models_over_probe_corpus() {
+        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+        use std::io::BufRead;
+
+        fn cosine_f32(a: &[f32], b: &[f32]) -> f64 {
+            let (mut dot, mut na, mut nb) = (0.0f64, 0.0f64, 0.0f64);
+            for (x, y) in a.iter().zip(b) {
+                let (x, y) = (*x as f64, *y as f64);
+                dot += x * y;
+                na += x * x;
+                nb += y * y;
+            }
+            if na == 0.0 || nb == 0.0 {
+                0.0
+            } else {
+                dot / (na.sqrt() * nb.sqrt())
+            }
+        }
+
+        let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../state/thinking-machine/coverage-probes.jsonl");
+        let Ok(file) = std::fs::File::open(&path) else {
+            eprintln!(
+                "SKIP embedding_sweep: probe corpus not found at {}",
+                path.display()
+            );
+            return;
+        };
+        let mut sentences = Vec::new();
+        let mut labels: Vec<(bool, String)> = Vec::new(); // (is_in_domain, kind)
+        for line in std::io::BufReader::new(file).lines() {
+            let line = line.unwrap();
+            if line.trim().is_empty() {
+                continue;
+            }
+            let p: Value = serde_json::from_str(&line).unwrap();
+            sentences.push(p["sentence"].as_str().unwrap().to_string());
+            labels.push((
+                p["label"].as_str().unwrap() == "in_domain",
+                p["kind"].as_str().unwrap().to_string(),
+            ));
+        }
+        let skills = pipeline_callable_skills();
+        let docs: Vec<String> = skills
+            .iter()
+            .map(|s| format!("{} {}", s.name.replace(['.', '_'], " "), s.doc))
+            .collect();
+
+        // Given per-query scores, compute AUC + the operating point at recall≥0.99.
+        let eval = |scores: &[f64]| -> (f64, f64, f64, f64, f64, f64) {
+            let pos: Vec<f64> = scores
+                .iter()
+                .zip(&labels)
+                .filter(|(_, (i, _))| *i)
+                .map(|(s, _)| *s)
+                .collect();
+            let neg: Vec<f64> = scores
+                .iter()
+                .zip(&labels)
+                .filter(|(_, (i, _))| !*i)
+                .map(|(s, _)| *s)
+                .collect();
+            let (mut wins, mut total) = (0.0f64, 0.0f64);
+            for p in &pos {
+                for n in &neg {
+                    total += 1.0;
+                    if p > n {
+                        wins += 1.0;
+                    } else if (p - n).abs() < 1e-12 {
+                        wins += 0.5;
+                    }
+                }
+            }
+            let auc = if total > 0.0 { wins / total } else { 0.0 };
+            let mut ps = pos.clone();
+            ps.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let drop = ((1.0 - 0.99) * ps.len() as f64).floor() as usize;
+            let thr = ps[drop.min(ps.len().saturating_sub(1))];
+            let recall = pos.iter().filter(|s| **s >= thr).count() as f64 / pos.len().max(1) as f64;
+            let tnr = neg.iter().filter(|s| **s < thr).count() as f64 / neg.len().max(1) as f64;
+            let kt = |k: &str| -> f64 {
+                let t: Vec<f64> = scores
+                    .iter()
+                    .zip(&labels)
+                    .filter(|(_, (i, kk))| !*i && kk == k)
+                    .map(|(s, _)| *s)
+                    .collect();
+                t.iter().filter(|s| **s < thr).count() as f64 / t.len().max(1) as f64
+            };
+            (auc, thr, recall, tnr, kt("near_miss_ood"), kt("far_ood"))
+        };
+
+        // (name, model, query-prefix, passage-prefix). e5 uses query:/passage:;
+        // bge/mxbai/arctic use a query instruction + bare passages; gte uses none.
+        let instr = "Represent this sentence for searching relevant passages: ";
+        let configs: Vec<(&str, EmbeddingModel, String, String)> = vec![
+            (
+                "multilingual-e5-base",
+                EmbeddingModel::MultilingualE5Base,
+                "query: ".into(),
+                "passage: ".into(),
+            ),
+            (
+                "bge-base-en-v1.5",
+                EmbeddingModel::BGEBaseENV15,
+                instr.into(),
+                String::new(),
+            ),
+            (
+                "gte-base-en-v1.5",
+                EmbeddingModel::GTEBaseENV15,
+                String::new(),
+                String::new(),
+            ),
+            (
+                "snowflake-arctic-embed-m",
+                EmbeddingModel::SnowflakeArcticEmbedM,
+                instr.into(),
+                String::new(),
+            ),
+        ];
+
+        eprintln!(
+            "{:28} {:>5} {:>7} {:>6} {:>6} {:>6} {:>6}",
+            "model (mean-top-3 cosine)", "AUC", "thr", "recall", "TNR", "near", "far"
+        );
+        let (mut best_tnr, mut best_name) = (0.0f64, "none");
+        for (name, model_kind, qp, pp) in configs {
+            let mut model = match TextEmbedding::try_new(
+                InitOptions::new(model_kind).with_show_download_progress(true),
+            ) {
+                Ok(m) => m,
+                Err(e) => {
+                    eprintln!("{name:28} load FAILED: {e}");
+                    continue;
+                }
+            };
+            let passages: Vec<String> = docs.iter().map(|d| format!("{pp}{d}")).collect();
+            let queries: Vec<String> = sentences.iter().map(|s| format!("{qp}{s}")).collect();
+            let cat = model.embed(passages, None).expect("embed catalog");
+            let qry = model.embed(queries, None).expect("embed queries");
+            let scores: Vec<f64> = qry
+                .iter()
+                .map(|q| {
+                    let mut c: Vec<f64> = cat.iter().map(|p| cosine_f32(q, p)).collect();
+                    c.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+                    c.iter().take(3).sum::<f64>() / 3.0
+                })
+                .collect();
+            let (auc, thr, recall, tnr, near, far) = eval(&scores);
+            eprintln!("{name:28} {auc:.3} {thr:.4} {recall:.3} {tnr:.3} {near:.3} {far:.3}");
+            if tnr > best_tnr {
+                best_tnr = tnr;
+                best_name = name;
+            }
+        }
+        eprintln!(
+            "{:28} {:>5} {:>7} {:>6} {:>6} {:>6} {:>6}",
+            "TF-IDF baseline", "~.78", "-", "0.990", "0.163", "0.036", "0.458"
+        );
+        eprintln!("BEST embedder: {best_name} @ TNR {best_tnr:.3} (recall≈0.99)");
+
+        // Go/no-go bar: at least one English embedder must out-refuse the lexical
+        // baseline at equal recall — else embeddings aren't worth the ONNX dep.
+        assert!(
+            best_tnr > 0.163,
+            "no English embedder out-refused the TF-IDF baseline (TNR 0.163) at recall≈0.99; best={best_name} {best_tnr:.3}"
+        );
+    }
 }

--- a/crates/ix-skill/src/verbs/embed_coverage.rs
+++ b/crates/ix-skill/src/verbs/embed_coverage.rs
@@ -1,0 +1,181 @@
+//! Optional in-process embedding coverage scorer (Cargo feature `embeddings`).
+//!
+//! Scores natural-language-request ↔ skill-catalog relevance with
+//! **bge-base-en-v1.5** via in-process `fastembed-rs` (ONNX Runtime), replacing
+//! the lexical TF-IDF pre-gate when the `embeddings` feature is built. Chosen by
+//! the 2026-06-07 validation sweep (AUC 0.936, OOD TNR 0.625 @ recall 0.99 —
+//! 3.8× the TF-IDF baseline; near-miss 0.036 → 0.482). Full results:
+//! `state/thinking-machine/embedding-sweep-rust-results.md`.
+//!
+//! Inference-only pretrained tooling behind an optional-dep boundary per the
+//! CLAUDE.md ML-framework carve-out; the pure-Rust TF-IDF gate in `compile.rs`
+//! stays the default + graceful fallback. This module degrades (returns
+//! `None`/`0.0`) on any failure rather than hard-failing the gate.
+
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+use std::cmp::Ordering;
+
+/// bge-v1.5 s2p-retrieval query instruction (passages get no prefix).
+const BGE_QUERY_INSTRUCTION: &str = "Represent this sentence for searching relevant passages: ";
+const MODEL_TAG: &str = "bge-base-en-v1.5";
+
+pub struct EmbeddingCoverage {
+    model: TextEmbedding,
+    /// (skill name, passage embedding) — cosine normalizes, so raw is fine.
+    catalog: Vec<(String, Vec<f32>)>,
+}
+
+impl EmbeddingCoverage {
+    /// Load bge-base-en-v1.5 + the catalog passage embeddings (disk-cached by
+    /// model + catalog-content hash). Returns `None` on any failure (model
+    /// download/init or embedding) so the caller falls back to TF-IDF.
+    pub fn load(skills: &[&'static ix_registry::SkillDescriptor]) -> Option<Self> {
+        let mut model =
+            TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGEBaseENV15)).ok()?;
+        let passages: Vec<String> = skills
+            .iter()
+            .map(|s| format!("{} {}", s.name.replace(['.', '_'], " "), s.doc))
+            .collect();
+        let embeddings = catalog_embeddings(&mut model, passages)?;
+        if embeddings.len() != skills.len() {
+            return None;
+        }
+        let catalog = skills
+            .iter()
+            .map(|s| s.name.to_string())
+            .zip(embeddings)
+            .collect();
+        Some(Self { model, catalog })
+    }
+
+    /// Coverage score for a request: the mean of the top-3 cosine similarities
+    /// to the catalog, plus the top-3 nearest skills (for an auditable verdict).
+    pub fn score(&mut self, sentence: &str) -> (f64, Vec<(String, f64)>) {
+        let query = format!("{BGE_QUERY_INSTRUCTION}{sentence}");
+        let emb = match self.model.embed(vec![query], None) {
+            Ok(mut e) if !e.is_empty() => e.remove(0),
+            _ => return (0.0, Vec::new()),
+        };
+        let mut scored: Vec<(String, f64)> = self
+            .catalog
+            .iter()
+            .map(|(name, p)| (name.clone(), cosine(&emb, p)))
+            .collect();
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(Ordering::Equal));
+        let top3 = scored.iter().take(3).map(|x| x.1).sum::<f64>() / 3.0;
+        scored.truncate(3);
+        (top3, scored)
+    }
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    let (mut dot, mut na, mut nb) = (0.0f64, 0.0f64, 0.0f64);
+    for (x, y) in a.iter().zip(b) {
+        let (x, y) = (*x as f64, *y as f64);
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        0.0
+    } else {
+        dot / (na.sqrt() * nb.sqrt())
+    }
+}
+
+/// Embed the catalog passages, caching to disk keyed by (model, catalog-content
+/// hash) so a static catalog is embedded only once across CLI invocations.
+fn catalog_embeddings(model: &mut TextEmbedding, passages: Vec<String>) -> Option<Vec<Vec<f32>>> {
+    let key = blake3::hash(passages.join("\n").as_bytes()).to_hex();
+    let cache = std::path::Path::new("state/thinking-machine/embed-cache")
+        .join(format!("{MODEL_TAG}.{}.bin", &key[..16]));
+    let n = passages.len();
+    if let Some(v) = read_cache(&cache) {
+        if v.len() == n {
+            return Some(v);
+        }
+    }
+    let embeddings = model.embed(passages, None).ok()?;
+    write_cache(&cache, &embeddings);
+    Some(embeddings)
+}
+
+/// Binary cache layout: `[count u32 LE][dim u32 LE][f32 LE × count*dim]`.
+fn read_cache(path: &std::path::Path) -> Option<Vec<Vec<f32>>> {
+    let bytes = std::fs::read(path).ok()?;
+    if bytes.len() < 8 {
+        return None;
+    }
+    let count = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
+    let dim = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
+    if dim == 0 || bytes.len() != 8 + count * dim * 4 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(count);
+    let mut off = 8;
+    for _ in 0..count {
+        let mut row = Vec::with_capacity(dim);
+        for _ in 0..dim {
+            row.push(f32::from_le_bytes(bytes[off..off + 4].try_into().ok()?));
+            off += 4;
+        }
+        out.push(row);
+    }
+    Some(out)
+}
+
+fn write_cache(path: &std::path::Path, embeddings: &[Vec<f32>]) {
+    let dim = embeddings.first().map(|e| e.len()).unwrap_or(0);
+    if dim == 0 || embeddings.iter().any(|e| e.len() != dim) {
+        return;
+    }
+    if let Some(parent) = path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let mut buf = Vec::with_capacity(8 + embeddings.len() * dim * 4);
+    buf.extend_from_slice(&(embeddings.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&(dim as u32).to_le_bytes());
+    for row in embeddings {
+        for &v in row {
+            buf.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    let _ = std::fs::write(path, buf);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_round_trips_and_rejects_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("c.bin");
+        let emb = vec![vec![0.1f32, 0.2, 0.3], vec![-0.4, 0.5, 0.6]];
+        write_cache(&path, &emb);
+        assert_eq!(read_cache(&path).expect("round trip"), emb);
+        // A truncated cache must be rejected (→ recompute), not mis-read.
+        std::fs::write(&path, b"\x02\x00\x00\x00\x03").unwrap();
+        assert!(read_cache(&path).is_none());
+    }
+
+    #[test]
+    fn embedding_ranks_in_domain_above_out_of_domain() {
+        // Real model load (downloads bge-base-en on first run); proves the
+        // scorer separates an in-domain request from an out-of-domain one.
+        let skills = crate::verbs::compile::pipeline_callable_skills();
+        let Some(mut ec) = EmbeddingCoverage::load(&skills) else {
+            eprintln!("SKIP: bge-base-en unavailable (offline / no ONNX)");
+            return;
+        };
+        let (in_dom, _) = ec.score("compute the mean and standard deviation of these numbers");
+        let (out_dom, _) = ec.score("teleport to the moon and bake a chocolate cake");
+        eprintln!("embedding coverage: in={in_dom:.3} out={out_dom:.3}");
+        assert!(
+            in_dom > out_dom,
+            "in-domain {in_dom} must exceed OOD {out_dom}"
+        );
+    }
+}

--- a/crates/ix-skill/src/verbs/mod.rs
+++ b/crates/ix-skill/src/verbs/mod.rs
@@ -5,6 +5,9 @@ pub mod check;
 pub mod compile;
 pub mod demo;
 pub mod describe;
+/// Optional in-process embedding coverage scorer (feature `embeddings`).
+#[cfg(feature = "embeddings")]
+pub mod embed_coverage;
 pub mod list;
 pub mod pipeline;
 pub mod run;

--- a/docs/plans/2026-06-06-ix-thinking-machine.md
+++ b/docs/plans/2026-06-06-ix-thinking-machine.md
@@ -156,7 +156,16 @@ drop below 0.90 (a gate that false-blocks real work is worse than useless).
      resolved-args-gated** — it executes `$step.field` substitution directly,
      bypassing `lower_with_gate`. Gating-or-retiring it is the open security
      follow-up.
-4. **Embeddings coverage** — replace lexical pre-filter (D4). Now *measurable*:
-   `hits.jsonl` + the coverage-baseline test give the before/after yield &
-   guardrail numbers the embedding sidecar must beat (e5-base, mean-top-3,
-   threshold ≈ 0.76 per `state/thinking-machine/embedding-sweep-results.md`).
+4. **Embeddings coverage** — replace lexical pre-filter (D4).
+   - ✅ **Runtime decided + spiked** — *in-process* fastembed-rs (`ort`/ONNX),
+     NOT a Python sidecar (deep-research 2026-06-07). Validation spike
+     (`embedding_sweep_english_models_over_probe_corpus`, feature-gated; results
+     in `state/thinking-machine/embedding-sweep-rust-results.md`) swept 4 built-in
+     English embedders over the 184 probes: **`bge-base-en-v1.5` wins — AUC 0.936,
+     OOD TNR 0.625 @ recall 0.99** (3.8× the TF-IDF baseline 0.163; near-miss
+     0.036 → **0.482**, the headline gap). multilingual-e5-base was *worse* than
+     TF-IDF; e5-base-v2 isn't needed. Windows ONNX build confirmed.
+   - ⏳ **Wire it in (next):** make bge-base-en-v1.5 the coverage gate's primary
+     tier (mean-top-3 cosine, threshold ≈ 0.45) behind the `embeddings` feature,
+     TF-IDF as graceful fallback; `hits.jsonl` tracks the before/after.
+   - ⏳ score→verdict refinement (kNN-distance / per-query calibration) — follow-up.

--- a/docs/plans/2026-06-06-ix-thinking-machine.md
+++ b/docs/plans/2026-06-06-ix-thinking-machine.md
@@ -165,7 +165,16 @@ drop below 0.90 (a gate that false-blocks real work is worse than useless).
      OOD TNR 0.625 @ recall 0.99** (3.8× the TF-IDF baseline 0.163; near-miss
      0.036 → **0.482**, the headline gap). multilingual-e5-base was *worse* than
      TF-IDF; e5-base-v2 isn't needed. Windows ONNX build confirmed.
-   - ⏳ **Wire it in (next):** make bge-base-en-v1.5 the coverage gate's primary
-     tier (mean-top-3 cosine, threshold ≈ 0.45) behind the `embeddings` feature,
-     TF-IDF as graceful fallback; `hits.jsonl` tracks the before/after.
+   - ✅ **Wired in.** `verbs::embed_coverage::EmbeddingCoverage` (bge-base-en-v1.5,
+     mean-top-3 cosine, disk-cached catalog embeddings) is the coverage gate's
+     primary tier via the `score_coverage` dispatcher when the `embeddings`
+     feature is built; TF-IDF is the default + graceful fallback (model
+     unavailable / `IX_THINKER_DISABLE_EMBED` → TF-IDF). Threshold ≈ 0.45
+     (`IX_THINKER_EMBED_COVERAGE_MIN`). `hits.jsonl` records `detected_by` +
+     `coverage_max`, so the before/after is tracked automatically.
+     **Live-verified:** the near-miss "scrape a website and email a summary" —
+     which TF-IDF let through (0.324 > 0.08, the pinned known-limitation) — is now
+     refused by `embedding-bge-base-en` (0.44 < 0.45); in-domain data-bearing
+     requests still compile (recall intact). CI never builds ONNX (non-default
+     feature).
    - ⏳ score→verdict refinement (kNN-distance / per-query calibration) — follow-up.

--- a/state/thinking-machine/embedding-sweep-rust-results.md
+++ b/state/thinking-machine/embedding-sweep-rust-results.md
@@ -1,0 +1,58 @@
+# Embedding coverage-gate — in-process Rust sweep (2026-06-07)
+
+Validation spike for the embedding coverage gate (step 1 of the embedding-gate
+increment). Replaces the earlier Python sweep with an **in-process pure-Rust**
+path (`fastembed-rs` on the `ort`/ONNX Runtime crate), per the 2026-06-07
+deep-research decision (`reference_embedding_gate_runtime_fastembed`).
+
+Reproduce: `cargo test -p ix-skill --features embeddings embedding_sweep_english_models_over_probe_corpus -- --nocapture`
+(feature-gated; CI's `--workspace` default-feature path never pulls ONNX).
+First run downloads each model (~270–670 MB) + the ONNX Runtime native lib.
+
+## Setup
+- **Corpus:** the 184-probe validated set (`coverage-probes.jsonl`; 104 in-domain,
+  56 near-miss-OOD, 24 far-OOD).
+- **Signal:** mean of the top-3 cosine similarities between the request and the
+  52 pipeline-callable skills' "name + doc".
+- **Per-model prefix scheme** (applied caller-side): e5 → `query:` / `passage:`;
+  bge / mxbai / arctic → query instruction "Represent this sentence for searching
+  relevant passages: " + bare passages; gte → none.
+- **Operating point:** highest threshold holding in-domain recall ≥ 0.99 (same
+  methodology as the Python sweep, so the numbers are comparable).
+
+## Results — @ recall ≥ 0.99
+
+| model (mean-top-3 cosine) | AUC | threshold | in-domain recall | overall OOD TNR | near-miss TNR | far-OOD TNR |
+|---|---|---|---|---|---|---|
+| multilingual-e5-base | 0.808 | 0.768 | 0.990 | 0.075 | 0.018 | 0.208 |
+| **bge-base-en-v1.5** | **0.936** | **0.454** | **0.990** | **0.625** | **0.482** | 0.958 |
+| gte-base-en-v1.5 | 0.881 | 0.347 | 0.990 | 0.375 | 0.107 | 1.000 |
+| snowflake-arctic-embed-m | 0.896 | 0.203 | 0.990 | 0.500 | 0.339 | 0.875 |
+| **TF-IDF baseline** | ~0.78 | — | 0.990 | 0.163 | 0.036 | 0.458 |
+
+## Findings
+1. **Winner: `bge-base-en-v1.5`** — AUC 0.936, overall OOD TNR **0.625** at
+   in-domain recall 0.99. That is **3.8× the lexical baseline** (0.163) and beats
+   even the Python e5-base-v2 sweep (0.425 / AUC 0.885). It is **fastembed
+   built-in** — no custom ONNX export needed.
+2. **It closes the headline near-miss gap.** Near-miss OOD TNR goes **0.036 →
+   0.482 (13×)** — the catastrophic slice the whole embedding effort targeted.
+   Far-OOD is near-solved (0.458 → 0.958).
+3. **The spike reversed two assumptions.** `multilingual-e5-base` (the planned
+   "start" model) is *worse than TF-IDF* at this operating point (TNR 0.075) —
+   the multilingual model is far weaker on English-only discrimination. And
+   `e5-base-v2` (the original sweep model) is **not needed** — bge-base-en beats
+   it and ships built-in.
+4. **Windows ONNX build confirmed.** `fastembed` v5.16.0 + `ort` (native ONNX
+   Runtime) compile and run on Windows 11 — the main runtime risk is retired.
+
+## Decision
+Productionize the gate with **`bge-base-en-v1.5`** via in-process fastembed-rs,
+mean-top-3 cosine, threshold ≈ **0.45**, behind the `embeddings` Cargo feature
+(optional-dep boundary per the CLAUDE.md carve-out), with the pure-Rust TF-IDF
+gate as graceful fallback. Guardrail: in-domain recall must stay ≥ ~0.97.
+
+Open (next): the score→verdict *method* refinement (per-query calibration /
+kNN-distance OOD vs the fixed cosine threshold) remains the unsettled front —
+but the fixed mean-top-3 threshold already delivers a 3.8× TNR lift, so it ships
+first and the refinement is a follow-up.


### PR DESCRIPTION
## What

Step 1 (validation spike) of the embedding coverage gate, per the 2026-06-07 deep-research decision to use an **in-process pure-Rust** embedder (`fastembed-rs` on `ort`/ONNX Runtime) instead of a Python sidecar.

A feature-gated, in-process Rust ROC sweep embeds the 184-probe corpus with four built-in English retrieval embedders — each with its correct query/passage prefix scheme — and reports AUC + the operating point at in-domain recall ≥ 0.99 (same methodology as the prior Python sweep).

## Result — @ recall ≥ 0.99

| model (mean-top-3 cosine) | AUC | OOD TNR | near-miss | far-OOD |
|---|---|---|---|---|
| multilingual-e5-base | 0.808 | 0.075 | 0.018 | 0.208 |
| **bge-base-en-v1.5** | **0.936** | **0.625** | **0.482** | 0.958 |
| gte-base-en-v1.5 | 0.881 | 0.375 | 0.107 | 1.000 |
| snowflake-arctic-embed-m | 0.896 | 0.500 | 0.339 | 0.875 |
| TF-IDF baseline | ~0.78 | 0.163 | 0.036 | 0.458 |

**`bge-base-en-v1.5` wins** — 3.8× the lexical baseline on overall OOD TNR, and it closes the headline near-miss gap **13×** (0.036 → 0.482). It's fastembed-built-in (no custom ONNX export), and beats even the originally-planned e5-base-v2 (AUC 0.936 vs 0.885). The spike reversed two assumptions: multilingual-e5-base is *worse* than TF-IDF here, and e5-base-v2 isn't needed. **Windows ONNX build confirmed.**

## CI isolation
`fastembed` is an **optional** dep behind a non-default `embeddings` feature, so `cargo {build,test,clippy} --workspace` (the CI path) never pulls ONNX. The sweep runs locally with `--features embeddings`. The pure-Rust TF-IDF gate stays the default + graceful fallback (CLAUDE.md ML-framework carve-out).

## Next (separate PR)
Wire `bge-base-en-v1.5` into the live coverage gate as the primary tier (mean-top-3 cosine, threshold ≈ 0.45), TF-IDF fallback, `hits.jsonl` tracking the before/after. The score→verdict refinement (kNN / per-query calibration) is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
