### PR TITLE
feat(ix-thinking-machine): standalone `dbscan` skill (catalog-breadth #2) + canonical-label fix

### DIFF
--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -353,6 +353,59 @@ pub fn pca(params: Value) -> Result<Value, String> {
     }))
 }
 
+// ── ix_dbscan ────────────────────────────────────────────────
+
+// @ai:invariant DBSCAN labels noise as 0 and numbers clusters from 1, so n_noise counts label==0 and n_clusters counts distinct labels>0 [T:test conf:0.9 src:skills::batch1::tests::dbscan_skill_executes_and_separates_clusters_from_noise]
+pub fn dbscan(params: Value) -> Result<Value, String> {
+    use ix_unsupervised::traits::Clusterer;
+    use std::collections::BTreeSet;
+
+    let data_rows = parse_f64_matrix(&params, "data")?;
+    if data_rows.is_empty() {
+        return Err("data must have ≥ 1 row".into());
+    }
+    let eps = params.get("eps").and_then(|v| v.as_f64()).ok_or_else(|| {
+        "field 'eps' (the neighborhood radius) is required and must be a number".to_string()
+    })?;
+    if eps <= 0.0 {
+        return Err(format!("eps must be > 0, got {eps}"));
+    }
+    // min_points defaults to 4 (classic DBSCAN heuristic) only when absent/null;
+    // a present-but-malformed value is rejected, not silently coerced (cf. the
+    // kmeans max_iter fix, Codex #84 P2).
+    let min_points = match params.get("min_points") {
+        None | Some(Value::Null) => 4usize,
+        Some(v) => v
+            .as_u64()
+            .map(|n| n as usize)
+            .ok_or_else(|| "field 'min_points' must be a non-negative integer".to_string())?,
+    };
+    // Reject min_points < 1: with min_points=0 every point clears the core
+    // threshold (a point is its own neighbour), so nothing is ever noise and the
+    // skill's advertised "0 = noise" contract becomes unreachable.
+    if min_points < 1 {
+        return Err("min_points must be >= 1".to_string());
+    }
+
+    let data = vecs_to_array2(&data_rows)?;
+
+    let mut db = ix_unsupervised::dbscan::DBSCAN::new(eps, min_points);
+    let labels = db.fit_predict(&data);
+    let labels_vec: Vec<u64> = labels.iter().map(|&l| l as u64).collect();
+
+    let n_noise = labels_vec.iter().filter(|&&l| l == 0).count();
+    let distinct: BTreeSet<u64> = labels_vec.iter().copied().filter(|&l| l > 0).collect();
+    let n_clusters = distinct.len();
+
+    Ok(json!({
+        "labels": labels_vec,
+        "n_clusters": n_clusters,
+        "n_noise": n_noise,
+        "eps": eps,
+        "min_points": min_points,
+    }))
+}
+
 // ── ix_tsne ────────────────────────────────────────────────
 
 pub fn tsne(params: Value) -> Result<Value, String> {

--- a/crates/ix-agent/src/skills/batch1.rs
+++ b/crates/ix-agent/src/skills/batch1.rs
@@ -206,6 +206,64 @@ pub fn pca(params: Value) -> Result<Value, String> {
     handlers::pca(params)
 }
 
+// --- ix_dbscan -------------------------------------------------------------
+
+fn dbscan_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "data": {
+                "type": "array",
+                "items": { "type": "array", "items": { "type": "number" } },
+                "description": "Matrix where each row is a data point"
+            },
+            "eps": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Neighborhood radius: two points are neighbors when within this Euclidean distance"
+            },
+            "min_points": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 4,
+                "description": "Minimum neighbors (including the point itself) for a core point; defaults to 4 when omitted"
+            }
+        },
+        "required": ["data", "eps"]
+    })
+}
+
+fn dbscan_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "labels": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "description": "Cluster id per input row; 0 = noise, clusters numbered from 1"
+            },
+            "n_clusters": { "type": "integer", "description": "Number of clusters found (noise excluded)" },
+            "n_noise": { "type": "integer", "description": "Number of points labeled noise (label 0)" },
+            "eps": { "type": "number", "description": "Neighborhood radius used" },
+            "min_points": { "type": "integer", "description": "Core-point threshold used" }
+        }
+    })
+}
+
+/// Cluster points by density with DBSCAN. Unlike k-means there is no preset
+/// cluster count: dense regions become clusters (numbered from 1) and points in
+/// sparse regions are labeled noise (0).
+#[ix_skill(
+    domain = "unsupervised",
+    name = "dbscan",
+    governance = "empirical",
+    schema_fn = "crate::skills::batch1::dbscan_schema",
+    output_schema_fn = "crate::skills::batch1::dbscan_output_schema"
+)]
+pub fn dbscan(params: Value) -> Result<Value, String> {
+    handlers::dbscan(params)
+}
+
 // --- ix_linear_regression --------------------------------------------------
 
 fn linear_regression_schema() -> Value {
@@ -329,5 +387,95 @@ mod tests {
     fn pca_rejects_too_many_components() {
         let err = pca(json!({ "data": [[1.0, 2.0], [3.0, 4.0]], "n_components": 5 })).unwrap_err();
         assert!(err.contains("exceeds the feature count"), "got: {err}");
+    }
+
+    // Executes-test for the new `dbscan` skill: two well-separated dense blobs
+    // plus a far outlier → exactly two clusters and one noise point. The catalog
+    // entry must EXECUTE, not merely register (no green-but-dead).
+    #[test]
+    fn dbscan_skill_executes_and_separates_clusters_from_noise() {
+        let out = dbscan(json!({
+            "data": [
+                [0.0, 0.0], [0.1, 0.1], [0.2, 0.0], [0.0, 0.2],
+                [5.0, 5.0], [5.1, 5.1], [5.2, 5.0], [5.0, 5.2],
+                [50.0, 50.0]
+            ],
+            "eps": 0.5,
+            "min_points": 2
+        }))
+        .expect("dbscan skill runs");
+
+        assert_eq!(out["n_clusters"].as_u64().unwrap(), 2, "two dense blobs");
+        assert_eq!(
+            out["n_noise"].as_u64().unwrap(),
+            1,
+            "the far point is noise"
+        );
+        let labels = out["labels"].as_array().unwrap();
+        assert_eq!(labels.len(), 9, "one label per input row");
+        assert_eq!(
+            labels[8].as_u64().unwrap(),
+            0,
+            "the outlier is labeled noise"
+        );
+        assert_eq!(labels[0], labels[1], "the first blob shares a cluster");
+        assert_ne!(labels[0], labels[4], "the two blobs are different clusters");
+    }
+
+    // The skill must be registered AND pipeline-callable (arity-1), so the
+    // NL→pipeline proposer can actually see it.
+    #[test]
+    fn dbscan_skill_is_registered_and_pipeline_callable() {
+        let desc = ix_registry::all()
+            .find(|s| s.name == "dbscan")
+            .expect("dbscan skill registered in the capability registry");
+        assert_eq!(
+            desc.inputs.len(),
+            1,
+            "must be arity-1 to be pipeline-callable"
+        );
+    }
+
+    // Honest boundary: `eps` is required — there is no data-blind default radius,
+    // so an omitted `eps` returns a clear error instead of a guessed clustering.
+    #[test]
+    fn dbscan_requires_eps() {
+        let err = dbscan(json!({ "data": [[0.0, 0.0], [1.0, 1.0]] })).unwrap_err();
+        assert!(err.contains("eps"), "got: {err}");
+    }
+
+    // The canonical-label fix must propagate through the SKILL, not just the
+    // crate: a point density-unreachable from any core (within eps of a border
+    // point only) is reported as noise, and n_noise counts it. With the default
+    // Clusterer fit_predict (fit+predict) this point would be absorbed and
+    // n_noise would read 0.
+    #[test]
+    fn dbscan_skill_labels_border_adjacent_point_as_noise() {
+        let out = dbscan(json!({
+            "data": [
+                [0.0, 0.0], [0.2, 0.0], [0.4, 0.0], [0.2, 0.2],
+                [1.3, 0.0],
+                [2.2, 0.0]
+            ],
+            "eps": 1.0,
+            "min_points": 4
+        }))
+        .expect("dbscan skill runs");
+        let labels = out["labels"].as_array().unwrap();
+        assert_eq!(
+            labels[5].as_u64().unwrap(),
+            0,
+            "unreachable point must be noise"
+        );
+        assert_eq!(out["n_noise"].as_u64().unwrap(), 1);
+        assert_eq!(out["n_clusters"].as_u64().unwrap(), 1);
+    }
+
+    // Honest boundary: min_points < 1 is rejected — under it nothing can be noise,
+    // contradicting the advertised contract.
+    #[test]
+    fn dbscan_rejects_min_points_below_one() {
+        let err = dbscan(json!({ "data": [[0.0, 0.0]], "eps": 1.0, "min_points": 0 })).unwrap_err();
+        assert!(err.contains("min_points"), "got: {err}");
     }
 }

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -64,6 +64,7 @@ const EXPECTED: &[&str] = &[
     "ix_grothendieck_nearby",
     "ix_grothendieck_path",
     "ix_hyperloglog",
+    "ix_dbscan",
     "ix_kmeans",
     "ix_linear_regression",
     "ix_pca",
@@ -154,9 +155,11 @@ fn parity_expected_count() {
     //   aggregate, agent-native parity with `ix pipeline hits`) = 77.
     // + ix_pca (2026-06-07, standalone PCA — first dogfood catalog-breadth fix;
     //   auto-exposed via the registry bridge) = 78.
+    // + ix_dbscan (2026-06-07, density clustering — dogfood catalog-breadth fix;
+    //   auto-exposed via the registry bridge) = 79.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 78);
+    assert_eq!(EXPECTED.len(), 79);
 }
 
 #[test]
@@ -286,10 +289,11 @@ fn parity_all_43_registry_backed() {
     // session.flywheel_export) + prime_radiant (2) migration, all 47
     // algorithm tools are registry-backed. ix_demo is manual.
     // + pca (2026-06-07, dogfood catalog-breadth fix) = 53.
+    // + dbscan (2026-06-07, dogfood catalog-breadth fix) = 54.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 53,
-        "expected 53 registry skills, got {registry_count}"
+        registry_count, 54,
+        "expected 54 registry skills, got {registry_count}"
     );
 }
 

--- a/crates/ix-approval/src/classify.rs
+++ b/crates/ix-approval/src/classify.rs
@@ -76,6 +76,7 @@ pub fn classify_action_kind(tool_name: &str) -> ActionKind {
         "ix_linear_regression",
         "ix_kmeans",
         "ix_pca",
+        "ix_dbscan",
         "ix_optimize",
         "ix_search",
         "ix_markov",
@@ -161,6 +162,7 @@ mod tests {
             "ix_code_analyze",
             "ix_fft",
             "ix_pca",
+            "ix_dbscan",
         ] {
             assert_eq!(
                 classify_action_kind(tool),

--- a/crates/ix-skill/tests/cli.rs
+++ b/crates/ix-skill/tests/cli.rs
@@ -25,12 +25,12 @@ fn list_skills_returns_all_entries() {
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     let count = value["count"].as_u64().expect("count is number");
-    // 53 = batch1 (6 + pca, 2026-06-07 dogfood catalog-breadth fix) + batch2 (28)
-    // + batch3 (10 + context.walk + session.flywheel_export + fuzzy.eval)
-    // + prime_radiant (2) + assumption_graph (4: assumption.query + .belief_at
-    // + .drift + .claims).
+    // 54 = batch1 (6 + pca + dbscan, 2026-06-07 dogfood catalog-breadth fixes)
+    // + batch2 (28) + batch3 (10 + context.walk + session.flywheel_export
+    // + fuzzy.eval) + prime_radiant (2) + assumption_graph (4: assumption.query
+    // + .belief_at + .drift + .claims).
     // If this drifts, update the assertion alongside the batch changes.
-    assert_eq!(count, 53, "expected 53 registry skills, got {count}");
+    assert_eq!(count, 54, "expected 54 registry skills, got {count}");
 }
 
 #[test]

--- a/crates/ix-unsupervised/src/dbscan.rs
+++ b/crates/ix-unsupervised/src/dbscan.rs
@@ -138,6 +138,20 @@ impl Clusterer for DBSCAN {
 
         result
     }
+
+    /// Override the `Clusterer` default (`fit(x); predict(x)`). For DBSCAN that
+    /// default is subtly wrong on the training data: `predict` re-assigns each
+    /// point to the nearest non-noise neighbour within `eps` — border points
+    /// included — so a density-unreachable point adjacent to a border point gets
+    /// absorbed into the cluster and noise is undercounted. The canonical labels
+    /// are the ones `fit` already computed (proper core/border/noise), so return
+    /// those directly.
+    fn fit_predict(&mut self, x: &Array2<f64>) -> Array1<usize> {
+        self.fit(x);
+        self.labels
+            .clone()
+            .expect("fit always sets labels before returning")
+    }
 }
 
 #[cfg(test)]
@@ -263,5 +277,33 @@ mod tests {
                 "All dense points should share a cluster"
             );
         }
+    }
+
+    // Regression for the fit_predict override: on the training data, fit_predict
+    // must return fit()'s CANONICAL labels, not predict()'s re-derivation.
+    // predict() assigns any point to the nearest non-noise neighbour within eps —
+    // which includes border points — so a density-unreachable point hanging off a
+    // border point would be silently absorbed (and noise undercounted). Here the
+    // far point (2.2,0) is within eps of the border (1.3,0) only, so canonical
+    // DBSCAN labels it noise; the default fit()+predict() would absorb it.
+    #[test]
+    fn fit_predict_returns_canonical_fit_labels_not_predict() {
+        let x = array![
+            [0.0, 0.0],
+            [0.2, 0.0],
+            [0.4, 0.0],
+            [0.2, 0.2], // dense core blob (each is a core point at min_points=4)
+            [1.3, 0.0], // border: within eps of a core, but < 4 neighbours
+            [2.2, 0.0]  // within eps of the border ONLY → canonical noise
+        ];
+        let mut db = DBSCAN::new(1.0, 4);
+        let labels = db.fit_predict(&x).to_vec();
+        assert_eq!(
+            labels[5], 0,
+            "border-adjacent unreachable point must stay noise"
+        );
+        assert!(labels[0] > 0 && labels[..4].iter().all(|&l| l == labels[0]));
+        // fit_predict must agree with fit()'s stored labels exactly.
+        assert_eq!(labels, db.labels.clone().unwrap().to_vec());
     }
 }

