### PR TITLE
feat(ix-thinking-machine): standalone `pca` skill — first dogfood catalog-breadth fix

### DIFF
--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -298,6 +298,51 @@ pub fn kmeans(params: Value) -> Result<Value, String> {
     }))
 }
 
+// ── ix_pca ────────────────────────────────────────────────
+
+pub fn pca(params: Value) -> Result<Value, String> {
+    use ix_unsupervised::traits::DimensionReducer;
+
+    let data_rows = parse_f64_matrix(&params, "data")?;
+    if data_rows.is_empty() {
+        return Err("data must have ≥ 1 row".into());
+    }
+    let n_features = data_rows[0].len();
+    let n_components = parse_usize(&params, "n_components")?;
+    if n_components < 1 {
+        return Err("n_components must be ≥ 1".into());
+    }
+    if n_components > n_features {
+        return Err(format!(
+            "n_components {n_components} exceeds the feature count {n_features}"
+        ));
+    }
+
+    let data = vecs_to_array2(&data_rows)?;
+
+    let mut pca = ix_unsupervised::pca::PCA::new(n_components);
+    let transformed = pca.fit_transform(&data);
+
+    let transformed_rows: Vec<Vec<f64>> = (0..transformed.nrows())
+        .map(|i| transformed.row(i).to_vec())
+        .collect();
+    let explained_variance_ratio: Vec<f64> = pca
+        .explained_variance_ratio()
+        .map(|v| v.to_vec())
+        .unwrap_or_default();
+    let components: Vec<Vec<f64>> = pca
+        .components()
+        .map(|c| (0..c.nrows()).map(|i| c.row(i).to_vec()).collect())
+        .unwrap_or_default();
+
+    Ok(json!({
+        "transformed": transformed_rows,
+        "explained_variance_ratio": explained_variance_ratio,
+        "components": components,
+        "n_components": n_components,
+    }))
+}
+
 // ── ix_tsne ────────────────────────────────────────────────
 
 pub fn tsne(params: Value) -> Result<Value, String> {

--- a/crates/ix-agent/src/skills/batch1.rs
+++ b/crates/ix-agent/src/skills/batch1.rs
@@ -126,6 +126,40 @@ pub fn kmeans(params: Value) -> Result<Value, String> {
     handlers::kmeans(params)
 }
 
+// --- ix_pca ----------------------------------------------------------------
+
+fn pca_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "array",
+                "items": { "type": "array", "items": { "type": "number" } },
+                "description": "Matrix where each row is an observation and each column a feature"
+            },
+            "n_components": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Number of principal components to keep"
+            }
+        },
+        "required": ["data", "n_components"]
+    })
+}
+
+/// Reduce dimensionality with Principal Component Analysis: project the data
+/// onto its top `n_components` principal axes and report the explained-variance
+/// ratio per component.
+#[ix_skill(
+    domain = "unsupervised",
+    name = "pca",
+    governance = "empirical,deterministic",
+    schema_fn = "crate::skills::batch1::pca_schema"
+)]
+pub fn pca(params: Value) -> Result<Value, String> {
+    handlers::pca(params)
+}
+
 // --- ix_linear_regression --------------------------------------------------
 
 fn linear_regression_schema() -> Value {
@@ -188,4 +222,66 @@ fn governance_belief_schema() -> Value {
 )]
 pub fn governance_belief(params: Value) -> Result<Value, String> {
     handlers::governance_belief(params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Executes-test for the new `pca` skill: the catalog entry must EXECUTE,
+    // not merely register (no green-but-dead). Classic Lindsay-Smith 2D PCA
+    // example — its first principal component carries ~96% of the variance.
+    #[test]
+    fn pca_skill_executes_and_reduces_dimensions() {
+        let out = pca(json!({
+            "data": [
+                [2.5, 2.4], [0.5, 0.7], [2.2, 2.9], [1.9, 2.2], [3.1, 3.0],
+                [2.3, 2.7], [2.0, 1.6], [1.0, 1.1], [1.5, 1.6], [1.1, 0.9]
+            ],
+            "n_components": 1
+        }))
+        .expect("pca skill runs");
+
+        let transformed = out["transformed"].as_array().expect("transformed array");
+        assert_eq!(
+            transformed.len(),
+            10,
+            "one projected row per input observation"
+        );
+        assert_eq!(
+            transformed[0].as_array().unwrap().len(),
+            1,
+            "reduced from 2 features to 1 component"
+        );
+
+        let evr = out["explained_variance_ratio"].as_array().unwrap();
+        assert_eq!(evr.len(), 1);
+        assert!(
+            evr[0].as_f64().unwrap() > 0.9,
+            "the single retained PC should explain most of the variance, got {}",
+            evr[0].as_f64().unwrap()
+        );
+    }
+
+    // The skill must be registered AND pipeline-callable (arity-1), so the
+    // NL→pipeline proposer can actually see it (the dogfood gap this closes).
+    #[test]
+    fn pca_skill_is_registered_and_pipeline_callable() {
+        let desc = ix_registry::all()
+            .find(|s| s.name == "pca")
+            .expect("pca skill registered in the capability registry");
+        assert_eq!(
+            desc.inputs.len(),
+            1,
+            "must be arity-1 to be pipeline-callable"
+        );
+    }
+
+    // Honest boundary: more components than features is rejected, not silently
+    // clamped — the proposer/caller gets a clear error instead of a wrong shape.
+    #[test]
+    fn pca_rejects_too_many_components() {
+        let err = pca(json!({ "data": [[1.0, 2.0], [3.0, 4.0]], "n_components": 5 })).unwrap_err();
+        assert!(err.contains("exceeds the feature count"), "got: {err}");
+    }
 }

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -66,6 +66,7 @@ const EXPECTED: &[&str] = &[
     "ix_hyperloglog",
     "ix_kmeans",
     "ix_linear_regression",
+    "ix_pca",
     "ix_markov",
     "ix_ml_pipeline",
     "ix_ml_predict",
@@ -151,9 +152,11 @@ fn parity_expected_count() {
     //   MCP tool, agent-native parity with `ix pipeline compile`) = 76.
     // + ix_thinker_hits (2026-06-07, thinking-machine yield/guardrail ledger
     //   aggregate, agent-native parity with `ix pipeline hits`) = 77.
+    // + ix_pca (2026-06-07, standalone PCA — first dogfood catalog-breadth fix;
+    //   auto-exposed via the registry bridge) = 78.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 77);
+    assert_eq!(EXPECTED.len(), 78);
 }
 
 #[test]
@@ -282,10 +285,11 @@ fn parity_all_43_registry_backed() {
     // After batch1 (6) + batch2 (28) + batch3 (10+1 context.walk +
     // session.flywheel_export) + prime_radiant (2) migration, all 47
     // algorithm tools are registry-backed. ix_demo is manual.
+    // + pca (2026-06-07, dogfood catalog-breadth fix) = 53.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 52,
-        "expected 52 registry skills, got {registry_count}"
+        registry_count, 53,
+        "expected 53 registry skills, got {registry_count}"
     );
 }
 

--- a/crates/ix-approval/src/classify.rs
+++ b/crates/ix-approval/src/classify.rs
@@ -75,6 +75,7 @@ pub fn classify_action_kind(tool_name: &str) -> ActionKind {
         "ix_fft",
         "ix_linear_regression",
         "ix_kmeans",
+        "ix_pca",
         "ix_optimize",
         "ix_search",
         "ix_markov",
@@ -151,7 +152,16 @@ mod tests {
 
     #[test]
     fn read_tools_classify_as_read() {
-        for tool in &["ix_stats", "ix_context_walk", "ix_code_analyze", "ix_fft"] {
+        // ix_pca: pure deterministic ML compute (like ix_kmeans) — must classify
+        // as Read so the approval middleware doesn't block the new MCP tool /
+        // pipeline stage at Tier 3 (Codex P1 on #83: exposed-but-unusable).
+        for tool in &[
+            "ix_stats",
+            "ix_context_walk",
+            "ix_code_analyze",
+            "ix_fft",
+            "ix_pca",
+        ] {
             assert_eq!(
                 classify_action_kind(tool),
                 ActionKind::Read,

--- a/crates/ix-skill/src/verbs/compile.rs
+++ b/crates/ix-skill/src/verbs/compile.rs
@@ -1540,7 +1540,7 @@ mod tests {
         let mean_top3 = |c: &[f64]| c.iter().take(3).sum::<f64>() / 3.0;
 
         // A: raw mean-top-3 (the production signal). B: per-query z-norm of
-        // mean-top-3 against the query's own 52-catalog-cosine distribution
+        // mean-top-3 against the query's own per-catalog cosine distribution
         // (calibration, catalog-only → runtime-cheap). C: top1−top2 margin.
         // D: A × kNN(10)-guidance to the in-domain QUERY set (NNGuide-style,
         // leave-one-out for in-domain probes; needs the in-domain reference).

--- a/crates/ix-skill/tests/cli.rs
+++ b/crates/ix-skill/tests/cli.rs
@@ -25,11 +25,12 @@ fn list_skills_returns_all_entries() {
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     let count = value["count"].as_u64().expect("count is number");
-    // 52 = batch1 (6) + batch2 (28) + batch3 (10 + context.walk +
-    // session.flywheel_export + fuzzy.eval) + prime_radiant (2) +
-    // assumption_graph (4: assumption.query + .belief_at + .drift + .claims).
+    // 53 = batch1 (6 + pca, 2026-06-07 dogfood catalog-breadth fix) + batch2 (28)
+    // + batch3 (10 + context.walk + session.flywheel_export + fuzzy.eval)
+    // + prime_radiant (2) + assumption_graph (4: assumption.query + .belief_at
+    // + .drift + .claims).
     // If this drifts, update the assertion alongside the batch changes.
-    assert_eq!(count, 52, "expected 52 registry skills, got {count}");
+    assert_eq!(count, 53, "expected 53 registry skills, got {count}");
 }
 
 #[test]

--- a/state/thinking-machine/dogfood-2026-06-07-findings.md
+++ b/state/thinking-machine/dogfood-2026-06-07-findings.md
@@ -1,0 +1,113 @@
+# Thinking-machine dogfood — 2026-06-07 (what the instrument says to build next)
+
+Ran a 20-request realistic batch through `ix pipeline compile` (compile-only, no
+`--run`; default Opus proposer `claude-opus-4-8`; default TF-IDF coverage gate),
+then read the `hits.jsonl` instrument (#80) + `gaps.jsonl`.
+
+## Instrument (cumulative, n=32)
+
+| field | value | reading |
+|---|---|---|
+| `yield_rate` | **0.281** | metric — fraction that compiled |
+| `coverage_refusal_rate` | **0.719** | guardrail — fraction refused at coverage/relevance |
+| `governance_refusal_rate` | 0.000 | governance never refused |
+| `translate_fail_rate` | 0.000 | proposer never produced an unrepairable spec |
+
+This batch's 24 refusals: **22 `semantic-noncoverage`** (proposer emits NO_COVERAGE
+*after* the cheap pre-gate passes) + 2 `coverage` (TF-IDF pre-gate). So refusals
+happen at the **proposer/catalog-match stage**, not the pre-gate.
+
+## Diagnosis: the bottleneck is catalog breadth, not the gate, model, or lower()
+
+The gate, `lower()`, repair loop, and governance are all working: **0% translate-fail,
+0% governance-refusal, and no confabulation** — the 4–9 successes map to real skills
+(e.g. "standardize → PCA → classifier" correctly compiled to the composite
+`ml_pipeline` skill with `normalize:true, pca_components:5, task:classify`, not a
+faked PCA stage). The machine honestly refuses what it can't serve instead of
+inventing specs — exactly the design goal.
+
+The yield ceiling is the **pipeline-callable catalog**: exactly **52 arity-1 skills**,
+a thin slice of IX's real capability surface. Refusals fall in three categories:
+
+1. **Genuine catalog gaps — algorithm EXISTS in a library crate, but is not wrapped
+   as a callable `#[ix_skill]`:**
+   - **PCA / dimensionality reduction** — refused "compute the principal components",
+     "PCA then k-means". `ix-unsupervised` implements it (`fit_transform`, `components`,
+     `explained_variance_ratio`, `reconstruct`) + `classical_mds` + t-SNE. Only
+     reachable today as a *preprocess flag inside* `ml_pipeline`, never standalone.
+   - **DBSCAN** — refused "cluster with DBSCAN". `ix-unsupervised/src/dbscan.rs` exists;
+     only `kmeans` is callable.
+   - **eigendecomposition** — refused "compute the eigenvalues". `ix-math/src/eigen.rs`
+     + `svd.rs` exist; neither is a callable skill.
+2. **Composite-only access (no composition):** PCA exists only bundled inside
+   `ml_pipeline`, so "PCA then k-means" can't be expressed — you can't pipe
+   `ml_pipeline`'s internal PCA into `kmeans`. Standalone primitives unlock this.
+3. **Honest capability boundaries (correct refusals, not bugs):** `nn.forward` is a
+   forward pass, so "train an NN for 100 epochs" is correctly refused; `optimize`
+   minimizes *benchmark* functions (Rosenbrock…), not an arbitrary user objective;
+   `topo` is *topological data analysis* (persistent homology), not topological sort.
+   Multi-array supervised skills (`random_forest` x_train/y_train/x_test,
+   `linear_regression` X/y) are shoehorned into one data-flow socket and need inline
+   data an abstract request doesn't carry.
+
+## Next increment (data-driven): widen the callable catalog
+
+Wrap the **already-implemented** library algorithms as arity-1 `#[ix_skill]`s, highest
+refused-frequency first — **PCA**, **DBSCAN**, **eigendecomposition** (all exist in
+`ix-unsupervised`/`ix-math`; pure additive registration + a test each). Then re-run
+this batch to confirm yield rises via **real compilations that execute**, not
+confabulation.
+
+**Guardrail (from the instrument's own note):** a yield gain paired with a
+coverage-refusal *drop* is gate-loosening unless the new skills genuinely work.
+Because these algorithms already exist and are tested in their crates, exposing them
+is a *legitimate* yield gain — but each new skill must ship with a test proving it
+executes (no green-but-dead catalog entries). Add **one primitive at a time, each
+driving a re-run that shows a real compiled+executable spec.**
+
+Structural follow-ups (lower priority): standalone PCA enables PCA→kmeans
+composition; multi-input pipeline stages for (X, y) supervised learning; `silhouette`
+and graph `topological_sort` need implementing (not found as core ML).
+
+Reproduce: `target/debug/ix.exe pipeline compile "<request>" --format json`;
+aggregate via `ix pipeline hits`. Raw batch: `.ix/dogfood-2026-06-07/results.jsonl`.
+
+---
+
+## Increment 1 (shipped same session): standalone `pca` skill
+
+Wrapped `ix-unsupervised`'s PCA as an arity-1 `#[ix_skill]` (`pca`; handler
+`handlers::pca`; schema `data` + `n_components`; output `transformed` /
+`explained_variance_ratio` / `components`). Auto-exposed as MCP tool `ix_pca` via
+the registry bridge (parity 77→78, registry 52→53). Three executes-tests
+(real PCA run + registered-and-arity-1 + too-many-components rejection).
+
+**Verified effect (re-ran the refused PCA requests):**
+- ✅ **Composition unblocked:** "run PCA to reduce these vectors then cluster them
+  with k-means" now **compiles to a real 2-stage DAG** — `reduce {skill: pca}` →
+  `cluster {skill: kmeans, data:{from: reduce.projected}}`. That chain was
+  impossible before (no standalone PCA to pipe into k-means).
+- ✅ **Catalog gap closed:** standalone "compute the principal components"
+  refusals *changed character* from "no IX skill covers this" to
+  **"no input data matrix provided to run PCA on"** (`llm-relevance`,
+  deterministic) — the proposer now **recognizes** PCA and refuses only for
+  missing data, which is correct (it won't fabricate inputs).
+
+**Two NEW findings this increment surfaced (next-up backlog):**
+1. **Data-binding (was a known structural follow-up, now the dominant refusal):**
+   abstract requests with no inline data/file/URL are refused because required
+   data args can't be filled. The fix is a data-source binding story
+   (placeholder/param spec, or `--run` data binding), not more skills.
+2. **Output-schema gap (NEW, exposed by the first multi-stage composition):**
+   `catalog_value` (compile.rs) exposes only `name`/`doc`/`governance_tags`/
+   `args_schema` — **no output schema**. So cross-stage refs *guess* the upstream
+   output field name: the PCA→kmeans spec referenced `reduce.projected` but the
+   handler emits `transformed`, so the compiled spec would **fail at `--run`**.
+   This means "compiled" ≠ "executable" for multi-stage pipelines. Highest-value
+   next fix: add each skill's output field names to the catalog (and/or validate
+   cross-stage refs in `lower()`), so compositions execute, not just compile.
+
+Remaining catalog primitives (same pattern as `pca`, next passes): **DBSCAN**
+(`ix-unsupervised/src/dbscan.rs`), **eigendecomposition** (`ix-math/src/eigen.rs`
++ `svd.rs`). Each: arity-1 `#[ix_skill]` + handler + executes-test + parity bump
++ dogfood re-run.


### PR DESCRIPTION
## What & why — telemetry-driven

Dogfooded the live thinking machine (20 realistic requests through `ix pipeline compile`) and read the `hits.jsonl` instrument. Verdict: the yield ceiling (**28% yield, 72% coverage-refusal, 22/24 refusals at the proposer stage**) is **catalog breadth** — *not* the gate, model, or `lower()` (**0% translate-fail, 0% governance-refusal, no confabulation**). The pipeline-callable catalog was 52 arity-1 skills; high-frequency primitives IX *implements* in its crates (PCA, DBSCAN, eigendecomposition) simply weren't exposed as callable skills. Full diagnosis: `state/thinking-machine/dogfood-2026-06-07-findings.md`.

This is the **first fix**: wrap `ix-unsupervised`'s PCA.

## Changes
- **`handlers::pca`** + arity-1 **`#[ix_skill] pca`** (batch1): args `data` + `n_components`; output `transformed` / `explained_variance_ratio` / `components`; guards `1 ≤ n_components ≤ feature count`.
- **Auto-exposed as MCP tool `ix_pca`** via the registry bridge → agent-native parity for free. Parity updated **77→78 tools, 52→53 registry skills** (+ `cli.rs` count).
- **Three executes-tests** (real PCA run; registered-and-arity-1; rejects too-many-components) — no green-but-dead catalog entry.

## Verified effect (re-ran the previously-refused requests)
- ✅ **Composition unblocked:** "PCA then cluster with k-means" now compiles to a real 2-stage DAG — `reduce {skill: pca}` → `cluster {skill: kmeans}`. Impossible before (no standalone PCA to pipe into k-means).
- ✅ **Catalog gap closed:** standalone-PCA refusals changed from *"no IX skill covers this"* to *"no input data matrix provided"* — the proposer now **recognizes PCA** and refuses only for missing data (won't fabricate inputs).

## Two next-up findings this surfaced (documented, not fixed — surgical scope)
1. **Data-binding** — abstract requests with no inline data are the dominant remaining refusal; needs a data-source binding story, not more skills.
2. **Output-schema gap (NEW)** — `catalog_value` omits skills' output field names, so cross-stage refs *guess* them (PCA→kmeans referenced `reduce.projected`; the handler emits `transformed`). So multi-stage **"compiled" ≠ "executable"** today. Highest-value next fix.

Remaining catalog primitives (same pattern, next passes): DBSCAN (`ix-unsupervised/src/dbscan.rs`), eigendecomposition (`ix-math/src/eigen.rs`+`svd.rs`).

## Verification
Full `ix-agent` + `ix-skill` test suites green; parity green (78/53); `clippy --all-targets` clean on both crates; fmt clean. No production behavior change beyond the additive new skill/tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)