### PR TITLE
feat(ix-thinking-machine): run-time data binding via `{param}` — closes the dominant refusal

### DIFF
--- a/crates/ix-demo/src/demos/pipeline_editor/mod.rs
+++ b/crates/ix-demo/src/demos/pipeline_editor/mod.rs
@@ -494,6 +494,23 @@ impl PipelineEditor {
                 return;
             }
         };
+        // Bind {param} placeholders before lowering. The editor has no --param
+        // channel, so a spec with an unbound {param} fails closed here with a
+        // clear message rather than passing a {"param":...} blob to a skill.
+        let spec = match ix_pipeline::lower::bind_params(&spec, &Default::default()) {
+            Ok(s) => s,
+            Err(e) => {
+                self.yaml_run = Some(YamlRun {
+                    path: path.into(),
+                    stages: BTreeMap::new(),
+                    total_duration_ms: 0,
+                    cache_hits: 0,
+                    error: Some(format!("params: {e}")),
+                });
+                self.last_action = format!("run ix.yaml: {e}");
+                return;
+            }
+        };
         let dag = match lower(&spec) {
             Ok(d) => d,
             Err(e) => {
@@ -1116,6 +1133,46 @@ stages:
         let run = editor.yaml_run.as_ref().unwrap();
         assert!(run.error.is_some());
         assert!(run.error.as_ref().unwrap().contains("lower"));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn run_yaml_fails_closed_on_unbound_param() {
+        // The editor has no --param channel, so a spec the NL compiler emitted
+        // for absent data ({param} placeholders) must fail closed BEFORE any
+        // stage runs — never pass a {"param":...} blob to the skill.
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "ix-editor-unbound-param-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let ix_yaml = dir.join("ix.yaml");
+        std::fs::write(
+            &ix_yaml,
+            r#"version: "1"
+params:
+  nums: null
+stages:
+  s:
+    skill: stats
+    args:
+      data: { param: nums }
+"#,
+        )
+        .unwrap();
+
+        let mut editor = PipelineEditor::default();
+        editor.run_yaml(ix_yaml.to_str().unwrap());
+        let run = editor.yaml_run.as_ref().unwrap();
+        let err = run.error.as_ref().expect("unbound param must error");
+        assert!(
+            err.contains("missing required param 'nums'"),
+            "expected fail-closed missing-param, got: {err}"
+        );
+        assert_eq!(run.stages.len(), 0, "no stage may run on an unbound param");
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/ix-pipeline/src/lower.rs
+++ b/crates/ix-pipeline/src/lower.rs
@@ -7,7 +7,7 @@
 //!  3. Build a compute closure that resolves the references against
 //!     upstream outputs at execution time, then calls the skill.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde_json::Value;
 
@@ -225,6 +225,126 @@ pub(crate) fn resolve_from_refs(
     }
 }
 
+/// Bind run-time parameters into a spec: replace every `{"param": "NAME"}`
+/// object-ref in a stage's args with a concrete value, *before* lowering.
+///
+/// Values are sourced from the spec's own `params` bag (defaults) overridden by
+/// `overrides` (run-time `--param` values win). Unlike `{"from": "stage"}` —
+/// which resolves against an upstream stage's OUTPUT during execution — a
+/// `{"param"}` is bound up front: it carries data the NL request didn't provide
+/// inline (e.g. "reduce *this dataset*" → `data: {param: "dataset"}`). A
+/// referenced param with no value (no spec default and no override, or an
+/// explicit `null` default meaning "must be supplied") is a hard error *before*
+/// anything executes — never silently dropped.
+// @ai:invariant bind_params returns an unbound {param:"X"} (missing/null) as Err, never as a substituted spec — so a caller that binds before executing cannot pass an unbound placeholder to a skill [T:test conf:0.9 src:lower::tests::bind_params_missing_param_errors]
+pub fn bind_params(
+    spec: &PipelineSpec,
+    overrides: &BTreeMap<String, Value>,
+) -> Result<PipelineSpec, String> {
+    // spec defaults first, then run-time overrides win.
+    let mut merged = spec.params.clone();
+    for (k, v) in overrides {
+        merged.insert(k.clone(), v.clone());
+    }
+
+    let mut out = spec.clone();
+    for (id, stage) in out.stages.iter_mut() {
+        stage.args =
+            substitute_params(&stage.args, &merged).map_err(|e| format!("stage '{id}': {e}"))?;
+    }
+    Ok(out)
+}
+
+/// Recursively replace `{"param": "NAME"}` (a single-key object whose value is a
+/// string) with `params[NAME]`. Everything else — including `{"from": ...}` — is
+/// passed through untouched. A `null` param value counts as unsupplied. The
+/// substituted value is NOT re-scanned for refs: a param is opaque DATA, so a
+/// supplied value that is itself a `{from}`/`{param}` reference is rejected
+/// rather than allowed to inject a DAG edge (data must not become control flow).
+fn substitute_params(value: &Value, params: &BTreeMap<String, Value>) -> Result<Value, String> {
+    match value {
+        Value::Object(map) => {
+            if map.len() == 1 {
+                if let Some(Value::String(name)) = map.get("param") {
+                    return match params.get(name) {
+                        Some(Value::Null) | None => Err(format!(
+                            "missing required param '{name}' (supply it with --param {name}=<json|@file> or give it a default in the spec's `params`)"
+                        )),
+                        Some(v) if contains_ref(v) => Err(format!(
+                            "param '{name}' value must be literal data, not a {{\"from\"}}/{{\"param\"}} reference (refs are control flow, params are data)"
+                        )),
+                        Some(v) => Ok(v.clone()),
+                    };
+                }
+            }
+            let mut out = serde_json::Map::new();
+            for (k, v) in map {
+                out.insert(k.clone(), substitute_params(v, params)?);
+            }
+            Ok(Value::Object(out))
+        }
+        Value::Array(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for v in items {
+                out.push(substitute_params(v, params)?);
+            }
+            Ok(Value::Array(out))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+/// True if `value` contains a `{"from": "..."}` or `{"param": "..."}` reference
+/// anywhere (single-key object with a string value). Used to reject a `--param`
+/// value that would smuggle a control-flow ref into the DAG via substitution.
+fn contains_ref(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.len() == 1
+                && (matches!(map.get("from"), Some(Value::String(_)))
+                    || matches!(map.get("param"), Some(Value::String(_))))
+            {
+                return true;
+            }
+            map.values().any(contains_ref)
+        }
+        Value::Array(items) => items.iter().any(contains_ref),
+        _ => false,
+    }
+}
+
+/// Collect every param NAME referenced by `{"param": "NAME"}` anywhere in a
+/// spec's stage args. Used to report what a template still needs.
+pub fn collect_param_names(spec: &PipelineSpec) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for stage in spec.stages.values() {
+        collect_param_refs(&stage.args, &mut out);
+    }
+    out
+}
+
+fn collect_param_refs(value: &Value, out: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(map) => {
+            if map.len() == 1 {
+                if let Some(Value::String(name)) = map.get("param") {
+                    out.insert(name.clone());
+                    return;
+                }
+            }
+            for v in map.values() {
+                collect_param_refs(v, out);
+            }
+        }
+        Value::Array(items) => {
+            for v in items {
+                collect_param_refs(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -266,5 +386,111 @@ mod tests {
         );
         let resolved = resolve_from_refs(&template, &inputs).unwrap();
         assert_eq!(resolved["data"], json!([1, 2, 3]));
+    }
+
+    // ---- bind_params (run-time data binding) ----------------------------
+
+    fn spec_with(params: Value, args: Value) -> PipelineSpec {
+        let mut stages = std::collections::BTreeMap::new();
+        stages.insert(
+            "s".to_string(),
+            crate::spec::StageSpec {
+                skill: "pca".to_string(),
+                args,
+                deps: vec![],
+                cache: None,
+            },
+        );
+        let params: BTreeMap<String, Value> =
+            serde_json::from_value(params).expect("params object");
+        PipelineSpec {
+            version: "1".into(),
+            params,
+            stages,
+            x_editor: Value::Null,
+        }
+    }
+
+    fn ov(pairs: &[(&str, Value)]) -> BTreeMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn bind_params_substitutes_whole_value() {
+        let spec = spec_with(
+            json!({ "dataset": null }),
+            json!({ "data": { "param": "dataset" }, "n_components": 2 }),
+        );
+        let bound =
+            bind_params(&spec, &ov(&[("dataset", json!([[1.0, 2.0], [3.0, 4.0]]))])).unwrap();
+        assert_eq!(
+            bound.stages["s"].args["data"],
+            json!([[1.0, 2.0], [3.0, 4.0]])
+        );
+        assert_eq!(bound.stages["s"].args["n_components"], json!(2));
+    }
+
+    #[test]
+    fn bind_params_uses_spec_default_and_override_wins() {
+        let spec = spec_with(
+            json!({ "n": 2 }),
+            json!({ "n_components": { "param": "n" } }),
+        );
+        // default
+        let bound = bind_params(&spec, &ov(&[])).unwrap();
+        assert_eq!(bound.stages["s"].args["n_components"], json!(2));
+        // override beats default
+        let bound = bind_params(&spec, &ov(&[("n", json!(5))])).unwrap();
+        assert_eq!(bound.stages["s"].args["n_components"], json!(5));
+    }
+
+    #[test]
+    fn bind_params_missing_param_errors() {
+        let spec = spec_with(json!({}), json!({ "data": { "param": "x" } }));
+        let err = bind_params(&spec, &ov(&[])).unwrap_err();
+        assert!(err.contains("missing required param 'x'"), "got: {err}");
+    }
+
+    #[test]
+    fn bind_params_null_default_is_unsupplied() {
+        let spec = spec_with(json!({ "x": null }), json!({ "data": { "param": "x" } }));
+        let err = bind_params(&spec, &ov(&[])).unwrap_err();
+        assert!(err.contains("missing required param 'x'"), "got: {err}");
+    }
+
+    #[test]
+    fn bind_params_leaves_from_refs_untouched() {
+        let spec = spec_with(json!({}), json!({ "data": { "from": "up" } }));
+        let bound = bind_params(&spec, &ov(&[])).unwrap();
+        assert_eq!(bound.stages["s"].args["data"], json!({ "from": "up" }));
+    }
+
+    #[test]
+    fn bind_params_rejects_ref_shaped_param_value() {
+        // A --param value that is itself a {from}/{param} ref must be rejected:
+        // external run-time input must not inject DAG control flow (data != control).
+        let spec = spec_with(json!({}), json!({ "data": { "param": "x" } }));
+        let err = bind_params(&spec, &ov(&[("x", json!({ "from": "load" }))])).unwrap_err();
+        assert!(err.contains("literal data"), "top-level ref, got: {err}");
+        let err =
+            bind_params(&spec, &ov(&[("x", json!({ "a": { "from": "load" } }))])).unwrap_err();
+        assert!(err.contains("literal data"), "nested ref, got: {err}");
+        // A plain data matrix is still accepted.
+        let ok = bind_params(&spec, &ov(&[("x", json!([[1.0, 2.0]]))])).unwrap();
+        assert_eq!(ok.stages["s"].args["data"], json!([[1.0, 2.0]]));
+    }
+
+    #[test]
+    fn collect_param_names_finds_refs() {
+        let spec = spec_with(
+            json!({}),
+            json!({ "data": { "param": "dataset" }, "k": { "param": "k" }, "lit": 3 }),
+        );
+        let names = collect_param_names(&spec);
+        assert!(names.contains("dataset") && names.contains("k"));
+        assert_eq!(names.len(), 2);
     }
 }

--- a/crates/ix-pipeline/src/spec.rs
+++ b/crates/ix-pipeline/src/spec.rs
@@ -33,8 +33,12 @@ pub struct PipelineSpec {
     #[serde(default = "default_version")]
     pub version: String,
 
-    /// Named parameter bag, substituted into stage args via `${params.NAME}`
-    /// (string expansion only; full templating deferred).
+    /// Named parameter bag: default values for `{"param": "NAME"}` object-refs in
+    /// stage args, bound at run time by `lower::bind_params` and overridable with
+    /// `ix pipeline run --param NAME=<json|@file>`. A `null` default means the
+    /// param MUST be supplied at run. This is how the NL compiler emits a spec for
+    /// a request whose data isn't inline ("reduce this dataset"). (A separate
+    /// `${params.NAME}` string-interpolation form is reserved, not yet built.)
     #[serde(default)]
     pub params: BTreeMap<String, Value>,
 

--- a/crates/ix-skill/src/main.rs
+++ b/crates/ix-skill/src/main.rs
@@ -215,6 +215,12 @@ enum PipelineNoun {
         /// Stream NDJSON events to stdout while the pipeline runs
         #[arg(long)]
         json: bool,
+        /// Bind a run-time parameter referenced by `{param: "name"}` in the
+        /// spec. Repeatable. VALUE is parsed as JSON, or `@path` reads JSON from
+        /// a file; a bare unparseable word is taken as a string. Example:
+        /// --param dataset=@data.json --param k=3
+        #[arg(long = "param", value_name = "NAME=VALUE")]
+        param: Vec<String>,
     },
     /// Show execution-level DAG structure
     Dag {
@@ -239,6 +245,11 @@ enum PipelineNoun {
         /// Execute the compiled pipeline (default: compile + gate only).
         #[arg(long)]
         run: bool,
+        /// Bind a run-time parameter the proposer emitted for absent data
+        /// ({param: "name"}). Repeatable; same syntax as `pipeline run --param`.
+        /// Only meaningful with --run. e.g. --param dataset=@data.json
+        #[arg(long = "param", value_name = "NAME=VALUE")]
+        param: Vec<String>,
     },
     /// Aggregate the NL→pipeline translation ledger (hits.jsonl) into a yield
     /// metric paired with its refusal guardrails (Goodhart-resistant: a yield
@@ -346,15 +357,18 @@ fn dispatch(cli: Cli) -> i32 {
                 try_or(verbs::pipeline::validate(file.as_deref(), fmt))
             }
             PipelineNoun::Dag { file } => try_or(verbs::pipeline::dag(file.as_deref(), fmt)),
-            PipelineNoun::Run { file, json } => {
-                try_or(verbs::pipeline::run(file.as_deref(), json, fmt))
+            PipelineNoun::Run { file, json, param } => {
+                try_or(verbs::pipeline::run(file.as_deref(), json, &param, fmt))
             }
             PipelineNoun::Schema => try_or(verbs::pipeline::schema(fmt)),
             PipelineNoun::Compile {
                 sentence,
                 max_rounds,
                 run,
-            } => try_or(verbs::compile::compile(&sentence, max_rounds, run, fmt)),
+                param,
+            } => try_or(verbs::compile::compile(
+                &sentence, max_rounds, run, &param, fmt,
+            )),
             PipelineNoun::Hits => try_or(verbs::compile::hits(fmt)),
         },
 

--- a/crates/ix-skill/src/verbs/compile.rs
+++ b/crates/ix-skill/src/verbs/compile.rs
@@ -50,9 +50,10 @@ pub fn compile(
     sentence: &str,
     max_rounds: u32,
     run_it: bool,
+    params: &[String],
     format: Format,
 ) -> Result<(), String> {
-    let outcome = compile_inner(sentence, max_rounds, run_it, format);
+    let outcome = compile_inner(sentence, max_rounds, run_it, params, format);
     if outcome.is_err() {
         // coverage_max is unknown/irrelevant for an operational error → NaN,
         // which serializes to JSON null (summarize_hits ignores the field).
@@ -65,6 +66,7 @@ fn compile_inner(
     sentence: &str,
     max_rounds: u32,
     run_it: bool,
+    params: &[String],
     format: Format,
 ) -> Result<(), String> {
     let api_key = std::env::var("ANTHROPIC_API_KEY")
@@ -182,11 +184,17 @@ fn compile_inner(
                         "stages": spec.stages.len(),
                         "governance": gate,
                         "path": GEN_FILE,
-                        "note": "governance PASS; spec written. Re-run with --run to execute.",
+                        // The {param} placeholders this template still needs at run
+                        // time — supply each with `--param NAME=<json|@file>`.
+                        "params_needed": ix_pipeline::lower::collect_param_names(&spec)
+                            .into_iter()
+                            .collect::<Vec<_>>(),
+                        "note": "governance PASS; spec written. Re-run with --run \
+                            (plus --param NAME=... for any params_needed) to execute.",
                     }),
                 );
             }
-            execute_and_narrate(&spec, sentence, rounds_used, cov_max, gate, format)
+            execute_and_narrate(&spec, params, sentence, rounds_used, cov_max, gate, format)
         }
         Err(rejection) => {
             log_gap(sentence, "governance", &rejection, rounds_used);
@@ -374,12 +382,24 @@ fn is_resolved_governance_rejection(execute_err: &str) -> bool {
 /// Execute the lowered pipeline and narrate the run back in prose.
 fn execute_and_narrate(
     spec: &PipelineSpec,
+    raw_params: &[String],
     sentence: &str,
     rounds: u32,
     coverage_max: f64,
     gate: Value,
     format: Format,
 ) -> Result<(), String> {
+    // Bind {param} placeholders BEFORE governance + execution — the compile --run
+    // path (and the ix_nl_to_pipeline MCP tool that spawns it) must honor the same
+    // no-unbound-{param} invariant as `ix pipeline run`. Binding first means an
+    // unbound {param} fails closed here, before ConstitutionGate or any skill runs
+    // (so this is testable without a governance dir or a live proposer). With no
+    // --param supplied, a {param} the proposer emitted for absent data is a clear
+    // "missing required param" error, not a {"param":...} blob handed to a skill.
+    let params = crate::verbs::pipeline::parse_params(raw_params)?;
+    let spec = ix_pipeline::lower::bind_params(spec, &params)
+        .map_err(|e| format!("binding params: {e}"))?;
+    let spec = &spec;
     // Execution-time governance on RESOLVED args (PR #77 review P1): the same
     // constitution-backed gate `ix pipeline run` uses, so executing a compiled
     // pipeline cannot smuggle a destructive op through a `{"from"}` ref.
@@ -678,6 +698,17 @@ stages:
          that stage's skill `output_schema` (shown in the catalog). Do NOT invent \
          field names. If a producing skill has no `output_schema`, reference its \
          whole output with `{{\"from\": \"stage_id\"}}` (no field).\n\n\
+         RUN-TIME DATA (params): if the request names its data only abstractly \
+         with no concrete values inline (e.g. \"this dataset\", \"the data\", \
+         \"these points\", \"the matrix\"), do NOT refuse for missing data. Set \
+         that argument to `{{\"param\": \"NAME\"}}` (a run-time placeholder; NAME \
+         a short snake_case id) and declare NAME in a top-level `params:` map with \
+         a `null` default — the value is supplied later via `--param NAME=...`. \
+         For example \"reduce this dataset with PCA\" becomes a `params: {{dataset: \
+         null}}` map plus a pca stage whose `data` arg is \
+         `{{\"param\": \"dataset\"}}`. Reserve NO_COVERAGE for a missing \
+         CAPABILITY (no catalog skill fits the intent), NEVER for merely-absent \
+         data that a `{{\"param\"}}` placeholder can carry.\n\n\
          JSON SCHEMA for the document you must emit:\n{}\n\n\
          SKILL CATALOG (pipeline-callable skills only):\n{}\n\n\
          EXAMPLE of a valid PipelineSpec:\n{}\n",
@@ -933,6 +964,55 @@ fn summarize_hits(path: &std::path::Path) -> Result<Value, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The proposer must be told to emit a {param} placeholder for absent data
+    // rather than refuse — the behavior change that closes the dominant
+    // (missing-data) refusal. We can't unit-test the LLM, so assert the
+    // instruction is present in the system prompt it receives.
+    #[test]
+    fn system_prompt_instructs_param_placeholders_for_absent_data() {
+        let prompt = build_system_prompt(&serde_json::json!({}), &serde_json::json!([]));
+        assert!(
+            prompt.contains("RUN-TIME DATA"),
+            "missing RUN-TIME DATA section"
+        );
+        assert!(
+            prompt.contains("{\"param\": \"NAME\"}"),
+            "missing {{param}} guidance"
+        );
+        assert!(
+            prompt.contains("NEVER for merely-absent data"),
+            "must steer NO_COVERAGE away from missing-data refusals"
+        );
+    }
+
+    // The compile --run path (and the ix_nl_to_pipeline MCP tool that spawns it)
+    // must honor the same no-unbound-{param} invariant as `ix pipeline run`: a
+    // {param} the proposer emitted for absent data, with no --param supplied, must
+    // FAIL CLOSED before governance/execution — never be passed to a skill as a
+    // literal {"param":...} blob. bind_params runs first in execute_and_narrate,
+    // so this needs no governance dir or live proposer.
+    #[test]
+    fn execute_and_narrate_fails_closed_on_unbound_param() {
+        let spec = PipelineSpec::from_yaml_str(
+            "version: \"1\"\nparams:\n  nums: null\nstages:\n  s:\n    skill: stats\n    args:\n      data: { param: nums }\n",
+        )
+        .unwrap();
+        let err = execute_and_narrate(
+            &spec,
+            &[],
+            "reduce this data",
+            0,
+            0.0,
+            json!({}),
+            Format::Json,
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("missing required param 'nums'"),
+            "compile --run must fail closed on an unbound param, got: {err}"
+        );
+    }
 
     // ── output-ref validation (chain-of-evidence: a downstream stage may only
     //    reference fields its upstream skill actually emits) ──────────────────

--- a/crates/ix-skill/src/verbs/pipeline.rs
+++ b/crates/ix-skill/src/verbs/pipeline.rs
@@ -3,7 +3,7 @@
 use crate::output::{self, Format};
 use ix_pipeline::executor::{execute, NoCache};
 use ix_pipeline::lock::LockFile;
-use ix_pipeline::lower::{lower, lower_with_gate};
+use ix_pipeline::lower::{bind_params, lower, lower_with_gate};
 use ix_pipeline::spec::PipelineSpec;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -110,8 +110,11 @@ pub(crate) fn build_schema() -> Value {
             "version": { "const": "1", "default": "1" },
             "params": {
                 "type": "object",
-                "description": "Named parameter bag (string expansion only; \
-                    inert in the current executor — prefer inlining values)."
+                "description": "Default values for {\"param\": \"NAME\"} \
+                    placeholders used in stage args, bound at run via \
+                    `--param NAME=...`. A null default means the value MUST be \
+                    supplied at run. Use this when the request's data is not \
+                    inline (e.g. \"reduce this dataset\")."
             },
             "stages": {
                 "type": "object",
@@ -134,8 +137,10 @@ pub(crate) fn build_schema() -> Value {
                     },
                     "args": {
                         "type": "object",
-                        "description": "Static JSON input for the skill. May embed \
-                            {\"from\": \"upstream_stage[.key]\"} references."
+                        "description": "JSON input for the skill. May embed \
+                            {\"from\": \"upstream_stage[.key]\"} references to an \
+                            upstream output, or {\"param\": \"NAME\"} placeholders \
+                            bound at run from the top-level `params`/`--param`."
                     },
                     "deps": {
                         "type": "array",
@@ -484,13 +489,53 @@ fn append_provenance(lock: &LockFile) {
     }
 }
 
-/// `ix pipeline run [-f FILE] [--json]` — execute the pipeline.
+/// Parse `--param NAME=VALUE` strings into a value map. VALUE is parsed as JSON;
+/// a leading `@` reads JSON from that file; a value that is not valid JSON is
+/// taken verbatim as a string (so `--param label=foo` works without quoting).
+pub(crate) fn parse_params(
+    raw: &[String],
+) -> Result<std::collections::BTreeMap<String, serde_json::Value>, String> {
+    let mut out = std::collections::BTreeMap::new();
+    for entry in raw {
+        let (name, val) = entry
+            .split_once('=')
+            .ok_or_else(|| format!("--param must be NAME=VALUE, got '{entry}'"))?;
+        if name.is_empty() {
+            return Err(format!("--param has an empty name: '{entry}'"));
+        }
+        let value = if let Some(file) = val.strip_prefix('@') {
+            let text = std::fs::read_to_string(file)
+                .map_err(|e| format!("--param {name}=@{file}: {e}"))?;
+            serde_json::from_str(&text)
+                .map_err(|e| format!("--param {name}=@{file}: not valid JSON: {e}"))?
+        } else {
+            serde_json::from_str(val).unwrap_or_else(|_| serde_json::Value::String(val.to_string()))
+        };
+        out.insert(name.to_string(), value);
+    }
+    Ok(out)
+}
+
+/// `ix pipeline run [-f FILE] [--json] [--param NAME=VALUE]...` — execute the
+/// pipeline.
 ///
 /// When `stream_ndjson` is true, emits NDJSON events (`start`, `stage_start`,
 /// `stage_complete`, `done`) to stdout in real time as the DAG runs.
-pub fn run(file: Option<&str>, stream_ndjson: bool, format: Format) -> Result<(), String> {
+pub fn run(
+    file: Option<&str>,
+    stream_ndjson: bool,
+    raw_params: &[String],
+    format: Format,
+) -> Result<(), String> {
     let path: &str = file.unwrap_or(DEFAULT_FILE);
     let spec = PipelineSpec::from_file(path).map_err(|e| format!("loading {path}: {e}"))?;
+    // Bind run-time `--param NAME=VALUE` values into `{param: "name"}` placeholders
+    // BEFORE the governance gate and lowering, so the gate vets the real resolved
+    // values and the executor (and ix.lock provenance) see concrete data, not the
+    // template. A referenced-but-unsupplied param fails here, before any stage runs.
+    let params = parse_params(raw_params)?;
+    let spec =
+        bind_params(&spec, &params).map_err(|e| format!("binding params for {path}: {e}"))?;
     // Template-time pre-flight: fail fast on literal violations before ANY
     // stage runs (prevents partial side effects from a multi-stage pipeline).
     governance_gate(&spec).map_err(|e| format!("governance gate: {e}"))?;
@@ -918,5 +963,39 @@ stages:
             .unwrap(),
             Some("sha256:deadbeef".to_string())
         );
+    }
+
+    // ---- --param parsing -------------------------------------------------
+
+    #[test]
+    fn parse_params_parses_json_and_falls_back_to_string() {
+        let p = parse_params(&[
+            "k=3".to_string(),
+            "data=[[1.0,2.0],[3.0,4.0]]".to_string(),
+            "label=hello".to_string(), // bare word, not valid JSON -> string
+        ])
+        .unwrap();
+        assert_eq!(p["k"], serde_json::json!(3));
+        assert_eq!(p["data"], serde_json::json!([[1.0, 2.0], [3.0, 4.0]]));
+        assert_eq!(p["label"], serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn parse_params_rejects_missing_equals() {
+        let err = parse_params(&["noequals".to_string()]).unwrap_err();
+        assert!(err.contains("NAME=VALUE"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_params_allows_equals_in_value() {
+        // split_once('=') keeps later '=' in the value (e.g. base64/expr).
+        let p = parse_params(&["expr=a=b".to_string()]).unwrap();
+        assert_eq!(p["expr"], serde_json::json!("a=b"));
+    }
+
+    #[test]
+    fn parse_params_at_file_missing_errors() {
+        let err = parse_params(&["data=@/no/such/file.json".to_string()]).unwrap_err();
+        assert!(err.contains("data=@"), "got: {err}");
     }
 }

--- a/crates/ix-skill/tests/governance.rs
+++ b/crates/ix-skill/tests/governance.rs
@@ -223,3 +223,55 @@ stages:
     assert!(lock_text.contains("output_hash: sha256:"));
     fs::remove_dir_all(&dir).ok();
 }
+
+// ---- run-time data binding (--param) ------------------------------------
+
+const PARAM_SPEC: &str = r#"version: "1"
+params:
+  nums: null
+stages:
+  s:
+    skill: stats
+    args:
+      data: { param: nums }
+"#;
+
+#[test]
+fn pipeline_run_binds_param_at_runtime() {
+    let dir = tempdir("param_bind");
+    fs::write(dir.join("ix.yaml"), PARAM_SPEC).unwrap();
+    // The spec leaves `data` as a {param: nums} placeholder; --param supplies it.
+    ix_in(&dir)
+        .args([
+            "--format",
+            "json",
+            "pipeline",
+            "run",
+            "--param",
+            "nums=[1.0, 2.0, 3.0]",
+        ])
+        .assert()
+        .success();
+    // The lock records the stage actually ran with bound (not placeholder) data.
+    let lock_text = fs::read_to_string(dir.join("ix.lock")).unwrap();
+    assert!(lock_text.contains("skill: stats"));
+    assert!(lock_text.contains("output_hash: sha256:"));
+    fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn pipeline_run_unbound_param_fails_closed() {
+    let dir = tempdir("param_missing");
+    fs::write(dir.join("ix.yaml"), PARAM_SPEC).unwrap();
+    // No --param: the placeholder is unbound, so the run must fail BEFORE any
+    // stage executes, with a clear message — not pass a {param} blob to `stats`.
+    let assert = ix_in(&dir).args(["pipeline", "run"]).assert().failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("missing required param 'nums'"),
+        "expected a missing-param error, got: {stderr}"
+    );
+    // And it must NOT have produced a lock (nothing executed).
+    assert!(!dir.join("ix.lock").exists(), "no ix.lock on a failed bind");
+    fs::remove_dir_all(&dir).ok();
+}

--- a/docs/plans/2026-06-07-pipeline-data-binding.md
+++ b/docs/plans/2026-06-07-pipeline-data-binding.md
@@ -1,0 +1,72 @@
+# Pipeline run-time data binding (`{param}`)
+
+**Date:** 2026-06-07
+**Status:** shipped
+**Closes:** the dominant thinking-machine refusal — abstract requests with no
+inline data (`"reduce this dataset with PCA"`) were refused because required
+data args (`data`/`matrix`/`X`,`y`) had no value and the proposer (correctly)
+won't fabricate inputs (dogfood finding #1, `state/thinking-machine/dogfood-2026-06-07-findings.md`).
+
+## Decision
+
+Make the already-declared-but-dead `PipelineSpec.params` field live, via a
+**whole-value object-ref**: an arg of the form `{"param": "NAME"}` is replaced,
+*before lowering*, with a value sourced from the spec's `params` bag (defaults)
+overridden by run-time `ix pipeline run --param NAME=<json|@file>` (overrides
+win). A referenced param with no value (no default / `null` default / no
+override) is a hard error **before any stage executes** — never silently passed
+to a skill.
+
+This is distinct from `{"from": "stage"}` (resolved against an upstream stage's
+*output* during execution). Params carry data the NL request didn't provide
+inline; they are bound up front.
+
+The NL proposer is instructed to emit `{"param": "NAME"}` + a `params: {NAME:
+null}` declaration for absent data instead of `NO_COVERAGE`. `NO_COVERAGE` is
+now reserved for a missing *capability*, never merely-absent data.
+
+## Execution paths & hardening
+
+There are two execution sites and BOTH bind before running, so the
+no-unbound-`{param}` invariant holds everywhere (an adversarial review caught
+that the compile path originally did not bind — the exact path the proposer
+prompt enables):
+
+- `ix pipeline run` → `pipeline::run` binds, then gates + executes.
+- `ix pipeline compile --run` (and the `ix_nl_to_pipeline` MCP tool, which
+  spawns it) → `compile::execute_and_narrate` binds **first** (before the
+  governance gate and execution). Both `run` and `compile` take `--param`. With
+  no `--param`, an unbound `{param}` is a hard "missing required param" error
+  before any stage — never a `{"param":...}` blob handed to a skill. (The MCP
+  tool plumbs no `--param` yet, so a `{param}` spec run via MCP fails closed; a
+  params channel on the MCP surface is a follow-up.)
+
+`--param` values are **data, not references**: a supplied value that itself
+contains a `{from}`/`{param}` ref (at any depth) is rejected, so run-time input
+cannot inject a DAG edge (data must not become control flow).
+
+`ix pipeline compile` (without `--run`) reports the placeholders a template
+still needs as `params_needed`, so the caller knows what to supply.
+
+## Considered alternatives
+
+- **Source skills** (`load_csv`/`fetch_url`): adds a file/URL read side-effect +
+  governance/approval surface; the finding explicitly says the fix is a binding
+  mechanism, not more skills. Deferred.
+- **`${params.NAME}` string interpolation** (the field's original reserved
+  design): string-only, so it cannot carry a JSON *matrix* — insufficient for
+  data binding. Left reserved, unbuilt.
+
+## Reversibility
+
+**Two-way door.** Additive: specs without `{param}` are unchanged; the
+`PipelineSpec` schema is still draft (`$id: urn:ix:pipeline:v1-draft`, not the
+frozen public URL). No sibling repo consumes the PipelineSpec format (ga/tars/
+Demerzel consume `optick.index` + SAE artifacts, not `ix.yaml`). The
+`{param}` token can evolve without cross-repo coordination until the schema is
+explicitly frozen.
+
+**Revisit trigger:** if/when the PipelineSpec schema is promoted from
+`urn:`-draft to the public `https://ix.guitaralchemist.com/...` `$id` (the
+freeze milestone), the `{param}` resolution rule must be specified in the
+frozen contract; re-run the dogfood batch to confirm the refusal rate drops.

--- a/state/assumptions/annotations.snapshot.json
+++ b/state/assumptions/annotations.snapshot.json
@@ -230,6 +230,18 @@
       "test_binding": null
     },
     {
+      "key": "sha256:5c3817bdf0d1cc6481638085ed38b29a164ed8eb74687a361deed0cd13f46620",
+      "path": "crates/ix-pipeline/src/lower.rs",
+      "line": 239,
+      "kind": "invariant",
+      "claim": "bind_params returns an unbound {param:\"X\"} (missing/null) as Err, never as a substituted spec — so a caller that binds before executing cannot pass an unbound placeholder to a skill",
+      "verdict": "T",
+      "certainty": "Test",
+      "evidence": "lower::tests::bind_params_missing_param_errors",
+      "anchor_hash": "sha256:2590c7049c54362049baf80499cb56bdecaefd7326c0670107e195cb0adfad71",
+      "test_binding": "bind_params_missing_param_errors"
+    },
+    {
       "key": "sha256:50cbdd5adf3ce6007ecff9300d4cf519473bb56be4c443688af4e5de43082c7b",
       "path": "crates/ix-search/src/astar.rs",
       "line": 75,
@@ -364,7 +376,7 @@
     {
       "key": "sha256:6511bb88a56c682ef0cf5414b979950553c36152bf89adbf74a7d2413fce0a74",
       "path": "crates/ix-skill/src/verbs/compile.rs",
-      "line": 1657,
+      "line": 1737,
       "kind": "invariant",
       "claim": "fixed-ref z-norm (E) is affine-identical to raw (A) on AUC/TNR/near-miss — a monotone affine map is rank- and ID-quantile-invariant",
       "verdict": "T",
@@ -376,7 +388,7 @@
     {
       "key": "sha256:cc19c55cbfe8379f7037d60faad7f46b7c4b67837dca48d7ad7b3cde620cf07e",
       "path": "crates/ix-skill/src/verbs/compile.rs",
-      "line": 1658,
+      "line": 1738,
       "kind": "assumption",
       "claim": "on the 184-probe corpus + bge-base-en, raw mean-top-3 cosine dominates every per-query/margin/kNN calibration on AUC, so the gate keeps the raw threshold — CONDITIONAL on the corpus + embedder, re-run on change",
       "verdict": "T",


### PR DESCRIPTION
## What

Abstract requests with no inline data — "reduce **this dataset** with PCA" — were the **dominant** thinking-machine refusal (dogfood finding #1): a required data arg had no value and the proposer correctly won't fabricate inputs. The fix is a **binding mechanism**, not more skills.

Makes the already-declared-but-**dead** `PipelineSpec.params` field live:

- **`bind_params`** (ix-pipeline): a pre-lowering pass replacing every `{"param": "NAME"}` object-ref in stage args with a value from the spec's `params` defaults overridden by run-time `--param` (overrides win). An unbound param (missing / `null` default) is a **hard error before any stage runs**. Distinct from `{"from"}` (upstream output, resolved during execution).
- **CLI**: `ix pipeline run --param NAME=VALUE` **and** `ix pipeline compile --param ...`. VALUE is JSON, `@file` reads JSON, a bare word is a string.
- **All three** `PipelineSpec`-execution sites bind before the governance gate + lowering — `pipeline::run`, `compile::execute_and_narrate` (also serving the `ix_nl_to_pipeline` MCP tool that spawns it), and the editor's `run_yaml`. (MCP `ix_pipeline_run` uses a separate `steps` format with no `{param}`.)
- **Proposer** + emitted JSON-schema now instruct emitting `{"param":"NAME"}` for absent data instead of `NO_COVERAGE`. `compile` (no `--run`) reports `params_needed`.

## Two adversarial review passes hardened this

The first review confirmed the resolution layer; the **second caught a P0**: `compile --run` (the exact flow the new prompt enables, also reachable via MCP) and the editor's `run_yaml` did **not** bind — an unbound `{"param":...}` blob reached the skill. All fixed:

- **P0** — bind FIRST at all three sites; fail-closed **executable** tests for the compile path (no governance dir / LLM needed) and the editor path.
- **P1** — a `--param` value that is itself a `{from}`/`{param}` ref could inject a DAG edge (data→control); rejected at any depth (`contains_ref` + test).
- **P1** — `collect_param_names` was green-but-dead; wired into the compile output as `params_needed`.
- **P1** — the `@ai:invariant` over-claimed a system property from a unit test; narrowed to `bind_params`' isolated contract (system property covered by the run + compile + editor fail-closed tests).

## Tests

15 new tests: `bind_params` (substitute/default/override/missing/null/leaves-`{from}`/ref-guard) + `collect_param_names`; `parse_params` (json/string/`@file`/missing-eq/equals-in-value); proposer-prompt presence; and **end-to-end fail-closed** on all three execution paths. clippy `--all-targets` + fmt + workspace test green; assumption snapshot 33 claims, `drift --check` clean (this PR exercises the now-live gate).

One-way-door note: `docs/plans/2026-06-07-pipeline-data-binding.md` (two-way door — additive, schema still urn-draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)