### PR TITLE
docs(streeling): IX & DuckDB course (committed Streeling material)

### DIFF
--- a/docs/streeling/courses/ix-and-duckdb/MISSION.md
+++ b/docs/streeling/courses/ix-and-duckdb/MISSION.md
@@ -1,0 +1,27 @@
+# Mission — Learn IX & DuckDB
+
+**Started:** 2026-06-14 · **Tutor:** Claude (`/teach`)
+
+## Why
+Learn the project + how DuckDB is used across GA and IX, to **steer and review** development
+confidently (the "Learn" in the Learn→Ship→Steer loop, `docs/LEARNING.md`).
+
+## Goal
+**Steer & understand** — reason about the architecture and know *when/why* DuckDB is the right
+tool. Light on writing code.
+
+## Starting level
+Know SQL (SELECT / JOIN / GROUP BY). New to DuckDB specifics.
+
+## How I learn best
+Worked examples on real ix data (Streeling `catalog.jsonl`, `quality-snapshots/`, the
+`quality.duckdb` analytics layer).
+
+## Success criteria
+- [ ] Explain *why* ix uses DuckDB (SQL over on-disk state, zero ETL) and when not to.
+- [ ] Read any `build-views.sql` in the repo and say what each table/view does.
+- [ ] Judge whether a proposed "analytics over X" is a `.sql` file or a service.
+- [ ] Know the cross-repo producer/consumer SQL-parity story (ix produces, ga consumes).
+
+## Language
+English (French translation available on request — `feedback_french_docs`).

--- a/docs/streeling/courses/ix-and-duckdb/README.md
+++ b/docs/streeling/courses/ix-and-duckdb/README.md
@@ -1,0 +1,38 @@
+# Course: IX & DuckDB
+
+A Streeling University course — learn how DuckDB is used across IX (and GA), by querying
+ix's **real** on-disk catalogs. Built with `/teach`; committed here as institutional material
+(the "Learn" in Learn→Ship→Steer, `docs/LEARNING.md`).
+
+- **Audience:** know SQL, new to DuckDB; want to *steer & understand* (light on coding).
+- **Style:** worked examples on real ix data.
+- **Mission / success criteria:** [`MISSION.md`](./MISSION.md)
+- **Resources (verified):** [`RESOURCES.md`](./RESOURCES.md)
+- **Glossary:** [`reference/glossary.md`](./reference/glossary.md)
+
+## Lessons
+1. [SQL over files — and why ix leans on DuckDB](./lessons/01-sql-over-files.md)
+2. [A folder of daily files → one time-series table (`glob` + `filename`)](./lessons/02-glob-filename-timeseries.md)
+3. _next:_ `union_by_name` + `CREATE TABLE AS` — materializing the portable `quality.duckdb`
+
+## Play along — a DuckDB session in a separate terminal
+
+Open a terminal **at the repo root** (e.g. a Zed terminal tab) and launch a session with
+ix's catalogs pre-loaded as views:
+
+```bash
+duckdb -init docs/streeling/courses/ix-and-duckdb/playground.sql
+```
+
+You'll get views `learnings`, `chatbot_qa`, `embeddings`, `voicing_analysis` ready to query:
+
+```sql
+SELECT repo, count(*) FROM learnings GROUP BY ALL;
+SELECT day, round(pass_pct,1) FROM chatbot_qa ORDER BY day;
+```
+
+`duckdb` is on PATH (v1.5.3). The `.duckdb` analytics DB is regenerable — see
+`state/quality/analytics/` (gitignored binary; rebuild with its `build-views.sql`).
+
+## Progress
+- 2026-06-14: Lessons 1–2 delivered. Next: Lesson 3 (materialization / `quality.duckdb`).

--- a/docs/streeling/courses/ix-and-duckdb/README.md
+++ b/docs/streeling/courses/ix-and-duckdb/README.md
@@ -13,7 +13,7 @@ ix's **real** on-disk catalogs. Built with `/teach`; committed here as instituti
 ## Lessons
 1. [SQL over files — and why ix leans on DuckDB](./lessons/01-sql-over-files.md)
 2. [A folder of daily files → one time-series table (`glob` + `filename`)](./lessons/02-glob-filename-timeseries.md)
