### PR TITLE
fix(ci): make the assumption-drift gate actually parse (dead since PR #76)

### DIFF
--- a/.github/workflows/assumption-drift.yml
+++ b/.github/workflows/assumption-drift.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Check @ai: annotations against the committed baseline
+      - name: "Check @ai: annotations against the committed baseline"
         run: |
           cargo run -p ix-assumption-graph --bin ix-assumption-graph-drift -- \
             --check state/assumptions/annotations.snapshot.json


### PR DESCRIPTION
## Problem

The **Assumption Drift** gate — the CI lint that makes the `@ai:` annotation discipline real (CLAUDE.md, 2026-06-01: *\"Drift is the lint that makes it last\"*) — has **failed at GitHub's workflow-file validation on every push since it was added in #76**: `0s` duration, **no jobs instantiated**, *\"this run likely failed because of a workflow file issue\"*, no logs. It has therefore **never once run the drift binary**. A governance gate that is dead-red, not green — the same disease as green-but-dead, just the other color.

It is not a *required* PR check, so it slipped by unnoticed across ~6 days of merges.

## Root cause

The step name was unquoted:

```yaml
- name: Check @ai: annotations against the committed baseline
```

The `: ` inside `@ai:` is a YAML mapping-value indicator, so the line is invalid YAML — `mapping values are not allowed here`, line 44 col 24. PyYAML reproduces it exactly; GitHub's stricter parser rejects the **whole file** before scheduling any job.

> The gate that enforces the `@ai:` annotation discipline was broken by the literal string `@ai:` in its own step name.

## Fix

Quote the step name (one line). The drift binary itself is healthy — run locally against the committed baseline:

```
assumption-graph drift check (30 claims)
  unchanged 30  moved 0  added 0  removed 0  verdict-revised 0
  ✓ no claim needs re-confirmation   (exit 0)
```

CI-only change; no Rust touched. **Success criterion: this PR's own run instantiates the `drift-check` job and reports green** (vs. the historical 0s/no-job failure) — i.e. you can see the gate actually execute in the checks below.

## Follow-up (not in this PR)

A parse-failed workflow reports as a non-required, 0s, logless failure that is easy to miss. Worth a tiny meta-lint (assert every `.github/workflows/*.yml` parses) so the next silent break is caught — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)