### PR TITLE
chore(agent-blackbox): bump ref to 90ed651 (case-insensitive harness-audit)

### DIFF
--- a/.github/workflows/agent-blackbox.yml
+++ b/.github/workflows/agent-blackbox.yml
@@ -12,9 +12,9 @@ permissions:
 
 # Pinning: AGENT_BLACKBOX_REF is a 40-char commit SHA (not main), per install-audit
 # scoring. Bump the SHA in a dedicated PR when consuming a new agent-blackbox release.
-# Latest agent-blackbox main commit as of 2026-05-17.
+# Latest agent-blackbox main commit as of 2026-06-14 (case-insensitive harness-audit paths, #36).
 env:
-  AGENT_BLACKBOX_REF: "942f808d3290441ab7d47e78a6b05e0e5587441d"
+  AGENT_BLACKBOX_REF: "90ed651c73a296c13c9b4953754a2f4898ac4114"
   VERIFY_COMMAND: "pwsh scripts/verify.ps1"
   IX_BLAST_RADIUS_BUILD_COMMAND: ""
   IX_BLAST_RADIUS_COMMAND: ""


### PR DESCRIPTION
Bumps `AGENT_BLACKBOX_REF` `942f808` → `90ed651` to pick up GuitarAlchemist/agent-blackbox#36 (case-insensitive repo-path resolution in `harness-audit`, with backtracking over case variants).

ix already scores 100/100 (it uses lowercase `scripts/`), so this is **hygiene** — keeping the whole ecosystem on one agent-blackbox version. The real beneficiary is tars (capital `Scripts/`), bumped in GuitarAlchemist/tars#36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)