### PR TITLE
chore(aihero): tracer-bullet discipline + /teach skill

### DIFF
--- a/.claude/skills/teach/SKILL.md
+++ b/.claude/skills/teach/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: teach
+description: Personalized AI tutor — turns any topic into a customized, progress-tracked learning course. Use when the user wants to LEARN a concept, skill, language, tool, or domain. Creates a MISSION, curated RESOURCES, iterative lessons with self-checks, and learning-records that persist across sessions. NOT for interrogating the user about their own design (use brainstorming/IDSD for that).
+---
+
+# /teach — personalized learning tutor
+
+Adapted from aihero.dev (`learn-anything-with-my-teach-skill`). Turns the agent
+into a tutor that builds a personalized course for whatever the user wants to learn,
+adapted to their goal and proficiency, with progress tracked across sessions.
+
+## When to use
+The user wants to **learn** something. NOT for the agent interrogating the user
+about *their* design/plan — that's `brainstorming` / the IDSD intent gate.
+
+## Workflow
+
+### 1. Assess before teaching (ask one concise batch)
+- **Motivation** — why learn this, and what will they do with it?
+- **Current level** — none / some exposure / intermediate / advanced?
+- **Success criteria** — what does "done" look like concretely?
+- **Modality** — worked examples, theory-first, exercises, analogies, projects?
+
+> "The more detail you give, the better your personalized lessons will be."
+
+### 2. Set up the course under `./learning/<topic>/`
+- `MISSION.md` — goals, current level, success criteria (from step 1).
+- `RESOURCES.md` — curated materials. **Ground every entry in a real, verified
+  source — never fabricate links or citations** (fetch/verify before listing).
+- `reference/glossary.md` — key terms, grown as the course proceeds.
+- `lessons/` — one file per lesson (Markdown by default; HTML if embedded
+  quizzes/audio are wanted — optional, heavier).
+- `learning-records/` — what was covered, what landed, what didn't.
+
+### 3. Deliver lessons iteratively
+- One lesson at a time, scoped to the assessed level — short and concrete,
+  prefer worked examples over walls of theory.
+- End each lesson with a brief self-check (a few questions + answers).
+- Stop and wait for the learner to report how it went.
+
+### 4. Adapt
+- After each lesson, update `learning-records/` and `reference/glossary.md`.
+- Generate the next lesson based on what landed and what was missed.
+
+## Guardrails
+- Resources must be real and verified — no invented citations (ecosystem rule).
+- Keep lessons tight; one concept at a time; check understanding before advancing.
+- Persist progress so a later session can resume from `learning-records/`.

--- a/.claude/skills/teach/SKILL.md
+++ b/.claude/skills/teach/SKILL.md
@@ -46,3 +46,6 @@ about *their* design/plan — that's `brainstorming` / the IDSD intent gate.
 - Resources must be real and verified — no invented citations (ecosystem rule).
 - Keep lessons tight; one concept at a time; check understanding before advancing.
 - Persist progress so a later session can resume from `learning-records/`.
+
+## Output hygiene
+Generated course state under `./learning/` is personal and regenerable — it is gitignored and must NOT be committed (add `learning/` to .gitignore on first use).

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ embed-cache/
 # embed-cache/, so it can appear at repo root or under a crate dir during tests.
 # NEVER commit; regenerated on demand.
 .fastembed_cache/
+
+# /teach generated courses (personal, regenerable)
+learning/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,15 @@ These rules complement (don't replace) the Collaboration discipline above. They 
 
 Before-merge addendum: scan Codex bot comments before any `gh pr merge` — see **Session-learned rules** below for the exact command and policy.
 
+## Tracer-bullets + vertical slices (aihero delta, 2026-06-14)
+
+Adopted from aihero.dev as the genuine *delta* over the rules above (complements Karpathy r2 simplicity + r4 goal-driven). Counters AI's "build the whole thing at once" failure mode:
+
+- **Tracer-bullet first.** For any non-trivial feature, build the smallest **end-to-end** slice that touches *every* layer, test it, get feedback, then expand — never build layers in isolation. aihero: "Context-window constraints make the discipline non-negotiable." (This session's spike was exactly this: held-out→train→head→eval→cross-validate as one thin slice before scaling.)
+- **Vertical, not horizontal, decomposition.** Each task/PR is a thin slice cutting through all integration layers (surfacing unknowns early), not a horizontal layer.
+
+Already covered by existing machinery — do NOT add duplicate skills: `/grill-me`→IDSD intent gate + `brainstorming`; `/to-prd`,`/to-issues`→`ce-plan` + `docs/plans`; `/tdd`→test discipline + `ce-work`; `/improve-codebase-architecture`→sentrux + `ix-code-*` + `simplify`/`code-review`.
+
 Self-improvement reflex: when the user corrects you, invoke `/correct` so the rule lands in this file's **Session-learned rules** section — Cherny's "most important loop" from the 2026 Sequoia talk.
 
 ## Session continuity (Cherny pattern)


### PR DESCRIPTION
Ecosystem-wide adoption from aihero.dev:
- Tracer-bullets + vertical-slice discipline added to agent guidance.
- /teach personalized-tutor skill under .claude/skills/teach.
Other aihero skills (grill-me/to-prd/to-issues/tdd/improve-arch) already covered by existing tooling — not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)