--- a/state/assumptions/annotations.snapshot.json
+++ b/state/assumptions/annotations.snapshot.json
@@ -2,6 +2,18 @@
   "schema": 1,
   "claims": [
     {
+      "key": "sha256:b12bceb2ebaca8148cafd9d9bfc685e19b5bd679822b7ec7b87cffa35c6e010d",
+      "path": "crates/ix-agent/src/handlers.rs",
+      "line": 358,
+      "kind": "invariant",
+      "claim": "DBSCAN labels noise as 0 and numbers clusters from 1, so n_noise counts label==0 and n_clusters counts distinct labels>0",
+      "verdict": "T",
+      "certainty": "Test",
+      "evidence": "skills::batch1::tests::dbscan_skill_executes_and_separates_clusters_from_noise",
+      "anchor_hash": "sha256:f3ebabf7e34968423cad116341e7d96fd067f0e339759795abd78bbc39b0cdf7",
+      "test_binding": "dbscan_skill_executes_and_separates_clusters_from_noise"
+    },
+    {
       "key": "sha256:dd5f98b683ce720d99120636957b1c8fece736215d4b0ce424a6380c2e1b79e2",
       "path": "crates/ix-assumption-graph/src/graph.rs",
       "line": 171,


### PR DESCRIPTION
## What

Adds a standalone **`dbscan`** density-clustering skill to the thinking-machine catalog, following the proven `pca` pattern (#84). DBSCAN is one of the top-three unmet requests in the dogfood gap ledger (with eigen + standalone-PCA), so it directly lifts the translation yield ceiling — catalog breadth is the proven bottleneck.

Auto-exposed as MCP tool `ix_dbscan` via the registry bridge; added to `ix-approval` `READ_TOOLS` (else Tier-3 blocked — the #83 P1 lesson).

## Correctness fix (found by an adversarial review of this very diff)

A 3-lens adversarial review caught a **P1 the unit tests and clippy could not see**: the handler used `Clusterer::fit_predict`, whose default is `fit(x); predict(x)`. For DBSCAN that default is subtly wrong on the training data — `predict()` re-assigns each point to its nearest non-noise neighbour within `eps` (**border points included**), so a density-unreachable point hanging off a border point gets **absorbed into the cluster** and `n_noise` is **undercounted**.

Verified empirically before fixing (the reviewer's own numeric repro was miscalculated, so I reconstructed a correct one):

```
layout: dense core blob + border (1.3,0) + far point (2.2,0) within eps of the border only
fit():        [1, 1, 1, 1, 1, 0]   ← canonical: far point is noise
fit_predict:  [1, 1, 1, 1, 1, 1]   ← default absorbs it
```

**Fix:** override `fit_predict` in `impl Clusterer for DBSCAN` to return `fit()`'s canonical labels. This is a method-body change inside the trait impl, so it adds **no `pub` line** — the stable-surface `api_hash` for `ix-unsupervised` is unchanged (`9d4b9a17d253eb66` before and after; verified locally). Scoped to DBSCAN only — KMeans/GMM keep the trait default. DBSCAN is used nowhere else in the workspace, so zero regression surface.

Two more findings, both fixed:
- **P2** — the `@ai:invariant` `src:` was malformed free-text; rewritten as a `::`-pathed token so the drift extractor actually binds it (snapshot now resolves `test_binding`, non-null — a genuinely live binding, not the weaker null-bound siblings).
- **P3** — `min_points=0` made "noise" unreachable; handler now rejects `min_points < 1` and schema sets `minimum: 1`.

A second adversarial pass (3 skeptics trying to *refute* the fix) returned **`merge_ready: true`** — `p1_resolved` consensus, no regression, zero blockers; its lone P3 confirms the override's `.expect()` is provably unreachable.

## Tests (executes, not just registers)

- `ix-unsupervised`: canonical-label regression (`fit_predict` must equal `fit()`'s labels, far point stays noise).
- skill: executes-and-separates, registered+arity-1, `eps` required, `min_points >= 1`, and a **border-adjacent-noise** test proving the fix propagates through the handler (`n_noise == 1`).
- Counts bumped everywhere: registry 53→54, parity EXPECTED 78→79, cli 53→54.
- Assumption snapshot re-captured to 31 claims; `drift --check` clean. This is the first PR whose drift gate actually **runs** (it was dead until #86).

🤖 Generated with [Claude Code](https://claude.com/claude-code)