### PR TITLE
fix(ix-agent): ix_git_log commits == sum(series) (unbreak risk-report gate)

### DIFF
--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -2400,7 +2400,6 @@ pub fn git_log(params: Value) -> Result<Value, String> {
         .map(|l| l.trim())
         .filter(|l| !l.is_empty())
         .collect();
-    let total_commits = raw_dates.len();
 
     // Bucket the commits into a dense per-day or per-week series.
     let (n_buckets, bucket_size_days) = match bucket {
@@ -2435,13 +2434,22 @@ pub fn git_log(params: Value) -> Result<Value, String> {
         }
     }
 
+    // `commits` is the count of commits that actually fall inside the
+    // reported window, i.e. `sum(series)` — NOT the raw `git log` line
+    // count. They differ at the boundary: `--since="N days ago"` is
+    // time-of-day relative, so git returns a *superset* spanning a
+    // partial extra calendar day, while the series buckets exactly N
+    // calendar days. Reporting the in-window count keeps `commits ==
+    // sum(series)` true by construction, in every timezone.
+    let windowed_commits = series.iter().sum::<f64>().round() as u64;
+
     Ok(json!({
         "path": path,
         "since_days": since_days,
         "bucket": bucket,
         "window_days": since_days,
         "n_buckets": n_buckets,
-        "commits": total_commits,
+        "commits": windowed_commits,
         "series": series,
         "dates": dates,
     }))

--- a/crates/ix-agent/tests/git_log_smoke.rs
+++ b/crates/ix-agent/tests/git_log_smoke.rs
@@ -60,9 +60,11 @@ fn produces_90_day_series_for_ix_agent() {
 
     let total: f64 = series.iter().sum();
     let reported = result["commits"].as_u64().unwrap() as f64;
-    // series only contains commits that fell inside the window; the
-    // reported `commits` is the raw git log count, which for a 90-day
-    // window should match exactly.
+    // `commits` is the in-window count (== sum(series)), not the raw
+    // git log count. `--since="90 days ago"` is time-of-day relative
+    // and returns a superset spanning a partial extra calendar day;
+    // the series buckets exactly 90 calendar days. The handler reports
+    // the windowed count, so these match exactly by construction.
     assert!(
         (total - reported).abs() < 0.5,
         "series sum ({total}) should match reported commits ({reported})"


### PR DESCRIPTION
## Problem

The Agent Blackbox `risk-report` gate (`pwsh scripts/verify.ps1` → `cargo test --workspace`) is **red repo-wide** — it fails on unrelated PRs (#93, #94) and on doc-only changes. Root cause is a single time-dependent test failure:

```
crates/ix-agent/tests/git_log_smoke.rs:66
produces_90_day_series_for_ix_agent ... FAILED
series sum (84) should match reported commits (87)
```

`ix_git_log` reported `commits` as the **raw `git log` line count**. But `git log --since="N days ago"` is **time-of-day relative**: from 14:30 today, the cutoff is `today-90 @ 14:30`, so git returns a *superset* spanning a partial extra calendar day. The cadence `series`, however, buckets exactly **N calendar days** and drops that boundary day → `sum(series) < commits` at the boundary (84 vs 87).

This is why it **passes `build-and-test`** (UTC Linux runner, no boundary commit at that moment) but **fails `risk-report`** when a commit lands on the boundary day — a flaky-by-clock gate failure, not a real per-PR defect.

## Fix

Report `commits = sum(series)` — the count of commits that actually fall **inside the reported window**. This makes the documented `commits == sum(series)` invariant true **by construction**, in every timezone, with no extra git work (git always returns a superset that fully covers the window).

- `commits` is only consumed for display elsewhere (the showcase oracle prints it); the FFT cadence analysis runs over `series`, which is unchanged.
- Updated the test's stale comment to describe the corrected (now-true) semantic.

## Verification

- `cargo test -p ix-agent --test git_log_smoke` → 7/7 pass
- `cargo test -p ix-agent --test showcase_r1_migrations` → 9/9 pass (with `governance/demerzel` submodule initialized)
- `cargo fmt --all --check` → clean
- Full `pwsh scripts/verify.ps1` green once submodules are present (as in CI)

Once merged, #93/#94 pick this up via merge-from-main and `risk-report` goes green with **no override**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)