### PR TITLE
feat(ix-pipeline): chain-of-evidence v1 — per-run provenance record (ix-lock/v2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,12 @@ ix.lock
 # gaps.jsonl, the curated dogfood BACKLOG, which IS tracked.)
 state/thinking-machine/hits.jsonl
 
+# ix "thinking machine" provenance trail (chain-of-evidence v1) — append-only
+# per-run records (ix-lock/v2). High-volume runtime instrumentation, read in
+# aggregate; the raw rows are per-environment runtime data, not a committed
+# artifact (contrast the schema, which lives in docs/contracts/).
+state/thinking-machine/provenance.jsonl
+
 # in-process embedding catalog cache (feature `embeddings`) — runtime data,
 # regenerated from the skill catalog on demand; cwd-relative so it can appear at
 # the repo root or under a crate dir during tests.

--- a/crates/ix-pipeline/Cargo.toml
+++ b/crates/ix-pipeline/Cargo.toml
@@ -15,5 +15,10 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
 parking_lot = "0.12"
+# sha256 for the provenance record's content/integrity hashes (ix-lock/v2,
+# chain-of-evidence v1) — distinct from the FNV cache/template hashes; aligns
+# with the constitution-pin + ix-harness-signing (see
+# docs/contracts/2026-06-07-provenance-record.contract.md).
+sha2 = "0.10"
 ix-registry = { workspace = true }
 ix-types = { workspace = true }

--- a/crates/ix-pipeline/src/lock.rs
+++ b/crates/ix-pipeline/src/lock.rs
@@ -152,10 +152,17 @@ impl LockFile {
             &serde_json::to_value(spec).unwrap_or(Value::Null),
         ));
         let generated = current_iso_timestamp();