-3. _next:_ `union_by_name` + `CREATE TABLE AS` — materializing the portable `quality.duckdb`
+3. [Materializing the portable `quality.duckdb` (`union_by_name` + `CREATE TABLE AS`)](./lessons/03-materialize-quality-duckdb.md) — **capstone**
 
 ## Play along — a DuckDB session in a separate terminal
 
@@ -35,4 +35,5 @@ SELECT day, round(pass_pct,1) FROM chatbot_qa ORDER BY day;
 `state/quality/analytics/` (gitignored binary; rebuild with its `build-views.sql`).
 
 ## Progress
-- 2026-06-14: Lessons 1–2 delivered. Next: Lesson 3 (materialization / `quality.duckdb`).
+- 2026-06-14: Lessons 1–3 delivered (capstone reached — can read any `build-views.sql`).
+  Possible extensions: a Rust-lens lesson (`ix-duck` UDFs), or the cross-repo SAE-parity deep-dive.

--- a/docs/streeling/courses/ix-and-duckdb/RESOURCES.md
+++ b/docs/streeling/courses/ix-and-duckdb/RESOURCES.md
@@ -1,0 +1,28 @@
+# Resources — IX & DuckDB
+
+> Only real, verified sources: official docs + in-repo files you can open right now.
+
+## DuckDB (official)
+- **DuckDB docs (root):** https://duckdb.org/docs/ — start here.
+- **Friendly SQL** — ergonomic extensions (`GROUP BY ALL`, `SELECT * EXCLUDE`, `QUALIFY`):
+  search "Friendly SQL" at duckdb.org/docs.
+- **Reading files directly** (`read_json_auto`, `read_csv_auto`, `read_parquet`, globs,
+  `filename=`): the "Data Import" section of duckdb.org/docs.
+- **No-browser doc search:** the `duckdb-skills:duckdb-docs` skill (cached docs index).
+  `duckdb-skills:query` runs SQL.
+
+## In-repo (ground truth — open in Zed)
+- `docs/DUCKDB.md` — ix's DuckDB tier model + decisions.
+- `crates/ix-duck/` — in-process bench + ix algorithms as SQL UDFs (`src/udf.rs`,
+  `examples/yield_analysis.rs`, `examples/ix_quality_lens.rs`).
+- `state/streeling/catalog.jsonl` + `docs/streeling/queries.sql` — learnings catalog + 5
+  example registrar queries (Lesson 1).
+- `state/quality-snapshots/{chatbot-qa,embeddings,voicing-analysis}/*.json` — daily snapshot
+  folders (Lesson 2).
+- `state/quality/analytics/build-views.sql` — the quality-analytics materialization (Lesson 3;
+  shipped in PR #101). Mirrors `../ga/state/quality/analytics/build-views.sql`.
+
+## CLI
+- `duckdb` is on PATH (v1.5.3). Quick check: `duckdb -c "SELECT 42"`.
+- Query a file in place: `duckdb -c "SELECT * FROM read_json_auto('state/streeling/catalog.jsonl') LIMIT 5"`.
+- Ready session with catalogs loaded: `duckdb -init docs/streeling/courses/ix-and-duckdb/playground.sql` (run from repo root).

--- a/docs/streeling/courses/ix-and-duckdb/lessons/01-sql-over-files.md
+++ b/docs/streeling/courses/ix-and-duckdb/lessons/01-sql-over-files.md
@@ -1,0 +1,61 @@
+# Lesson 1 — DuckDB is SQL over your files (and why ix leans on it)
+
+**The one idea.** You know SQL as something you run *against a database* — load data in, then
+query. DuckDB flips that: it's an **in-process analytics engine** ("SQLite for analytics") that
+runs SQL **directly against files on disk** — JSON, JSONL, CSV, Parquet — with **no import step
+and no server**. You point SQL at a file path and it's a table.
+
+That single property is *why ix uses it*. ix already produces piles of on-disk state
+(`*.json`, `*.jsonl`) — learnings, quality snapshots, telemetry, catalogs. Before DuckDB,
+answering "how many learnings per repo?" meant writing a Rust/JS loader. With DuckDB it's one
+query. The three ix DuckDB surfaces are all the same move — *point SQL at our state*:
+- **`ix-duck`** — in-process bench + ix algorithms as SQL functions (over `hits.jsonl`)
+- **Streeling catalog** — learnings as a queryable table
+- **quality-analytics** — daily quality snapshots → `quality.duckdb` (PR #101)
+
+## Worked example (real, against `state/streeling/catalog.jsonl`)
+
+```sql
+SELECT repo, kind, count(*) AS n
+FROM read_json_auto('state/streeling/catalog.jsonl')   -- ← the whole trick is right here
+GROUP BY repo, kind ORDER BY n DESC;
+```
+```
+ga  solution    27
+ix  solution    17
+ix  plan        17
+ix  brainstorm  11
+```
+
+Three DuckDB-specific things a SQL-knower should notice:
+1. **`read_json_auto('…file…')` in the `FROM`** — the file *is* the table. No `CREATE TABLE`,
+   no load, no schema declaration; DuckDB infers columns. (Also `read_csv_auto`,
+   `read_parquet`, and glob paths like `'snapshots/*.json'`.)
+2. **It's still just SQL** — `GROUP BY`, `JOIN`, window functions all work unchanged.
+3. **"Friendly SQL"** — e.g. `GROUP BY ALL` groups by every non-aggregated column automatically:
+   ```sql
+   SELECT repo, count(*) AS learnings
+   FROM read_json_auto('state/streeling/catalog.jsonl')
+   GROUP BY ALL ORDER BY learnings DESC;   -- → ix 45, ga 27
+   ```
+
+**Why this matters for steering:** when someone proposes "let's add analytics over X," the
+reflex question becomes — *is X already on disk as JSON/JSONL?* If yes, the cost is a `.sql`
+file, not a new service. That's the lens behind every DuckDB decision in ix.
+
+## Self-check
+1. What has to happen to a JSON file before you can query it with DuckDB?
+2. ix has `state/quality-snapshots/embeddings/*.json` (one file per day). In one phrase, how
+   would you point DuckDB at *all* of them at once?
+3. Why is DuckDB a better fit than Postgres for ix's `state/` artifacts specifically?
+
+<details><summary>Answers</summary>
+
+1. **Nothing** — no import/load/schema. `read_json_auto('path')` reads it in place.
+2. A **glob**: `read_json_auto('state/quality-snapshots/embeddings/*.json')` (optionally
+   `filename=true` to recover which file each row came from → that's how the date is parsed).
+3. The data is **already files on disk, regenerable, queried in-process** — no server, no ETL.
+   Postgres would mean standing up a server and importing.
+</details>
+
+→ Next: [Lesson 2 — glob + filename → time-series](./02-glob-filename-timeseries.md)

--- a/docs/streeling/courses/ix-and-duckdb/lessons/02-glob-filename-timeseries.md
+++ b/docs/streeling/courses/ix-and-duckdb/lessons/02-glob-filename-timeseries.md
@@ -1,0 +1,54 @@
+# Lesson 2 — A folder of daily files → one time-series table (`glob` + `filename`)
+
+**The one idea.** Lesson 1 pointed SQL at *one* file. Real quality data is *one file per day*
+in a folder. DuckDB reads the whole folder with a **glob** (`*.json`), and `filename=true`
+adds a hidden column telling you which file each row came from — so you can **recover the date
+from the path** and get a time series. No loop, no per-file code.
+
+## Worked example (real, against `state/quality-snapshots/chatbot-qa/`)
+
+```sql
+SELECT regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) AS day,  -- date from path
+       round(pass_pct, 1) AS pass_pct
+FROM read_json_auto('state/quality-snapshots/chatbot-qa/*.json', filename=true)  -- glob + filename
+ORDER BY day;
+```
+```
+2026-04-12  19.5
+2026-04-13  19.5
+   …          …      ← 14 days, 2026-04-12 → 2026-04-25
+2026-04-25  19.5
+```
+
+The three moving parts:
+1. **`'…/*.json'`** — a glob; DuckDB reads every matching file as one table (14 days here).
+2. **`filename=true`** — adds the source path as a column. The files carry no `date` field
+   *inside*; the date lives in the **filename**, the canonical key across ix's quality pipeline.
+3. **`regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1)`** — pulls `YYYY-MM-DD` out
+   of the path into a real `day` column.
+
+**This is exactly the pattern in `state/quality/analytics/build-views.sql`** (PR #101):
+`CREATE TABLE … AS SELECT regexp_extract(filename,…) AS day … FROM read_json_auto('…/*.json',
+filename=true)`. You can now read that file and know what every line does.
+
+**A steering insight, free from the data:** `pass_pct` is **flat at 19.5 for all 14 days**.
+That's not a frozen chatbot — these are `deterministic-fixture-ci` snapshots (same fixtures in,
+same number out). A director's reflex: *"is this metric measuring reality or replaying a
+fixture?"* A flat line in a quality trend is a smell worth questioning — the "green-but-dead"
+trap ix's discipline warns about.
+
+## Self-check
+1. Two files lack the `pass_pct` field (older format). What happens, and which option makes it
+   tolerant?
+2. Where does the `day` value come from — inside the JSON, or somewhere else?
+3. You see a quality metric perfectly flat for weeks. What's your first question?
+
+<details><summary>Answers</summary>
+
+1. It can error on the missing column. **`union_by_name=true`** merges files by column *name*,
+   NULL-filling missing ones — how `build-views.sql` tolerates drift (Lesson 3).
+2. **The filename/path**, not the JSON body — parsed with `regexp_extract`.
+3. *"Is this real measurement or a deterministic fixture/cached value?"*
+</details>
+
+← [Lesson 1](./01-sql-over-files.md) · → _next: Lesson 3 — `union_by_name` + `CREATE TABLE AS` (materializing `quality.duckdb`)_

--- a/docs/streeling/courses/ix-and-duckdb/lessons/03-materialize-quality-duckdb.md
+++ b/docs/streeling/courses/ix-and-duckdb/lessons/03-materialize-quality-duckdb.md
@@ -1,0 +1,76 @@
+# Lesson 3 — Materializing the portable `quality.duckdb` (`union_by_name` + `CREATE TABLE AS`)
+
+**The one idea.** Lessons 1–2 queried files *live* — every run re-reads and re-infers the JSON.
+That's great for ad-hoc, but for a durable analytics layer you want two more things:
+**drift tolerance** (files change shape over time) and **materialization** (freeze the result
+into a real table so it's portable and fast). That's what `build-views.sql` does to produce
+`quality.duckdb` — and it's the whole quality-analytics layer (PR #101).
+
+## Part A — `union_by_name=true` (schema-drift tolerance)
+When a glob reads many files and an older one is missing a column (or a newer one adds
+`degraded`/`degraded_reason`), positional matching breaks. `union_by_name=true` merges files
+by **column name**, NULL-filling whatever's absent:
+```sql
+FROM read_json_auto('chatbot-qa/*.json', filename = true, union_by_name = true)
+```
+This is why ix's snapshots can evolve without breaking the pipeline. (Pair it with `TRY_CAST`
+so a stray string in a numeric column yields NULL instead of an error.)
+
+## Part B — `CREATE OR REPLACE TABLE … AS SELECT` (materialize)
+A *view* re-runs its query every time (and keeps the glob-path dependency). A **materialized
+table** runs the query once and stores the rows in the `.duckdb` file:
+```sql
+CREATE OR REPLACE TABLE ix_harness AS
+SELECT domain, emitted_at, metric_name, TRY_CAST(metric_value AS DOUBLE) AS metric_value, …
+FROM read_json_auto('ix-harness/last.json', filename = true, union_by_name = true);
+```
+Now `quality.duckdb` is **portable** — anything can open it (the Rust lens, the duckdb CLI,
+GA's tools) with no knowledge of the original JSON paths. Re-run the script to refresh.
+
+## Worked example (real — just built it)
+```bash
+# from state/quality/ :
+duckdb analytics/quality.duckdb < analytics/build-views.sql
+```
+```sql
+SHOW TABLES;
+-- ix_harness · optick_sae · quality_health · router_eval · quality_latest
+SELECT * FROM quality_latest;
+```
+```
+source          day         metric              metric_name
+optick_sae      2026-06-14  0.999559            reconstruction_r2
+ix_harness      2026-05-16  1.0                 harness_ready
+quality_health  2026-04-25  25.0                total_metrics
+router_eval     NULL        0.8193629899512…    test_macro_f1
+```
+- The first four are **materialized tables** (real rows, no glob); `quality_latest` is a
+  **view** over them — always current, zero path dependency, safe to query from anywhere.
+- **`optick_sae` has a real row** — the script reads GA's *consumed* SAE artifacts cross-repo
+  (`../../../ga/state/quality/optick-sae/*/optick-sae-artifact.json`). So **ix's analytics DB
+  queries the contract output it produces for GA**: SQL on both sides of one contract
+  (producer/consumer parity).
+
+## Why this matters for steering
+This is the full shape of an ix analytics layer: *glob the on-disk state → tolerate drift →
+materialize into a portable `.duckdb` → expose a `_latest` rollup view*. When you review a
+proposal, you can now check it against this pattern — and the `.duckdb` is a **regenerable,
+gitignored binary** (the SQL + README are the tracked source of truth).
+
+## Self-check
+1. Why materialize into tables instead of just keeping views over the JSON globs?
+2. What does `union_by_name=true` buy you, and what pairs well with it for numeric drift?
+3. `optick_sae` reads a file under `../../../ga/…` — what cross-repo idea is that demonstrating?
+
+<details><summary>Answers</summary>
+
+1. **Portability + speed + decoupling** — the `.duckdb` carries the rows with no dependency on
+   the original JSON paths, so any tool can open it; views would re-read the globs every time.
+2. Tolerance of **schema drift** (merge by name, NULL-fill missing columns); pair with
+   **`TRY_CAST`** so an off-type value becomes NULL instead of erroring.
+3. **Producer/consumer SQL parity** — ix produces the SAE artifact GA consumes; reading GA's
+   copy lets ix query the same contract as SQL, so both sides inspect identical fields.
+</details>
+
+← [Lesson 2](./02-glob-filename-timeseries.md) · **Course capstone reached** — you can now read
+any `build-views.sql` in the repo and explain every table, view, and the producer/consumer story.

--- a/docs/streeling/courses/ix-and-duckdb/playground.sql
+++ b/docs/streeling/courses/ix-and-duckdb/playground.sql
@@ -1,0 +1,35 @@
+-- ix DuckDB playground — a ready-to-query session over ix's on-disk catalogs.
+--
+-- Launch a persistent session in a separate terminal, FROM THE REPO ROOT:
+--   duckdb -init docs/streeling/courses/ix-and-duckdb/playground.sql
+--
+-- (The relative paths below resolve from the repo root, so launch there.)
+-- Then just type SQL. Examples:
+--   SELECT repo, count(*) FROM learnings GROUP BY ALL;
+--   SELECT day, round(pass_pct,1) FROM chatbot_qa ORDER BY day;
+
+-- Streeling learnings catalog (Lesson 1).
+CREATE OR REPLACE VIEW learnings AS
+  SELECT * FROM read_json_auto('state/streeling/catalog.jsonl');
+
+-- Daily quality snapshots as time-series, date parsed from the filename (Lesson 2).
+CREATE OR REPLACE VIEW chatbot_qa AS
+  SELECT regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) AS day, *
+  FROM read_json_auto('state/quality-snapshots/chatbot-qa/*.json', filename = true);
+
+CREATE OR REPLACE VIEW embeddings AS
+  SELECT regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) AS day, *
+  FROM read_json_auto('state/quality-snapshots/embeddings/*.json', filename = true);
+
+CREATE OR REPLACE VIEW voicing_analysis AS
+  SELECT regexp_extract(filename, '([0-9]{4}-[0-9]{2}-[0-9]{2})', 1) AS day, *
+  FROM read_json_auto('state/quality-snapshots/voicing-analysis/*.json', filename = true);
+
+-- The materialized quality-analytics DB (tables + quality_latest rollup), PR #101.
+-- It's a regenerable, gitignored binary; rebuild first if missing:
+--   duckdb state/quality/analytics/quality.duckdb < state/quality/analytics/build-views.sql
+-- Then uncomment to attach it read-only as schema `quality`:
+-- ATTACH 'state/quality/analytics/quality.duckdb' AS quality (READ_ONLY);
+
+.tables
+SELECT 'ix DuckDB playground ready — views: learnings, chatbot_qa, embeddings, voicing_analysis' AS hint;

--- a/docs/streeling/courses/ix-and-duckdb/playground.sql
+++ b/docs/streeling/courses/ix-and-duckdb/playground.sql
@@ -26,8 +26,9 @@ CREATE OR REPLACE VIEW voicing_analysis AS
   FROM read_json_auto('state/quality-snapshots/voicing-analysis/*.json', filename = true);
 
 -- The materialized quality-analytics DB (tables + quality_latest rollup), PR #101.
--- It's a regenerable, gitignored binary; rebuild first if missing:
---   duckdb state/quality/analytics/quality.duckdb < state/quality/analytics/build-views.sql
+-- It's a regenerable, gitignored binary; rebuild first if missing (build-views.sql
+-- uses globs relative to state/quality/, so run it FROM THERE):
+--   (cd state/quality && duckdb analytics/quality.duckdb < analytics/build-views.sql)
 -- Then uncomment to attach it read-only as schema `quality`:
 -- ATTACH 'state/quality/analytics/quality.duckdb' AS quality (READ_ONLY);
 

--- a/docs/streeling/courses/ix-and-duckdb/reference/glossary.md
+++ b/docs/streeling/courses/ix-and-duckdb/reference/glossary.md
@@ -1,0 +1,26 @@
+# Glossary — IX & DuckDB
+
+- **DuckDB** — in-process OLAP (analytics) engine; "SQLite for analytics." Runs SQL directly
+  against files (JSON/CSV/Parquet) with no server and no import step.
+- **In-process** — runs inside your program/CLI, not a separate server (contrast: Postgres).
+- **`read_json_auto('path')`** — table function reading a JSON/JSONL file (or glob) as a table,
+  inferring columns. Used in `FROM`. Siblings: `read_csv_auto`, `read_parquet`.
+- **Glob** — wildcard path like `'dir/*.json'`; DuckDB reads every match as one combined table.
+- **`filename=true`** — adds the source file path as a column, so you can recover per-file info
+  (e.g. the date) not present in the JSON body.
+- **`regexp_extract(s, pattern, group)`** — pulls a substring via regex; used to parse
+  `YYYY-MM-DD` out of a filename into a `day` column.
+- **Friendly SQL** — DuckDB's ergonomic extensions (`GROUP BY ALL`, `SELECT * EXCLUDE`, `QUALIFY`).
+- **`GROUP BY ALL`** — group by every non-aggregated column automatically.
+- **`CREATE OR REPLACE TABLE x AS SELECT …`** — materialize a query into a stored table (vs a
+  view); makes the `.duckdb` portable — re-run the script to refresh.
+- **`union_by_name=true`** — when reading many files, merge by column *name* (NULL-fill missing)
+  instead of by position — tolerates schema drift between snapshots.
+- **`ix-duck`** — ix crate wrapping in-process DuckDB + ix algorithms as SQL scalar UDFs;
+  `duckdb` crate with the `bundled` feature (compiles DuckDB from source → no system lib).
+- **Streeling catalog** — `state/streeling/catalog.jsonl`, the federated learnings index;
+  queryable as a DuckDB table.
+- **quality-analytics layer** — `state/quality/analytics/build-views.sql` → `quality.duckdb`;
+  materializes daily quality snapshots into tables + a `quality_latest` rollup (PR #101).
+- **Producer/consumer SQL parity** — ix *produces* artifacts (SAE, optick index) that ga
+  *consumes*; DuckDB lets both sides query the same contract as SQL.


### PR DESCRIPTION
## Summary
A `/teach` course on **IX & DuckDB**, committed under `docs/streeling/courses/` as Streeling University institutional material (per operator request — *not* gitignored personal scratch).

- **Level:** know SQL, new to DuckDB; *steer & understand*.
- **Style:** worked examples on **real ix data** (every query verified against the actual catalogs).
- Lessons 1–2 (+ Lesson 3 outlined), `MISSION.md`, verified `RESOURCES.md`, `reference/glossary.md`.
- **`playground.sql`** — `duckdb -init docs/streeling/courses/ix-and-duckdb/playground.sql` launches a ready-to-query session (views: `learnings`, `chatbot_qa`, `embeddings`, `voicing_analysis`) in a separate terminal. Verified loads + returns rows.

## Notes
- Outside the Streeling freshness-gate groups (`docs/solutions`/`state/knowledge`/`docs/plans`/`docs/brainstorms`), so no catalog regen needed.
- Follow-up option: teach the Streeling generator to index `courses/` as `kind:"course"` so courses show up in the catalog + DuckDB registrar.

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required`: docs + an init SQL script, no runtime/build surface. Validation = `playground.sql` loads (confirmed) and lessons render.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)