### PR TITLE
feat(ix-thinking-machine): standalone `eigen` skill (catalog-breadth #3)

### DIFF
--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -406,6 +406,63 @@ pub fn dbscan(params: Value) -> Result<Value, String> {
     }))
 }
 
+// ── ix_eigen ────────────────────────────────────────────────
+
+// @ai:invariant symmetric_eigen returns eigenvalues descending and column-major eigenvectors; the handler transposes so eigenvectors[k] is the unit eigenvector for eigenvalues[k] [T:test conf:0.9 src:skills::batch1::tests::eigen_skill_executes_on_symmetric_matrix]
+pub fn eigen(params: Value) -> Result<Value, String> {
+    let rows = parse_f64_matrix(&params, "matrix")?;
+    let n = rows.len();
+    if n == 0 {
+        return Err("matrix must have ≥ 1 row".into());
+    }
+    if rows.iter().any(|r| r.len() != n) {
+        return Err(format!(
+            "matrix must be square; got {n} rows but a row has a different column count"
+        ));
+    }
+    // Be self-sufficient about non-finite entries rather than relying on the JSON
+    // parse layer (serde rejects NaN/inf today, but the symmetry check below is
+    // NOT NaN-safe — (NaN-NaN).abs() > tol is false — so guard explicitly).
+    if rows.iter().flatten().any(|x| !x.is_finite()) {
+        return Err("matrix entries must be finite (no NaN or infinity)".to_string());
+    }
+    // symmetric_eigen is the cyclic-Jacobi solver: it reads the matrix AS
+    // symmetric and would silently return wrong results for an asymmetric input.
+    // Reject asymmetry rather than mislead (honest boundary). The tolerance is
+    // RELATIVE to entry magnitude so a genuinely-symmetric large-scale matrix
+    // isn't falsely rejected on last-ULP rounding.
+    const SYM_EPS: f64 = 1e-9;
+    for (i, row_i) in rows.iter().enumerate() {
+        for (j, &aij) in row_i.iter().enumerate().skip(i + 1) {
+            let aji = rows[j][i];
+            let asym = (aij - aji).abs();
+            let tol = SYM_EPS * aij.abs().max(aji.abs()).max(1.0);
+            if asym > tol {
+                return Err(format!(
+                    "matrix must be symmetric (|A[{i}][{j}] - A[{j}][{i}]| = {asym} > {tol}); this is the symmetric Jacobi solver"
+                ));
+            }
+        }
+    }
+
+    let a = vecs_to_array2(&rows)?;
+    let (values, vectors) = ix_math::eigen::symmetric_eigen(&a)
+        .map_err(|e| format!("eigendecomposition failed: {e}"))?;
+
+    let eigenvalues: Vec<f64> = values.to_vec();
+    // Transpose column-major (vectors.column(k) is the k-th eigenvector) into a
+    // row-major list so eigenvectors[k] is the unit eigenvector for eigenvalues[k].
+    let eigenvectors: Vec<Vec<f64>> = (0..n)
+        .map(|k| (0..n).map(|i| vectors[[i, k]]).collect())
+        .collect();
+
+    Ok(json!({
+        "eigenvalues": eigenvalues,
+        "eigenvectors": eigenvectors,
+        "n": n,
+    }))
+}
+
 // ── ix_tsne ────────────────────────────────────────────────
 
 pub fn tsne(params: Value) -> Result<Value, String> {

--- a/crates/ix-agent/src/skills/batch1.rs
+++ b/crates/ix-agent/src/skills/batch1.rs
@@ -264,6 +264,54 @@ pub fn dbscan(params: Value) -> Result<Value, String> {
     handlers::dbscan(params)
 }
 
+// --- ix_eigen --------------------------------------------------------------
+
+fn eigen_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "matrix": {
+                "type": "array",
+                "items": { "type": "array", "items": { "type": "number" } },
+                "description": "A real SYMMETRIC square matrix (row-major)"
+            }
+        },
+        "required": ["matrix"]
+    })
+}
+
+fn eigen_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "eigenvalues": {
+                "type": "array",
+                "items": { "type": "number" },
+                "description": "Eigenvalues in descending order"
+            },
+            "eigenvectors": {
+                "type": "array",
+                "items": { "type": "array", "items": { "type": "number" } },
+                "description": "Unit eigenvectors; eigenvectors[k] corresponds to eigenvalues[k]"
+            },
+            "n": { "type": "integer", "description": "Matrix dimension" }
+        }
+    })
+}
+
+/// Eigendecomposition of a real symmetric matrix via cyclic Jacobi rotations:
+/// returns eigenvalues in descending order and the matching unit eigenvectors.
+#[ix_skill(
+    domain = "math",
+    name = "eigen",
+    governance = "deterministic",
+    schema_fn = "crate::skills::batch1::eigen_schema",
+    output_schema_fn = "crate::skills::batch1::eigen_output_schema"
+)]
+pub fn eigen(params: Value) -> Result<Value, String> {
+    handlers::eigen(params)
+}
+
 // --- ix_linear_regression --------------------------------------------------
 
 fn linear_regression_schema() -> Value {
@@ -477,5 +525,87 @@ mod tests {
     fn dbscan_rejects_min_points_below_one() {
         let err = dbscan(json!({ "data": [[0.0, 0.0]], "eps": 1.0, "min_points": 0 })).unwrap_err();
         assert!(err.contains("min_points"), "got: {err}");
+    }
+
+    // Executes-test for `eigen`. Uses a 3x3 with DISTINCT eigenvalues, whose
+    // eigenvector matrix is NOT component-symmetric — so this test discriminates
+    // a wrong row/column transpose (a 2x2 like [[2,1],[1,2]] has V == V^T, so a
+    // missing transpose would pass identically — the over-claim a review caught).
+    // Asserts A·v_k = λ_k·v_k for EVERY k (binds both the per-index alignment and
+    // the transpose), plus descending order and unit norm.
+    #[test]
+    fn eigen_skill_executes_on_symmetric_matrix() {
+        let m = [[4.0, 1.0, 2.0], [1.0, 3.0, 0.5], [2.0, 0.5, 5.0]];
+        let out = eigen(json!({ "matrix": m })).expect("eigen runs");
+
+        let vals: Vec<f64> = out["eigenvalues"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_f64().unwrap())
+            .collect();
+        assert_eq!(vals.len(), 3);
+        assert!(
+            vals[0] >= vals[1] && vals[1] >= vals[2],
+            "eigenvalues must be descending: {vals:?}"
+        );
+
+        let vecs: Vec<Vec<f64>> = out["eigenvectors"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| {
+                r.as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|v| v.as_f64().unwrap())
+                    .collect()
+            })
+            .collect();
+        assert_eq!(vecs.len(), 3, "one eigenvector per dimension");
+
+        for (k, vk) in vecs.iter().enumerate() {
+            let norm: f64 = vk.iter().map(|x| x * x).sum::<f64>().sqrt();
+            assert!(
+                (norm - 1.0).abs() < 1e-9,
+                "eigenvector {k} must be unit norm, got {norm}"
+            );
+            // A·v_k = λ_k·v_k. The rows of the eigenvector matrix are NOT
+            // eigenvectors of A, so a transposed/misaligned output fails here.
+            for (i, mrow) in m.iter().enumerate() {
+                let avi: f64 = (0..3).map(|j| mrow[j] * vk[j]).sum();
+                assert!(
+                    (avi - vals[k] * vk[i]).abs() < 1e-9,
+                    "A·v[{k}] = λ[{k}]·v[{k}] failed at row {i}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn eigen_skill_is_registered_and_pipeline_callable() {
+        let desc = ix_registry::all()
+            .find(|s| s.name == "eigen")
+            .expect("eigen skill registered in the capability registry");
+        assert_eq!(
+            desc.inputs.len(),
+            1,
+            "must be arity-1 to be pipeline-callable"
+        );
+    }
+
+    // Honest boundary: a non-square matrix is rejected with a clear error.
+    #[test]
+    fn eigen_rejects_non_square() {
+        let err = eigen(json!({ "matrix": [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]] })).unwrap_err();
+        assert!(err.contains("square"), "got: {err}");
+    }
+
+    // Honest boundary: a non-symmetric matrix is rejected, not silently solved
+    // as if symmetric — the Jacobi solver would otherwise return wrong results.
+    #[test]
+    fn eigen_rejects_non_symmetric() {
+        let err = eigen(json!({ "matrix": [[1.0, 2.0], [3.0, 4.0]] })).unwrap_err();
+        assert!(err.contains("symmetric"), "got: {err}");
     }
 }

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -65,6 +65,7 @@ const EXPECTED: &[&str] = &[
     "ix_grothendieck_path",
     "ix_hyperloglog",
     "ix_dbscan",
+    "ix_eigen",
     "ix_kmeans",
     "ix_linear_regression",
     "ix_pca",
@@ -157,9 +158,11 @@ fn parity_expected_count() {
     //   auto-exposed via the registry bridge) = 78.
     // + ix_dbscan (2026-06-07, density clustering — dogfood catalog-breadth fix;
     //   auto-exposed via the registry bridge) = 79.
+    // + ix_eigen (2026-06-07, symmetric eigendecomposition — dogfood
+    //   catalog-breadth fix; auto-exposed via the registry bridge) = 80.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 79);
+    assert_eq!(EXPECTED.len(), 80);
 }
 
 #[test]
@@ -290,10 +293,11 @@ fn parity_all_43_registry_backed() {
     // algorithm tools are registry-backed. ix_demo is manual.
     // + pca (2026-06-07, dogfood catalog-breadth fix) = 53.
     // + dbscan (2026-06-07, dogfood catalog-breadth fix) = 54.
+    // + eigen (2026-06-07, dogfood catalog-breadth fix) = 55.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 54,
-        "expected 54 registry skills, got {registry_count}"
+        registry_count, 55,
+        "expected 55 registry skills, got {registry_count}"
     );
 }
 
@@ -336,4 +340,11 @@ fn registry_backed_calls_dispatch_correctly() {
         .call("ix_number_theory", params)
         .expect("ix_number_theory via registry");
     assert_eq!(result["gcd"].as_u64(), Some(6));
+
+    // batch1: ix_eigen → eigen (exercises the MCP-name dispatch path for the new
+    // skill, not just the wrapper). [[2,1],[1,2]] has top eigenvalue 3.
+    let params = serde_json::json!({ "matrix": [[2.0, 1.0], [1.0, 2.0]] });
+    let result = reg.call("ix_eigen", params).expect("ix_eigen via registry");
+    let top = result["eigenvalues"][0].as_f64().expect("eigenvalues[0]");
+    assert!((top - 3.0).abs() < 1e-9, "top eigenvalue ~3, got {top}");
 }

--- a/crates/ix-approval/src/classify.rs
+++ b/crates/ix-approval/src/classify.rs
@@ -77,6 +77,7 @@ pub fn classify_action_kind(tool_name: &str) -> ActionKind {
         "ix_kmeans",
         "ix_pca",
         "ix_dbscan",
+        "ix_eigen",
         "ix_optimize",
         "ix_search",
         "ix_markov",
@@ -163,6 +164,7 @@ mod tests {
             "ix_fft",
             "ix_pca",
             "ix_dbscan",
+            "ix_eigen",
         ] {
             assert_eq!(
                 classify_action_kind(tool),

--- a/crates/ix-skill/tests/cli.rs
+++ b/crates/ix-skill/tests/cli.rs
@@ -25,12 +25,12 @@ fn list_skills_returns_all_entries() {
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     let count = value["count"].as_u64().expect("count is number");
-    // 54 = batch1 (6 + pca + dbscan, 2026-06-07 dogfood catalog-breadth fixes)
-    // + batch2 (28) + batch3 (10 + context.walk + session.flywheel_export
+    // 55 = batch1 (6 + pca + dbscan + eigen, 2026-06-07 dogfood catalog-breadth
+    // fixes) + batch2 (28) + batch3 (10 + context.walk + session.flywheel_export
     // + fuzzy.eval) + prime_radiant (2) + assumption_graph (4: assumption.query
     // + .belief_at + .drift + .claims).
     // If this drifts, update the assertion alongside the batch changes.
-    assert_eq!(count, 54, "expected 54 registry skills, got {count}");
+    assert_eq!(count, 55, "expected 55 registry skills, got {count}");
 }
 
 #[test]

--- a/state/assumptions/annotations.snapshot.json
+++ b/state/assumptions/annotations.snapshot.json
@@ -14,6 +14,18 @@
       "test_binding": "dbscan_skill_executes_and_separates_clusters_from_noise"
     },
     {
+      "key": "sha256:dda80e531670cb3bd281d503a7a9516e5c7dcfed68cb8e95364c95f0e953ddaa",
+      "path": "crates/ix-agent/src/handlers.rs",
+      "line": 411,
+      "kind": "invariant",
+      "claim": "symmetric_eigen returns eigenvalues descending and column-major eigenvectors; the handler transposes so eigenvectors[k] is the unit eigenvector for eigenvalues[k]",
+      "verdict": "T",
+      "certainty": "Test",
+      "evidence": "skills::batch1::tests::eigen_skill_executes_on_symmetric_matrix",
+      "anchor_hash": "sha256:7778d50d92cd959ae968c8ff10f56b3370c5b3be12299121928bd0241c51bb99",
+      "test_binding": "eigen_skill_executes_on_symmetric_matrix"
+    },
+    {
       "key": "sha256:dd5f98b683ce720d99120636957b1c8fece736215d4b0ce424a6380c2e1b79e2",
       "path": "crates/ix-assumption-graph/src/graph.rs",
       "line": 171,


### PR DESCRIPTION
## What

Adds a standalone **`eigen`** skill wrapping ix-math's symmetric eigendecomposition (cyclic Jacobi) as an arity-1 `#[ix_skill]`, following the proven `pca`/`dbscan` pattern. "Compute the eigenvalues of this symmetric matrix" is a top dogfood gap; this closes it and further lifts the translation yield ceiling. Third of the catalog-breadth fixes (PCA #84 → DBSCAN #87 → eigen).

Auto-exposed as MCP tool `ix_eigen` via the registry bridge; added to `ix-approval` `READ_TOOLS`.

## Honest boundary (the dbscan-review lesson, applied up front)

`symmetric_eigen` is the **Jacobi** solver — it reads the input *as* symmetric and would silently return wrong results for an asymmetric matrix. So the handler validates the matrix is **square AND symmetric within 1e-9 before solving**, and rejects asymmetry with a clear error rather than mislead. Eigenvalues are returned descending; eigenvectors are transposed to row-major so `eigenvectors[k]` matches `eigenvalues[k]`.

## Tests (executes, not just registers)

- `A·v = λ·v` on `[[2,1],[1,2]]` (eigenvalues 3, 1) — sign-robust.
- registered + arity-1 (pipeline-callable).
- non-square rejected; non-symmetric rejected.
- Counts: registry 54→55, parity EXPECTED 79→80, cli 54→55.
- `@ai:invariant` on the descending-order + transpose convention, `::`-pathed so the drift extractor binds it; snapshot re-captured to 32 claims (`drift --check` clean — this PR exercises the now-live gate).

A 3-lens adversarial review runs alongside CI; I'll address any P0/P1 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)