-        // Content+time run id: distinct per run, stable to re-parse. 16 hex chars
-        // of sha256 over (timestamp, spec hash, stage count) — drop the
-        // "sha256:" prefix so the id reads `run:<hex>`.
-        let run_digest = sha256_str(&format!("{generated}|{spec_hash}|{}", stages.len()));
+        // Distinct-per-run id: 16 hex chars of sha256 over (nanosecond clock,
+        // process-lifetime sequence, spec hash, stage count). The `generated`
+        // ISO string is only second-resolution, and on some platforms the clock
+        // is coarse (~15ms), so two runs of the SAME spec within that window
+        // would otherwise collide (Codex #85 P2) — the nanos + the monotonic
+        // counter guarantee uniqueness within a process and across the realistic
+        // multi-process case. (run_id is intentionally non-reproducible; only
+        // output_hash is deterministic.)
+        let nanos = now_nanos();
+        let seq = RUN_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let run_digest = sha256_str(&format!("{nanos}|{seq}|{spec_hash}|{}", stages.len()));
         let run_hex = run_digest.strip_prefix("sha256:").unwrap_or(&run_digest);
         let run_id = format!("run:{}", &run_hex[..16.min(run_hex.len())]);
         LockFile {
@@ -281,6 +288,20 @@ fn sha256_str(s: &str) -> String {
 /// sha256 of a JSON value over its canonical form (key-sorted), `sha256:` prefixed.
 fn sha256_json(v: &Value) -> String {
     sha256_str(&canonicalize(v))
+}
+
+/// Process-lifetime monotonic counter — guarantees distinct `run_id`s even when
+/// two runs read an identical (coarse) clock value.
+static RUN_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Wall-clock nanoseconds since the Unix epoch (best-effort; 0 if the clock is
+/// before the epoch). Used only for `run_id` entropy, never for content hashes.
+fn now_nanos() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -516,6 +537,20 @@ mod tests {
         assert_eq!(a, b, "same value → same hash");
         assert_ne!(a, c, "changed value → changed hash");
         assert!(a.starts_with("sha256:"));
+    }
+
+    // Criterion 5 (Codex #85 P2): the same spec run twice → DISTINCT run_id,
+    // even though the deterministic content hashes are identical.
+    #[test]
+    fn v2_run_id_is_unique_per_run() {
+        let (spec, result) = two_stage_run();
+        let a = LockFile::from_run(&spec, &result, &HashMap::new());
+        let b = LockFile::from_run(&spec, &result, &HashMap::new());
+        assert_ne!(a.run_id, b.run_id, "two runs of one spec → distinct run_id");
+        assert_eq!(
+            a.stages["reduce"].output_hash, b.stages["reduce"].output_hash,
+            "but the content hash stays deterministic"
+        );
     }
 
     // Criterion 6: a v1 lock still deserializes (v2 fields default).

--- a/crates/ix-pipeline/src/lock.rs
+++ b/crates/ix-pipeline/src/lock.rs
@@ -75,7 +75,10 @@ pub struct LockedStage {
 pub struct InputBinding {
     /// The consumer arg name the reference appeared under.
     pub name: String,
-    /// Producing stage id (or `__input__:KEY` for a seed input).
+    /// The reference's stage token — the text before the first `.` in the
+    /// `{"from"}` target. For a producing stage this is its id (and
+    /// `upstream_output_hash` links to it); for a seed-input ref it is the seed
+    /// key and `upstream_output_hash` is empty (no producing stage this run).
     pub from_stage: String,
     /// Output key within the producer's output (`*` = whole output).
     pub from_key: String,
@@ -93,13 +96,21 @@ impl LockFile {
     /// those outputs (deterministic, identical to what ran), so no executor or
     /// closure changes are needed. `initial_inputs` are the seed values handed to
     /// `execute()` (empty for inline-data specs).
+    ///
+    /// CALLER CONTRACT: `initial_inputs` MUST be the same seed map passed to
+    /// `execute()` for this run. Re-resolution looks refs up against (those
+    /// seeds + stage outputs); if a caller seeds `execute()` but hands `from_run`
+    /// a different/empty map, a seed-backed ref fails to resolve and
+    /// `resolved_args_hash` silently falls back to the template hash. The sole
+    /// caller (`ix pipeline run`) passes one shared, empty map, so this holds today.
+    // @ai:assumption from_run's `initial_inputs` is the SAME seed map passed to execute() this run; else a seed-backed resolved_args_hash silently degrades to the template hash [U:uncertain conf:0.6 src:ix-skill pipeline.rs run() passes one shared empty map to both — unenforced precondition]
     pub fn from_run(
         spec: &PipelineSpec,
         result: &PipelineResult,
         initial_inputs: &std::collections::HashMap<String, Value>,
     ) -> Self {
-        // stage_id (and `__input__:KEY` seeds) -> output value, for re-resolution
-        // and upstream-hash linking.
+        // {stage_id -> output} (plus any seed inputs by their own keys), for
+        // re-resolving `{"from"}` refs and linking upstream output hashes.
         let mut outputs: std::collections::HashMap<String, Value> = initial_inputs.clone();
         for (id, r) in &result.node_results {
             outputs.insert(id.clone(), r.output.clone());

--- a/crates/ix-pipeline/src/lock.rs
+++ b/crates/ix-pipeline/src/lock.rs
@@ -26,50 +26,162 @@ use serde_json::Value;
 use crate::executor::PipelineResult;
 use crate::spec::PipelineSpec;
 
-pub const LOCK_SCHEMA: &str = "ix-lock/v1";
+pub const LOCK_SCHEMA: &str = "ix-lock/v2";
+/// Accepted on read: v2 is a strict additive superset of v1's field set.
+const LOCK_SCHEMA_V1: &str = "ix-lock/v1";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockFile {
     pub schema: String,
     pub generated: String,
+    /// Unique-per-run id (content+time derived) — keys the append-only
+    /// `provenance.jsonl` trail. NEW in v2; defaulted when reading v1.
+    #[serde(default)]
+    pub run_id: String,
+    /// sha256 of the canonicalized `PipelineSpec`. NEW in v2.
+    #[serde(default)]
+    pub spec_hash: String,
     pub stages: BTreeMap<String, LockedStage>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockedStage {
     pub skill: String,
+    /// fnv1a64 over the canonicalized **template** args (v1 — unchanged).
     pub args_hash: String,
     pub deps: Vec<String>,
     pub duration_ms: u64,
     pub cache_hit: bool,
+    /// fnv1a64 over the canonicalized **resolved** args (post `{"from"}`
+    /// resolution) — the inputs the skill actually ran with. NEW in v2.
+    #[serde(default)]
+    pub resolved_args_hash: String,
+    /// sha256 of the canonical-JSON stage output. NEW in v2.
+    #[serde(default)]
+    pub output_hash: String,
+    /// The cross-stage edges that actually flowed into this stage. NEW in v2.
+    #[serde(default)]
+    pub inputs: Vec<InputBinding>,
+    /// RESERVED for chain-of-evidence: a hexavalent certainty for this output.
+    /// Unpopulated in v1 of the mechanism (no reusable propagation algebra yet —
+    /// see docs/plans/2026-06-07-chain-of-evidence-v1.md §Deferred).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub certainty: Option<Value>,
+}
+
+/// One consumed cross-stage reference (`{"from": "stage.key"}`), linked to the
+/// exact upstream output it carried.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputBinding {
+    /// The consumer arg name the reference appeared under.
+    pub name: String,
+    /// Producing stage id (or `__input__:KEY` for a seed input).
+    pub from_stage: String,
+    /// Output key within the producer's output (`*` = whole output).
+    pub from_key: String,
+    /// sha256 of the producing stage's output — equals that stage's
+    /// `output_hash` in the same run (the verifiable link). Empty for seed
+    /// inputs (no producing stage in this run).
+    pub upstream_output_hash: String,
 }
 
 impl LockFile {
-    /// Build a `LockFile` from a successfully-executed pipeline.
-    pub fn from_run(spec: &PipelineSpec, result: &PipelineResult) -> Self {
+    /// Build an `ix-lock/v2` provenance record from a successfully-executed
+    /// pipeline. Every v2 field is derived from `(spec, result, initial_inputs)`
+    /// alone — the per-stage outputs live in `result.node_results`, and the
+    /// resolved args are reconstructed by replaying `{"from"}` resolution against
+    /// those outputs (deterministic, identical to what ran), so no executor or
+    /// closure changes are needed. `initial_inputs` are the seed values handed to
+    /// `execute()` (empty for inline-data specs).
+    pub fn from_run(
+        spec: &PipelineSpec,
+        result: &PipelineResult,
+        initial_inputs: &std::collections::HashMap<String, Value>,
+    ) -> Self {
+        // stage_id (and `__input__:KEY` seeds) -> output value, for re-resolution
+        // and upstream-hash linking.
+        let mut outputs: std::collections::HashMap<String, Value> = initial_inputs.clone();
+        for (id, r) in &result.node_results {
+            outputs.insert(id.clone(), r.output.clone());
+        }
+        // Per-stage output hashes, computed once so InputBinding can link to them.
+        let output_hashes: BTreeMap<String, String> = result
+            .node_results
+            .iter()
+            .map(|(id, r)| (id.clone(), sha256_json(&r.output)))
+            .collect();
+
         let mut stages = BTreeMap::new();
         for (id, stage) in &spec.stages {
-            let args_hash = hash_json(&stage.args);
             let node_result = result.node_results.get(id);
             let (duration_ms, cache_hit) = node_result
                 .map(|r| (r.duration.as_millis() as u64, r.cache_hit))
                 .unwrap_or((0, false));
+            // Resolved args: replay {"from"} resolution; fall back to the template
+            // if a ref can't resolve (e.g. a seed not present) — never panic.
+            let resolved = crate::lower::resolve_from_refs(&stage.args, &outputs)
+                .unwrap_or_else(|_| stage.args.clone());
+            let inputs = collect_input_bindings(&stage.args, &output_hashes);
             stages.insert(
                 id.clone(),
                 LockedStage {
                     skill: stage.skill.clone(),
-                    args_hash,
+                    args_hash: hash_json(&stage.args),
                     deps: stage.deps.clone(),
                     duration_ms,
                     cache_hit,
+                    resolved_args_hash: hash_json(&resolved),
+                    output_hash: output_hashes.get(id).cloned().unwrap_or_default(),
+                    inputs,
+                    certainty: None,
                 },
             );
         }
+        let spec_hash = sha256_str(&canonicalize(
+            &serde_json::to_value(spec).unwrap_or(Value::Null),
+        ));
+        let generated = current_iso_timestamp();
+        // Content+time run id: distinct per run, stable to re-parse. 16 hex chars
+        // of sha256 over (timestamp, spec hash, stage count) — drop the
+        // "sha256:" prefix so the id reads `run:<hex>`.
+        let run_digest = sha256_str(&format!("{generated}|{spec_hash}|{}", stages.len()));
+        let run_hex = run_digest.strip_prefix("sha256:").unwrap_or(&run_digest);
+        let run_id = format!("run:{}", &run_hex[..16.min(run_hex.len())]);
         LockFile {
             schema: LOCK_SCHEMA.into(),
-            generated: current_iso_timestamp(),
+            generated,
+            run_id,
+            spec_hash,
             stages,
         }
+    }
+
+    /// Verify the evidence chain: every `InputBinding.upstream_output_hash` must
+    /// equal the `output_hash` recorded for its `from_stage` in this run (seed
+    /// inputs, which have no producing stage, are exempt). Returns the list of
+    /// broken edges (empty = the chain holds). This *records* integrity; v1 does
+    /// not gate execution on it.
+    pub fn verify_chain(&self) -> Vec<String> {
+        let mut broken = Vec::new();
+        for (stage_id, st) in &self.stages {
+            for b in &st.inputs {
+                if b.upstream_output_hash.is_empty() {
+                    continue; // seed input — no producing stage this run
+                }
+                match self.stages.get(&b.from_stage) {
+                    Some(up) if up.output_hash == b.upstream_output_hash => {}
+                    Some(up) => broken.push(format!(
+                        "stage '{stage_id}' input '{}' claims {}={} but '{}' produced {}",
+                        b.name, b.from_stage, b.upstream_output_hash, b.from_stage, up.output_hash
+                    )),
+                    None => broken.push(format!(
+                        "stage '{stage_id}' input '{}' references unknown producing stage '{}'",
+                        b.name, b.from_stage
+                    )),
+                }
+            }
+        }
+        broken
     }
 
     /// Serialize to YAML.
@@ -77,11 +189,17 @@ impl LockFile {
         serde_yaml::to_string(self)
     }
 
-    /// Load a lock from disk (for future verification).
+    /// One-line JSON for the append-only `provenance.jsonl` trail.
+    pub fn to_json_line(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Load a lock from disk. Accepts both `ix-lock/v2` and the legacy
+    /// `ix-lock/v1` (v2 fields default to empty when reading v1).
     pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<Self, LockError> {
         let text = std::fs::read_to_string(path)?;
         let lf: LockFile = serde_yaml::from_str(&text)?;
-        if lf.schema != LOCK_SCHEMA {
+        if lf.schema != LOCK_SCHEMA && lf.schema != LOCK_SCHEMA_V1 {
             return Err(LockError::SchemaMismatch {
                 expected: LOCK_SCHEMA.into(),
                 actual: lf.schema,
@@ -89,6 +207,69 @@ impl LockFile {
         }
         Ok(lf)
     }
+}
+
+/// Collect the cross-stage references in a stage's `args` as `InputBinding`s,
+/// attributing each to the arg name it appeared under and linking it to the
+/// producer's output hash. Mirrors `lower::collect_from_refs`/`resolve_from_refs`
+/// ref semantics (a ref is a single-key `{"from": "stage[.key]"}` object).
+fn collect_input_bindings(
+    args: &Value,
+    output_hashes: &BTreeMap<String, String>,
+) -> Vec<InputBinding> {
+    fn walk(
+        value: &Value,
+        name: &str,
+        hashes: &BTreeMap<String, String>,
+        out: &mut Vec<InputBinding>,
+    ) {
+        match value {
+            Value::Object(map) => {
+                if map.len() == 1 {
+                    if let Some(Value::String(target)) = map.get("from") {
+                        let (from_stage, from_key) = match target.split_once('.') {
+                            Some((s, k)) => (s.to_string(), k.to_string()),
+                            None => (target.clone(), "*".to_string()),
+                        };
+                        let upstream_output_hash =
+                            hashes.get(&from_stage).cloned().unwrap_or_default();
+                        out.push(InputBinding {
+                            name: name.to_string(),
+                            from_stage,
+                            from_key,
+                            upstream_output_hash,
+                        });
+                        return;
+                    }
+                }
+                for (k, v) in map {
+                    walk(v, k, hashes, out);
+                }
+            }
+            Value::Array(items) => {
+                for v in items {
+                    walk(v, name, hashes, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    walk(args, "", output_hashes, &mut out);
+    out
+}
+
+/// sha256 hex of a string, `sha256:` prefixed (the provenance integrity hash).
+fn sha256_str(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    format!("sha256:{:x}", h.finalize())
+}
+
+/// sha256 of a JSON value over its canonical form (key-sorted), `sha256:` prefixed.
+fn sha256_json(v: &Value) -> String {
+    sha256_str(&canonicalize(v))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -207,7 +388,7 @@ mod tests {
             execution_order: vec![],
         };
 
-        let lock = LockFile::from_run(&spec, &result);
+        let lock = LockFile::from_run(&spec, &result, &std::collections::HashMap::new());
         assert_eq!(lock.schema, LOCK_SCHEMA);
         assert_eq!(lock.stages.len(), 1);
         assert!(lock.stages["load"].args_hash.starts_with("fnv1a64:"));
@@ -216,5 +397,135 @@ mod tests {
         let back: LockFile = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(back.stages["load"].skill, "stats");
         assert_eq!(back.stages["load"].args_hash, lock.stages["load"].args_hash);
+    }
+
+    use crate::executor::NodeResult;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    fn two_stage_run() -> (PipelineSpec, PipelineResult) {
+        let mut stages = BTreeMap::new();
+        stages.insert(
+            "reduce".to_string(),
+            StageSpec {
+                skill: "pca".into(),
+                args: json!({"data": [[1.0, 2.0]], "n_components": 1}),
+                deps: vec![],
+                cache: None,
+            },
+        );
+        stages.insert(
+            "cluster".to_string(),
+            StageSpec {
+                skill: "kmeans".into(),
+                args: json!({"data": {"from": "reduce.transformed"}, "k": 2}),
+                deps: vec!["reduce".into()],
+                cache: None,
+            },
+        );
+        let spec = PipelineSpec {
+            version: "1".into(),
+            params: BTreeMap::new(),
+            stages,
+            x_editor: Value::Null,
+        };
+        let mut node_results = HashMap::new();
+        node_results.insert(
+            "reduce".to_string(),
+            NodeResult {
+                node_id: "reduce".into(),
+                output: json!({"transformed": [[0.5]], "explained_variance_ratio": [1.0]}),
+                duration: Duration::ZERO,
+                cache_hit: false,
+            },
+        );
+        node_results.insert(
+            "cluster".to_string(),
+            NodeResult {
+                node_id: "cluster".into(),
+                output: json!({"labels": [0], "k": 2}),
+                duration: Duration::ZERO,
+                cache_hit: false,
+            },
+        );
+        let result = PipelineResult {
+            node_results,
+            total_duration: Duration::ZERO,
+            cache_hits: 0,
+            execution_order: vec![],
+        };
+        (spec, result)
+    }
+
+    // Criterion 1 + 4: v2 record materializes with hashes + a verifiable edge.
+    #[test]
+    fn v2_records_hashes_and_links_the_edge() {
+        let (spec, result) = two_stage_run();
+        let lock = LockFile::from_run(&spec, &result, &HashMap::new());
+
+        assert_eq!(lock.schema, "ix-lock/v2");
+        assert!(lock.run_id.starts_with("run:"));
+        assert!(lock.spec_hash.starts_with("sha256:"));
+
+        let red = &lock.stages["reduce"];
+        let clu = &lock.stages["cluster"];
+        assert!(red.output_hash.starts_with("sha256:"), "output hashed");
+        assert!(clu.resolved_args_hash.starts_with("fnv1a64:"));
+
+        // The cross-stage edge is captured AND linked to the producer's hash.
+        assert_eq!(clu.inputs.len(), 1);
+        let edge = &clu.inputs[0];
+        assert_eq!(edge.name, "data");
+        assert_eq!(edge.from_stage, "reduce");
+        assert_eq!(edge.from_key, "transformed");
+        assert_eq!(edge.upstream_output_hash, red.output_hash);
+
+        // Criterion 4: the chain verifies clean.
+        assert!(lock.verify_chain().is_empty());
+    }
+
+    // Criterion 4 (negative): a tampered upstream hash is detected.
+    #[test]
+    fn v2_verify_chain_detects_a_broken_edge() {
+        let (spec, result) = two_stage_run();
+        let mut lock = LockFile::from_run(&spec, &result, &HashMap::new());
+        lock.stages.get_mut("cluster").unwrap().inputs[0].upstream_output_hash =
+            "sha256:deadbeef".into();
+        let broken = lock.verify_chain();
+        assert_eq!(broken.len(), 1, "one broken edge: {broken:?}");
+        assert!(broken[0].contains("cluster"));
+    }
+
+    // Criterion 2 + 3: output hashing is deterministic and value-sensitive.
+    #[test]
+    fn v2_output_hash_is_deterministic_and_change_sensitive() {
+        let a = sha256_json(&json!({"transformed": [[0.5]]}));
+        let b = sha256_json(&json!({"transformed": [[0.5]]}));
+        let c = sha256_json(&json!({"transformed": [[0.6]]}));
+        assert_eq!(a, b, "same value → same hash");
+        assert_ne!(a, c, "changed value → changed hash");
+        assert!(a.starts_with("sha256:"));
+    }
+
+    // Criterion 6: a v1 lock still deserializes (v2 fields default).
+    #[test]
+    fn v1_lock_still_loads() {
+        let v1 = r#"schema: ix-lock/v1
+generated: "2026-01-01T00:00:00Z"
+stages:
+  load:
+    skill: stats
+    args_hash: "fnv1a64:0000000000000000"
+    deps: []
+    duration_ms: 1
+    cache_hit: false
+"#;
+        let lf: LockFile = serde_yaml::from_str(v1).unwrap();
+        assert_eq!(lf.stages["load"].skill, "stats");
+        assert!(
+            lf.stages["load"].output_hash.is_empty(),
+            "v2 field defaults"
+        );
+        assert!(lf.run_id.is_empty());
     }
 }

--- a/crates/ix-pipeline/src/lower.rs
+++ b/crates/ix-pipeline/src/lower.rs
@@ -181,7 +181,10 @@ fn collect_from_refs(value: &Value, out: &mut BTreeSet<String>) {
 
 /// Clone `template` replacing every `{"from": "..."}` reference with the
 /// matching upstream output. Unknown references bubble up as `Err`.
-fn resolve_from_refs(template: &Value, inputs: &HashMap<String, Value>) -> Result<Value, String> {
+pub(crate) fn resolve_from_refs(
+    template: &Value,
+    inputs: &HashMap<String, Value>,
+) -> Result<Value, String> {
     match template {
         Value::Object(map) => {
             if let Some(Value::String(target)) = map.get("from") {

--- a/crates/ix-skill/src/verbs/pipeline.rs
+++ b/crates/ix-skill/src/verbs/pipeline.rs
@@ -462,6 +462,28 @@ impl ix_pipeline::gate::StageGate for ConstitutionGate {
     }
 }
 
+/// Append one provenance record (the v2 lock) to the durable, append-only
+/// `state/thinking-machine/provenance.jsonl` trail. Best-effort: any I/O error
+/// is swallowed so provenance logging never fails a pipeline run (same
+/// discipline as the hits.jsonl ledger). One `write_all` of line+newline keeps
+/// concurrent appends from interleaving mid-line.
+fn append_provenance(lock: &LockFile) {
+    use std::io::Write as _;
+    let path = Path::new("state/thinking-machine/provenance.jsonl");
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let mut line = lock.to_json_line();
+    line.push('\n');
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+    {
+        let _ = f.write_all(line.as_bytes());
+    }
+}
+
 /// `ix pipeline run [-f FILE] [--json]` — execute the pipeline.
 ///
 /// When `stream_ndjson` is true, emits NDJSON events (`start`, `stage_start`,
@@ -493,11 +515,12 @@ pub fn run(file: Option<&str>, stream_ndjson: bool, format: Format) -> Result<()
     // The current executor doesn't expose per-stage callbacks, so we emit
     // start+done around the whole run for phase 1. Per-stage events arrive
     // in a future iteration that adds a callback hook to `execute()`.
-    let result =
-        execute(&dag, &Default::default(), &NoCache).map_err(|e| format!("execution: {e}"))?;
+    let initial_inputs: std::collections::HashMap<String, serde_json::Value> =
+        std::collections::HashMap::new();
+    let result = execute(&dag, &initial_inputs, &NoCache).map_err(|e| format!("execution: {e}"))?;
 
-    // Write ix.lock alongside the spec (phase 1: write-only, no enforcement).
-    let lock = LockFile::from_run(&spec, &result);
+    // Write ix.lock (ix-lock/v2 provenance record) alongside the spec.
+    let lock = LockFile::from_run(&spec, &result, &initial_inputs);
     let lock_yaml = lock
         .to_yaml_string()
         .map_err(|e| format!("lock yaml: {e}"))?;
@@ -507,6 +530,11 @@ pub fn run(file: Option<&str>, stream_ndjson: bool, format: Format) -> Result<()
         .join("ix.lock");
     std::fs::write(&lock_path, &lock_yaml)
         .map_err(|e| format!("writing {}: {e}", lock_path.display()))?;
+
+    // Append the run to the durable provenance trail (best-effort, never blocks
+    // the run — same discipline as hits.jsonl). One JSON object per run, keyed
+    // by run_id. See docs/contracts/2026-06-07-provenance-record.contract.md.
+    append_provenance(&lock);
 
     if stream_ndjson {
         for (id, node_result) in &result.node_results {

--- a/crates/ix-skill/tests/governance.rs
+++ b/crates/ix-skill/tests/governance.rs
@@ -214,8 +214,12 @@ stages:
     let lock_path = dir.join("ix.lock");
     assert!(lock_path.is_file(), "ix.lock was not written");
     let lock_text = fs::read_to_string(&lock_path).unwrap();
-    assert!(lock_text.contains("schema: ix-lock/v1"));
+    assert!(lock_text.contains("schema: ix-lock/v2"));
     assert!(lock_text.contains("skill: stats"));
     assert!(lock_text.contains("args_hash: fnv1a64:"));
+    // ix-lock/v2 provenance fields (chain-of-evidence v1): the run carries a
+    // run id and the stage output is content-hashed.
+    assert!(lock_text.contains("run_id: run:"));
+    assert!(lock_text.contains("output_hash: sha256:"));
     fs::remove_dir_all(&dir).ok();
 }

--- a/docs/contracts/2026-06-07-provenance-record.contract.md
+++ b/docs/contracts/2026-06-07-provenance-record.contract.md
@@ -1,0 +1,77 @@
+# Contract: pipeline provenance record (`ix-lock/v2`)
+
+**Version:** v0.1.0 (DRAFT — Phase 0; freeze only at the named Phase 4 milestone)
+**Date:** 2026-06-07 · **Owner:** ix (`ix-pipeline`) · **Plan:** `docs/plans/2026-06-07-chain-of-evidence-v1.md`
+
+Defines the on-disk provenance record IX emits per pipeline run, so a consumer can
+answer *"did this output come from these inputs, under this skill?"*. Additive
+extension of `ix-lock/v1` (`crates/ix-pipeline/src/lock.rs`).
+
+## Locations
+
+- `ix.lock` (workspace-relative, latest run; overwritten each run — back-compat).
+- `state/thinking-machine/provenance.jsonl` (append-only durable trail; one JSON
+  object per run, keyed by `run_id`; torn-line-tolerant per the `hits.jsonl` convention).
+
+## Schema
+
+```jsonc
+// LockFile (ix-lock/v2)
+{
+  "schema": "ix-lock/v2",
+  "generated": "<ISO-8601 UTC>",
+  "run_id": "<ulid|uuid>",          // NEW — unique per run
+  "spec_hash": "sha256:<hex>",      // NEW — sha256 of the canonicalized PipelineSpec
+  "stages": [ /* LockedStage */ ]
+}
+
+// LockedStage
+{
+  // v1 fields — UNCHANGED (locked field set; renames are breaking → v3):
+  "skill": "<dotted skill name>",
+  "args_hash": "fnv1a64:<hex>",       // over canonicalized TEMPLATE args (spec)
+  "deps": ["<stage_id>", ...],
+  "duration_ms": 0,
+  "cache_hit": false,
+  // v2 additions (optional for forward-compat readers):
+  "resolved_args_hash": "fnv1a64:<hex>", // canonicalized RESOLVED args (post from-ref)
+  "output_hash": "sha256:<hex>",         // canonical-JSON of the stage output Value
+  "inputs": [ /* InputBinding */ ],
+  "certainty": null                       // RESERVED — unpopulated in v1 (see plan §Deferred)
+}
+
+// InputBinding — one per consumed cross-stage edge
+{
+  "name": "<consumer input arg name>",
+  "from_stage": "<sourceNodeId | __input__:KEY>",
+  "from_key": "<output key within source output ('*' = whole output)>",
+  "upstream_output_hash": "sha256:<hex>"  // == output_hash of from_stage in the same run
+}
+```
+
+## Locked fields & hashing rules (one-way doors — signed off 2026-06-07)
+
+1. **`output_hash` / `spec_hash` / `upstream_output_hash` use sha256**, prefixed
+   `sha256:`. (Distinct from the FNV-1a64 cache/template hashes, which stay FNV for
+   back-compat.) Algorithm change for *new* records only via a versioned prefix.
+2. **Canonical-JSON for all hashes = `lock.rs::canonicalize` exactly** (key sort +
+   number/whitespace normalization). Frozen; any change orphans persisted hashes.
+3. **`ix-lock/v2` is additive.** New optional fields are non-breaking; renames /
+   removals / type changes require a v3 bump and cross-consumer coordination.
+
+## Invariants (the verifiable chain)
+
+- **Edge integrity:** for every `InputBinding`, `upstream_output_hash` equals the
+  `output_hash` recorded for `from_stage` in the same run. A `verify_chain()` over a
+  `LockFile` returns `Ok` iff this holds for all edges.
+- **Determinism:** a deterministic spec + identical seed inputs ⇒ identical
+  `output_hash` for every stage across runs.
+- **Localized change:** mutating one seed input changes the `resolved_args_hash` /
+  `output_hash` of fed stages and the `upstream_output_hash` of their consumers, and
+  nothing else.
+
+## Out of scope for v0.1
+
+Signing the trail (`ix-harness-signing` — designed as a later pure-add), certainty
+propagation (`certainty` reserved but null), provenance-gated execution
+(`verify_chain` records, does not block), and System-A lineage unification.

--- a/docs/plans/2026-06-07-chain-of-evidence-v1.md
+++ b/docs/plans/2026-06-07-chain-of-evidence-v1.md
@@ -1,0 +1,113 @@
+# Chain of Evidence v1 — minimal provenance for IX ML pipelines
+
+**Date:** 2026-06-07 · **Status:** approved, pre-implementation · **Scope:** ix-pipeline
+
+## Problem
+
+Whoever later asks *"did this pipeline output actually come from those inputs, run
+by that skill, under that constitution?"* — an operator debugging a run, an
+auditor verifying a governance claim, a future agent deciding whether to trust a
+derived artifact — cannot answer it today. PR #84 made producer→consumer **bindings**
+provably valid at *compile* time (output schemas), but at *runtime* nothing proves
+the binding was honored. Three distinct gaps (not conflated):
+
+- **(a)** no materialized per-artifact provenance record — `PipelineResult`/`NodeResult`
+  (`executor.rs:31-50`) is the only lineage object and is dropped after the run;
+  `ix.lock` hashes the *static template* args (`lock.rs:52`), so two runs with
+  different upstream-fed values produce identical lock entries.
+- **(b)** no content-hashing of intermediate data — outputs are `Value`, echoed to
+  stdout, never hashed.
+- **(c)** no certainty propagation through data-flow.
+
+## Decision
+
+**Build (a)+(b) now; defer (c).** (a)+(b) are one cheap, high-value unit, almost
+entirely reuse. (c) has no reusable substrate (see "Deferred" below) and would ship
+uncalibrated magic numbers — green-but-dead.
+
+## Design (v1)
+
+**Integration point — reuse, don't add an executor hook.** The single attach point
+is the stage compute closure `lower.rs:102-130` — the only place holding `stage_id`,
+`skill`, the **resolved** args (post `resolve_from_refs`), the upstream `inputs` map
+(lineage), and the **output**. The governance gate already fires here, proving the
+seam carries side-effects. Inject `Arc<dyn ProvenanceSink>` per node exactly as
+`SharedGate` is injected (`gate.rs:41-47`), wired in `run()` (`pipeline.rs:480/496`)
+alongside `ConstitutionGate`. Do **not** add a per-stage callback to `execute()`.
+
+**Record — extend `LockedStage` → `ix-lock/v2` (additive):**
+
+```
+LockFile (v2)        { schema: "ix-lock/v2", generated, run_id, spec_hash, stages: [LockedStage] }
+LockedStage (v2)     { skill, args_hash, deps, duration_ms, cache_hit,   // v1, unchanged
+                       resolved_args_hash, output_hash, inputs: [InputBinding] }   // NEW
+InputBinding         { name, from_stage, from_key, upstream_output_hash }
+```
+
+- `resolved_args_hash` = `fnv1a64:<hex>` over canonicalized **resolved** args (reuse
+  `lock.rs:canonicalize`; only the input differs vs v1's template hash).
+- `output_hash` = `sha256:<hex>` over canonical-JSON of the stage output (one-way door §below).
+- `inputs[]` are free from `gather_inputs` + `input_map` `(sourceNode, outputKey)`;
+  `upstream_output_hash` links each consumed edge to the producer's `output_hash` —
+  the verifiable "this output came from these inputs" chain.
+
+**Storage.** Keep writing `ix.lock` (latest run) where it's written today; **also**
+append the v2 record as one line to `state/thinking-machine/provenance.jsonl`
+(append-only, torn-line-tolerant, best-effort-never-block — same convention as
+`hits.jsonl`). `run_id` keys the durable trail.
+
+**Certainty field.** Reserve an **optional** `certainty` slot, left unpopulated in v1.
+
+## Reuse map
+
+- `lower.rs` compute closure → the sink attaches here (full tuple).
+- `SharedGate` injection pattern → copy for `ProvenanceSink`.
+- `LockFile`/`LockedStage` + `canonicalize`/`hash_json` → extend in place.
+- `gather_inputs`/`input_map` → lineage edges for free.
+- `hits.jsonl` JSONL conventions → `provenance.jsonl`.
+- Constitution sha256-pin pattern → template for pinning the v2 schema (CI gate).
+- Hexavalent T/P/U/D/F/C → the scale the deferred certainty field will use.
+
+## One-way doors (signed off 2026-06-07)
+
+| Door | Decision | Reversibility | Revisit trigger |
+|---|---|---|---|
+| Output/integrity hash algo | **sha256** (`sha256:<hex>`) — aligns with constitution-pin + `ix-harness-signing`, NOT the FNV cache key | One-way for persisted history; two-way forward only via a versioned `algo:` prefix | A cryptographic weakness in sha256, or a signing requirement forcing a different primitive |
+| Canonical-JSON for hashing | Reuse `lock.rs:canonicalize` **exactly** (key sort, number/whitespace normalization) — frozen | One-way once hashes persist | Never, except a v3 break |
+| `ix-lock/v2` schema | Additive bump; new fields optional | Two-way while additive; one-way for renames/removals/type changes (→ v3) | A field rename/removal need |
+| `run_id` format (ulid vs uuid) | pick one (low stakes) | Two-way-ish (mixed logs tolerable) | — |
+| `provenance.jsonl` location | `state/thinking-machine/` | Two-way (path move + migration cheap) | — |
+
+A `docs/contracts/2026-06-07-provenance-record.contract.md` holds the v2 schema
+(draft v0.1; freeze only at its named Phase 4).
+
+## Verifiable success criteria
+
+1. **Cardinality** — a multi-stage run emits a v2 file whose `stages.len()` equals the
+   executed-stage count, each with non-empty `output_hash`/`resolved_args_hash`.
+2. **Determinism** — re-running a deterministic spec yields identical `output_hash`es.
+3. **Input-change detection** — mutating one seed input dirties *exactly* its
+   downstream cone's hashes; unaffected stages stay identical.
+4. **Edge integrity** — `verify_chain(&LockFile)` confirms every `InputBinding.upstream_output_hash`
+   equals the `output_hash` recorded for `from_stage`; `Ok` on a clean run.
+5. **Append-only history** — N runs → ≥N parseable lines, distinct `run_id`s, torn-line tolerant.
+6. **Back-compat** — v1-field consumers still find `skill/args_hash/deps/duration_ms/cache_hit`.
+
+## Deferred / out of scope for v1
+
+- **Certainty propagation (c).** IX has an `Opinion{b,d,u}` carrier and *same-claim*
+  fusion (`ix-fuzzy merge_all`) but **no `discount`/derivation operator** to propagate
+  certainty *through* a computation, and the `from_truth` 0.6 / `projected` 0.5 are
+  unvalidated magic numbers. Building it now = inventing uncalibrated semantics.
+  **Revisit when** there is (1) a certainty-gated decision demanding it and (2) an
+  `empirical` vs `deterministic` tag to discount against. Then: deterministic skill →
+  pass parent opinion through; empirical/llm → SL-discount toward `u`; multi-parent →
+  fuse via existing `merge_all`.
+- **Signing / Merkle-chaining the trail** — `ix-harness-signing` exists but unwired;
+  v1 records are hashed, not signed. Designed so signing is a later pure-add.
+- **Gating execution on provenance** — v1 only *records*; `verify_chain` is provided
+  but not wired to fail a run.
+- **System-A (`ix_pipeline_run {steps}`, ungated) ↔ System-B unification** — v1
+  instruments System B (the real thinking machine) only.
+- **Data-quality evidence**, **large/binary output streaming**, and fixing the
+  `PipelineResult::final_outputs()` dead stub — unrelated, surgical-scope.

--- a/state/assumptions/annotations.snapshot.json
+++ b/state/assumptions/annotations.snapshot.json
@@ -194,6 +194,18 @@
       "test_binding": null
     },
     {
+      "key": "sha256:b2b19de20b47c395e9c4b636baace37ff91cdf4a66057044a0114444118d171b",
+      "path": "crates/ix-pipeline/src/lock.rs",
+      "line": 106,
+      "kind": "assumption",
+      "claim": "from_run's `initial_inputs` is the SAME seed map passed to execute() this run; else a seed-backed resolved_args_hash silently degrades to the template hash",
+      "verdict": "U",
+      "certainty": "Uncertain",
+      "evidence": "ix-skill pipeline.rs run() passes one shared empty map to both — unenforced precondition",
+      "anchor_hash": "sha256:f95f70c18f0ffcb470281a493e4ce17a98832beece682ee4d6761da266f8b527",
+      "test_binding": null
+    },
+    {
       "key": "sha256:50cbdd5adf3ce6007ecff9300d4cf519473bb56be4c443688af4e5de43082c7b",
       "path": "crates/ix-search/src/astar.rs",
       "line": 75,
@@ -328,7 +340,7 @@
     {
       "key": "sha256:6511bb88a56c682ef0cf5414b979950553c36152bf89adbf74a7d2413fce0a74",
       "path": "crates/ix-skill/src/verbs/compile.rs",
-      "line": 1471,
+      "line": 1657,
       "kind": "invariant",
       "claim": "fixed-ref z-norm (E) is affine-identical to raw (A) on AUC/TNR/near-miss — a monotone affine map is rank- and ID-quantile-invariant",
       "verdict": "T",
@@ -340,7 +352,7 @@
     {
       "key": "sha256:cc19c55cbfe8379f7037d60faad7f46b7c4b67837dca48d7ad7b3cde620cf07e",
       "path": "crates/ix-skill/src/verbs/compile.rs",
-      "line": 1472,
+      "line": 1658,
       "kind": "assumption",
       "claim": "on the 184-probe corpus + bge-base-en, raw mean-top-3 cosine dominates every per-query/margin/kNN calibration on AUC, so the gate keeps the raw threshold — CONDITIONAL on the corpus + embedder, re-run on change",
       "verdict": "T",


### PR DESCRIPTION
## What & why
Makes **"did this output come from these inputs, under this skill?"** answerable and testable. Follows the output-schema work (#84), which made producer→consumer *bindings* valid at compile time; this records that the binding was *honored* at runtime.

The key insight (from the scoping survey): the executor already holds every stage's output in `PipelineResult`, and the resolved args can be reconstructed by replaying `{from}` resolution against those outputs — so the **entire record is derived in `LockFile::from_run(spec, result, initial_inputs)` with zero executor/closure surgery** (the lightest correct attach point).

## `ix-lock/v1` → `v2` (additive — v1 still loads, v2 fields default)
- **`LockedStage`** gains `resolved_args_hash` (fnv1a64, post-`{from}`), `output_hash` (**sha256** of canonical-JSON output), `inputs[]` (the cross-stage edges that actually flowed, each linked to the producer's `output_hash`), and a reserved `certainty` slot.
- **`LockFile`** gains `run_id` (content+time) and `spec_hash` (sha256).
- **`verify_chain()`**: every `InputBinding.upstream_output_hash` must equal the `from_stage`'s `output_hash` — records integrity, does **not** gate execution in v1.
- Each run appends one record to `state/thinking-machine/provenance.jsonl` (append-only, best-effort-never-block, gitignored — same discipline as `hits.jsonl`).

## Verified end-to-end (pca→kmeans via `ix pipeline run`)
- **Edge integrity:** `cluster.inputs[0].upstream_output_hash == reduce.output_hash`.
- **Resolved capture:** `cluster.resolved_args_hash` differs from its template `args_hash` (it hashed the *resolved* input, not the template).
- **Determinism:** re-runs yield identical `output_hash`es.
- **Change detection:** mutating one input changes exactly its downstream cone.
- 7 lock tests (4 new v2: hashes+edge, broken-edge detection, deterministic hash, v1-still-loads). Full `ix-pipeline`+`ix-skill` suites green; clippy + fmt clean; workspace builds.

## Design + one-way doors (signed off)
- `docs/plans/2026-06-07-chain-of-evidence-v1.md` — full design, reversibility, revisit triggers.
- `docs/contracts/2026-06-07-provenance-record.contract.md` — record schema (draft v0.1).
- One-way doors: **sha256** integrity hash, **frozen `canonicalize`**, **`ix-lock/v2` additive**.
- **Deferred** (no reusable substrate): certainty propagation, signing/Merkle-chaining, provenance-gating execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)