### PR TITLE
feat(ix-duck): loadable DuckDB extension (ix.duckdb_extension) for IX UDFs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,10 @@
 [workspace]
 resolver = "2"
+# ix-duck-ext is a loadable DuckDB C-API extension (cdylib). It is deliberately
+# EXCLUDED, not a member: as a member it would drag duckdb + arrow into every
+# `cargo build --workspace`, breaking the invariant that the default/CI build
+# never compiles DuckDB. Build it explicitly via crates/ix-duck-ext/build.ps1.
+exclude = ["crates/ix-duck-ext"]
 members = [
     "crates/ix-math",
     "crates/ix-optimize",

--- a/crates/ix-duck-ext/.gitignore
+++ b/crates/ix-duck-ext/.gitignore
@@ -1,0 +1,3 @@
+/target
+*.duckdb_extension
+*.duckdb_extension.tmp

--- a/crates/ix-duck-ext/Cargo.toml
+++ b/crates/ix-duck-ext/Cargo.toml
@@ -1,0 +1,27 @@
+# ix-duck-ext — loadable DuckDB C-API extension exposing IX UDFs.
+#
+# EXCLUDED from the ix workspace (see root Cargo.toml): building it must not be
+# part of `cargo build --workspace`. Build explicitly with build.ps1, which
+# compiles this cdylib, appends the DuckDB metadata footer, and emits
+# `ix.duckdb_extension`. Loadable into any duckdb.exe >= the C API min version
+# via:  duckdb -unsigned -c "LOAD 'ix.duckdb_extension'; SELECT ix_cosine(...);"
+#
+# Fields are hardcoded (not `*.workspace`) because excluded crates do not inherit
+# workspace package metadata.
+[package]
+name = "ix-duck-ext"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Loadable DuckDB C-API extension exposing IX algorithms (ix_cosine, ix_euclidean) as SQL UDFs."
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+# loadable-extension => C-API (C_STRUCT) path: binds DuckDB function pointers at
+# LOAD time, no bundled engine, engine-version-tolerant (declares min_duckdb_version).
+duckdb = { version = "=1.10503.1", default-features = false, features = ["loadable-extension"] }
+# The UDF surface, sans bundled engine (ix-duck's `udf` feature => duckdb/vscalar).
+ix-duck = { path = "../ix-duck", default-features = false, features = ["udf"] }

--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -59,6 +59,11 @@ pwsh ix-duck.ps1 -Database work.duckdb # open/persist a database file
 pwsh ix-duck.ps1 -Sql "SELECT ix_cosine([1,0]::DOUBLE[],[1,0]::DOUBLE[])"
 ```
 
+`examples.sql` has ready-made demos (kNN over a table, cosine ranking, PCA→2-D
+scatter, silhouette) — open it in the UI and run cells top to bottom. It also
+shows the `SET VARIABLE` + `getvariable()` bridge for feeding a table-built set
+into the table functions (whose args must be constant).
+
 ## How it works (and why it's not version-locked)
 
 Built via DuckDB's **C Extension API** (`C_STRUCT` ABI) through duckdb-rs's

--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -48,6 +48,17 @@ SELECT ix_cosine([1,0]::DOUBLE[], [1,0]::DOUBLE[]);    -- 1.0
 SELECT ix_euclidean([0,0]::DOUBLE[], [3,4]::DOUBLE[]); -- 5.0
 ```
 
+### One-word launch (`ix-duck.ps1`)
+
+Skips the `-unsigned` flag and manual `LOAD` (and builds the extension if missing):
+
+```powershell
+pwsh ix-duck.ps1                       # interactive CLI, ix_* ready
+pwsh ix-duck.ps1 -Ui                   # browser UI at http://localhost:4213
+pwsh ix-duck.ps1 -Database work.duckdb # open/persist a database file
+pwsh ix-duck.ps1 -Sql "SELECT ix_cosine([1,0]::DOUBLE[],[1,0]::DOUBLE[])"
+```
+
 ## How it works (and why it's not version-locked)
 
 Built via DuckDB's **C Extension API** (`C_STRUCT` ABI) through duckdb-rs's

--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -1,0 +1,64 @@
+# ix-duck-ext
+
+A **loadable DuckDB extension** exposing IX algorithms as SQL UDFs. The
+`LOAD`-able sibling of the in-process [`ix-duck`](../ix-duck) bench: it reuses the
+exact same registration (`ix_duck::udf::register_all`) but ships as a standalone
+`ix.duckdb_extension` that **any `duckdb.exe` can load** — no embedding host.
+
+## Functions
+
+### Scalar
+
+| UDF | Signature | Notes |
+|---|---|---|
+| `ix_cosine` | `(DOUBLE[], DOUBLE[]) -> DOUBLE` | Cosine similarity in [-1, 1]. Dimension mismatch → SQL error. |
+| `ix_euclidean` | `(DOUBLE[], DOUBLE[]) -> DOUBLE` | L2 distance. Primitive for kNN / OOD: `ORDER BY ix_euclidean(q, r) LIMIT k`. |
+
+### Table
+
+| UDF | Signature | Notes |
+|---|---|---|
+| `ix_pca_project` | `(json_vectors VARCHAR, n_components BIGINT) -> TABLE(row BIGINT, coords DOUBLE[])` | Fits PCA over the input set, returns each vector's projection. Wraps `ix_unsupervised::pca::PCA`. |
+| `ix_silhouette` | `(json_vectors VARCHAR, json_labels VARCHAR) -> TABLE(row BIGINT, label BIGINT, silhouette DOUBLE)` | Per-point silhouette for a clustering. Mean: `SELECT avg(silhouette) FROM ix_silhouette(...)`. |
+
+Scalars wrap `ix_math::distance` directly; the PCA table function wraps
+`ix_unsupervised` — no reimplementation, identical numbers to the in-process bench.
+Table functions take a whole set as a JSON param (2-D number array; labels a 1-D int
+array), so one SQL call processes the set:
+`SELECT * FROM ix_pca_project('[[1,2,3],[4,5,6]]', 2);`
+
+## Build
+
+```powershell
+pwsh crates/ix-duck-ext/build.ps1              # → ix.duckdb_extension
+pwsh crates/ix-duck-ext/build.ps1 -SmokeTest   # also LOAD into duckdb.exe and assert
+```
+
+Requires `cargo`, `python` (for the metadata footer), and `duckdb.exe` on PATH.
+This crate is **excluded** from the ix workspace, so `cargo build --workspace`
+never compiles it (preserving the "default/CI build never pulls DuckDB" invariant).
+
+## Use
+
+```sql
+-- Unsigned local extensions need the flag (startup config):
+--   duckdb -unsigned     OR     SET allow_unsigned_extensions=true; at launch
+LOAD 'C:/path/to/ix.duckdb_extension';
+SELECT ix_cosine([1,0]::DOUBLE[], [1,0]::DOUBLE[]);    -- 1.0
+SELECT ix_euclidean([0,0]::DOUBLE[], [3,4]::DOUBLE[]); -- 5.0
+```
+
+## How it works (and why it's not version-locked)
+
+Built via DuckDB's **C Extension API** (`C_STRUCT` ABI) through duckdb-rs's
+`loadable-extension` feature + `#[duckdb_entrypoint_c_api]`. DuckDB passes a struct
+of function pointers at `LOAD` time rather than the extension linking a specific
+engine, so one artifact loads into any engine **≥ the declared `min_duckdb_version`**
+(`v1.0.0` here) — verified loading into the v1.5.3 CLI. No bundled DuckDB, no C++
+build.
+
+A raw cdylib will not `LOAD` ("metadata at the end of the file is invalid"); DuckDB
+requires a 512-byte footer, appended by `append_extension_metadata.py` (vendored
+from `duckdb/extension-ci-tools`, MIT). `build.ps1` wires the whole chain.
+
+Provenance / design: GA `docs/plans/2026-06-15-tools-ix-duckdb-loadable-extension-plan.md`.

--- a/crates/ix-duck-ext/append_extension_metadata.py
+++ b/crates/ix-duck-ext/append_extension_metadata.py
@@ -1,0 +1,125 @@
+# Vendored verbatim from duckdb/extension-ci-tools (scripts/append_extension_metadata.py),
+# MIT-licensed. Appends DuckDB's 512-byte extension metadata footer so a raw cdylib
+# becomes a LOAD-able `.duckdb_extension`. Kept in-tree (rather than fetched at build
+# time) for reproducibility; re-sync from upstream if the footer format changes.
+import argparse
+import shutil
+
+def start_signature():
+    # This is needed so that Wasm binaries are valid
+    encoded_string = ''.encode('ascii')
+    # 0 for custom section
+    encoded_string += int(0).to_bytes(1, byteorder='big')
+    # 213 in hex = 531 in decimal, total lenght of what follows (1 + 16 + 2 + 8x32 + 256)
+    # [1(continuation) + 0010011(payload) = \x93 -> 147, 0(continuation) + 10(payload) = \x04 -> 4]
+    encoded_string += int(147).to_bytes(1, byteorder='big')
+    encoded_string += int(4).to_bytes(1, byteorder='big')
+    # 10 in hex = 16 in decimal, lenght of name, 1 byte
+    encoded_string += int(16).to_bytes(1, byteorder='big')
+    # the name of the WebAssembly custom section, 16 bytes
+    encoded_string += b'duckdb_signature'
+    # 1000 in hex, 512 in decimal
+    # [1(continuation) + 0000000(payload) = -> 128, 0(continuation) + 100(payload) -> 4],
+    encoded_string += int(128).to_bytes(1, byteorder='big')
+    encoded_string += int(4).to_bytes(1, byteorder='big')
+    return encoded_string
+
+def padded_byte_string(input):
+    encoded_string = input.encode('ascii')
+    encoded_string += b'\x00' * (32 - len(encoded_string))
+    return encoded_string
+
+def main():
+    arg_parser = argparse.ArgumentParser(description='Append extension metadata to loadable DuckDB extensions')
+
+    arg_parser.add_argument('-l','--library-file', type=str, help='Path to the raw shared library', required=True)
+    arg_parser.add_argument('-n', '--extension-name', type=str, help='Extension name to use', required=True)
+
+    arg_parser.add_argument('-o', '--out-file', type=str, help='Explicit path for the output file', default='')
+
+    # The platform
+    arg_parser.add_argument('-p', '--duckdb-platform', type=str, help='The DuckDB platform to encode')
+    arg_parser.add_argument('-pf', '--duckdb-platform-file', type=str, help='The file containing the DuckDB platform to encode')
+
+    arg_parser.add_argument('-dv', '--duckdb-version', type=str, help='The DuckDB version to encode, depending on the ABI type '
+                                                               'this encodes the duckdb version or the C API version', required=True)
+    arg_parser.add_argument('-ev', '--extension-version', type=str, help='The Extension version to encode')
+    arg_parser.add_argument('-evf', '--extension-version-file', type=str, help='The file containing the Extension version to encode')
+
+    arg_parser.add_argument('--abi-type', type=str, help='The ABI type to encode, set to C_STRUCT by default', default='C_STRUCT')
+
+    args = arg_parser.parse_args()
+
+    OUTPUT_FILE = args.out_file if args.out_file else args.extension_name + '.duckdb_extension'
+    OUTPUT_FILE_TMP = OUTPUT_FILE + ".tmp"
+
+    print("Creating extension binary:")
+
+    # Start with copying the library to a tmp file
+    print(f" - Input file: {args.library_file}")
+    print(f" - Output file: {OUTPUT_FILE}")
+    shutil.copyfile(args.library_file, OUTPUT_FILE_TMP)
+
+    # Handle the platform
+    PLATFORM = ""
+    if args.duckdb_platform:
+        PLATFORM = args.duckdb_platform
+    elif args.duckdb_platform_file:
+        try:
+            with open(args.duckdb_platform_file, 'r') as file:
+                PLATFORM = file.read().strip()
+        except Exception as e:
+            print(f"Failed to read platform from file {args.duckdb_platform_file}")
+            raise
+        if not PLATFORM:
+            raise Exception(f"Platform file passed to script is empty: {args.duckdb_platform_file}")
+    else:
+        raise Exception(f"Neither --duckdb-platform nor --duckdb-platform-file found, please specify the platform using either")
+
+    EXTENSION_VERSION = ""
+    if args.extension_version:
+        EXTENSION_VERSION = args.extension_version
+    elif args.extension_version_file:
+        try:
+            with open(args.extension_version_file, 'r') as file:
+                EXTENSION_VERSION = file.read().strip()
+        except Exception as e:
+            print(f"Failed to read extension version from file {args.extension_version_file}")
+            raise
+        if not EXTENSION_VERSION:
+            raise Exception(f"Extension version file passed to script is empty: {args.extension_version_file}")
+    else:
+        raise Exception(f"Neither --extension-version nor --extension-version-file found, please specify the extension version using either")
+
+
+
+    # Then append the metadata to the tmp file
+    print(f" - Metadata:")
+    with open(OUTPUT_FILE_TMP, 'ab') as file:
+        file.write(start_signature())
+        print(f"   - FIELD8 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD7 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD6 (unused)            = EMPTY")
+        file.write(padded_byte_string(""))
+        print(f"   - FIELD5 (abi_type)          = {args.abi_type}")
+        file.write(padded_byte_string(args.abi_type))
+        print(f"   - FIELD4 (extension_version) = {EXTENSION_VERSION}")
+        file.write(padded_byte_string(EXTENSION_VERSION))
+        print(f"   - FIELD3 (duckdb_version)    = {args.duckdb_version}")
+        file.write(padded_byte_string(args.duckdb_version))
+        print(f"   - FIELD2 (duckdb_platform)   = {PLATFORM}")
+        file.write(padded_byte_string(PLATFORM))
+        print(f"   - FIELD1 (header signature)  = 4 (special value to identify a duckdb extension)")
+        file.write(padded_byte_string("4"))
+
+        # Write some empty space for the signature
+        file.write(b"\x00" * 256)
+
+
+    # Finally we mv the tmp file to complete the process
+    shutil.move(OUTPUT_FILE_TMP, OUTPUT_FILE)
+
+if __name__ == '__main__':
+    main()

--- a/crates/ix-duck-ext/build.ps1
+++ b/crates/ix-duck-ext/build.ps1
@@ -1,0 +1,81 @@
+#!/usr/bin/env pwsh
+# build.ps1 — compile ix-duck-ext, append the DuckDB metadata footer, emit
+# `ix.duckdb_extension`, and (optionally) smoke-test it against a real duckdb.exe.
+#
+# This crate is EXCLUDED from the ix workspace (see root Cargo.toml), so the
+# default/CI `cargo build --workspace` never compiles DuckDB. Run this explicitly
+# when you want the loadable extension.
+#
+# Plan: docs/plans (GA) 2026-06-15-tools-ix-duckdb-loadable-extension-plan.md
+#
+#   pwsh crates/ix-duck-ext/build.ps1                 # build + footer
+#   pwsh crates/ix-duck-ext/build.ps1 -SmokeTest      # + LOAD into duckdb.exe and assert
+#
+# Requires: cargo, python (for append_extension_metadata.py), and duckdb.exe on
+# PATH (for the platform string + smoke test).
+[CmdletBinding()]
+param(
+    [string]$ExtName       = 'ix',
+    [string]$ExtVersion    = '0.1.0',
+    # C-API version encoded in the footer (C_STRUCT ABI). The extension loads into
+    # any engine >= this. Keep <= the oldest engine you must support.
+    [string]$CApiVersion   = 'v1.0.0',
+    [switch]$SmokeTest
+)
+$ErrorActionPreference = 'Stop'
+$root = $PSScriptRoot
+Push-Location $root
+try {
+    Write-Host '== cargo build --release ==' -ForegroundColor Cyan
+    cargo build --release
+    if ($LASTEXITCODE -ne 0) { throw "cargo build failed ($LASTEXITCODE)" }
+
+    $dll = Get-ChildItem "$root/target/release" -Filter '*.dll' |
+        Where-Object { $_.Name -like '*ix_duck_ext*' } | Select-Object -First 1
+    if (-not $dll) { throw 'cdylib not found in target/release (expected ix_duck_ext*.dll)' }
+    Write-Host " - cdylib: $($dll.FullName)"
+
+    # Resolve the DuckDB platform string from the CLI itself so the footer matches.
+    $platform = (& duckdb -noheader -list -c 'PRAGMA platform;').Trim()
+    if (-not $platform) { throw 'could not resolve duckdb platform (is duckdb.exe on PATH?)' }
+    Write-Host " - platform: $platform"
+
+    $out = Join-Path $root "$ExtName.duckdb_extension"
+    Write-Host '== append metadata footer (C_STRUCT) ==' -ForegroundColor Cyan
+    python "$root/append_extension_metadata.py" `
+        -l $dll.FullName -n $ExtName `
+        -dv $CApiVersion -p $platform -ev $ExtVersion `
+        --abi-type C_STRUCT -o $out
+    if ($LASTEXITCODE -ne 0) { throw "metadata append failed ($LASTEXITCODE)" }
+    Write-Host " - emitted: $out" -ForegroundColor Green
+
+    if ($SmokeTest) {
+        Write-Host '== smoke test (LOAD into duckdb.exe) ==' -ForegroundColor Cyan
+        $loadPath = $out -replace '\\', '/'
+
+        # Scalars: ix_cosine / ix_euclidean -> 1.0|0.0|5.0
+        $scalarSql = "LOAD '$loadPath';
+            SELECT ix_cosine([1.0,2.0,3.0]::DOUBLE[],[1.0,2.0,3.0]::DOUBLE[]) AS a,
+                   ix_cosine([1.0,0.0]::DOUBLE[],[0.0,1.0]::DOUBLE[])         AS b,
+                   ix_euclidean([0.0,0.0]::DOUBLE[],[3.0,4.0]::DOUBLE[])      AS c;"
+        $scalar = (& duckdb -unsigned -noheader -list -c $scalarSql).Trim()
+        Write-Host " - scalars: $scalar"
+        if ($scalar -notmatch '^1(\.0)?\|0(\.0)?\|5(\.0)?$') {
+            throw "SMOKE TEST FAILED (scalars) — expected '1.0|0.0|5.0', got '$scalar'"
+        }
+
+        # Table fns: ix_pca_project row count (4) | ix_silhouette mean rounded (1)
+        $tableSql = "LOAD '$loadPath';
+            SELECT (SELECT count(*) FROM ix_pca_project('[[1,2,3],[2,4,6],[3,6,9],[4,8,12]]', 1)) AS n,
+                   (SELECT round(avg(silhouette)) FROM ix_silhouette('[[0,0],[0,1],[10,10],[10,11]]','[0,0,1,1]')) AS s;"
+        $table = (& duckdb -unsigned -noheader -list -c $tableSql).Trim()
+        Write-Host " - table fns: $table"
+        if ($table -notmatch '^4\|1(\.0)?$') {
+            throw "SMOKE TEST FAILED (table fns) — expected '4|1.0', got '$table'"
+        }
+        Write-Host ' - PASS: scalar + table UDFs correct via LOAD' -ForegroundColor Green
+    }
+}
+finally {
+    Pop-Location
+}

--- a/crates/ix-duck-ext/examples.sql
+++ b/crates/ix-duck-ext/examples.sql
@@ -1,0 +1,78 @@
+-- examples.sql — ready-made IX-extension demos for the DuckDB UI.
+--
+-- Open this file in the DuckDB UI (http://localhost:4213) and run the cells
+-- top to bottom, or one section at a time. If you launched via ix-duck.ps1 the
+-- extension is already loaded; otherwise run the LOAD line first (adjust path).
+--
+-- Note on scalar vs table functions:
+--   * ix_cosine / ix_euclidean are SCALAR — they take two DOUBLE[] columns and
+--     work naturally per-row over a table (sections 2-3).
+--   * ix_pca_project / ix_silhouette are TABLE functions — they take a whole set
+--     as a constant JSON arg. DuckDB forbids subqueries in table-function args,
+--     so we stage the set into a session variable with SET VARIABLE and read it
+--     back with getvariable() (sections 4-5). That's the table→JSON→table bridge.
+
+-- 0) Load the extension (skip if launched via ix-duck.ps1 / build already loaded it).
+LOAD 'C:/Users/spare/source/repos/ix/crates/ix-duck-ext/ix.duckdb_extension';
+
+-- 1) A toy table of labelled 4-D embedding vectors — two rough families:
+--    "bright" (major-ish) and "tense" (dominant-ish).
+CREATE OR REPLACE TABLE voicings AS
+SELECT * FROM (VALUES
+  ('Cmaj7',  'bright', [0.00, 1.00, 0.00, 1.00]::DOUBLE[]),
+  ('Am7',    'bright', [0.10, 0.90, 0.10, 0.80]::DOUBLE[]),
+  ('Fmaj7',  'bright', [0.00, 1.00, 0.20, 0.90]::DOUBLE[]),
+  ('Em7',    'bright', [0.05, 0.95, 0.05, 0.85]::DOUBLE[]),
+  ('G7',     'tense',  [1.00, 0.00, 1.00, 0.00]::DOUBLE[]),
+  ('B7',     'tense',  [0.90, 0.10, 0.90, 0.20]::DOUBLE[]),
+  ('D7',     'tense',  [0.95, 0.05, 0.85, 0.10]::DOUBLE[]),
+  ('E7',     'tense',  [0.85, 0.15, 0.95, 0.05]::DOUBLE[])
+) AS t(name, family, vec);
+
+SELECT * FROM voicings;
+
+-- 2) kNN — the 4 nearest neighbours to Cmaj7 by L2 distance.
+--    ix_euclidean is the primitive: ORDER BY it, LIMIT k.
+SELECT name, family,
+       round(ix_euclidean((SELECT vec FROM voicings WHERE name = 'Cmaj7'), vec), 3) AS dist
+FROM voicings
+WHERE name <> 'Cmaj7'
+ORDER BY dist
+LIMIT 4;
+
+-- 3) Cosine similarity ranking against a query vector.
+SELECT name, family,
+       round(ix_cosine([0.0, 1.0, 0.0, 1.0]::DOUBLE[], vec), 3) AS cos_sim
+FROM voicings
+ORDER BY cos_sim DESC;
+
+-- 4) PCA → 2-D coordinates per voicing (good for a scatter plot in the UI).
+--    Stage the set + labels into session variables, then feed the table function.
+SET VARIABLE vecs  = (SELECT to_json(list(vec    ORDER BY name)) FROM voicings)::VARCHAR;
+SET VARIABLE names = (SELECT list(name   ORDER BY name) FROM voicings);
+SET VARIABLE fams  = (SELECT list(family ORDER BY name) FROM voicings);
+
+SELECT getvariable('names')[row + 1] AS name,     -- list is 1-based, row is 0-based
+       getvariable('fams')[row + 1]  AS family,
+       round(coords[1], 3) AS pc1,
+       round(coords[2], 3) AS pc2
+FROM ix_pca_project(getvariable('vecs'), 2)
+ORDER BY name;
+-- Tip: in the UI, switch this result to a scatter chart with x=pc1, y=pc2,
+-- colour=family — the two families separate cleanly along PC1.
+
+-- 5) Silhouette — how well does the "bright vs tense" labelling cluster?
+--    (Reuses 'vecs' and 'names' from section 4; sets the integer labels here.)
+SET VARIABLE labels =
+  (SELECT to_json(list(CASE family WHEN 'bright' THEN 0 ELSE 1 END ORDER BY name)) FROM voicings)::VARCHAR;
+
+-- Per-point coefficients (1 = deep in its cluster, < 0 = probably mislabeled):
+SELECT getvariable('names')[row + 1] AS name,
+       label,
+       round(silhouette, 3) AS silhouette
+FROM ix_silhouette(getvariable('vecs'), getvariable('labels'))
+ORDER BY silhouette DESC;
+
+-- ...and the single overall score:
+SELECT round(avg(silhouette), 3) AS mean_silhouette
+FROM ix_silhouette(getvariable('vecs'), getvariable('labels'));

--- a/crates/ix-duck-ext/ix-duck.ps1
+++ b/crates/ix-duck-ext/ix-duck.ps1
@@ -1,0 +1,48 @@
+#!/usr/bin/env pwsh
+# ix-duck.ps1 — launch duckdb.exe with the IX extension pre-loaded.
+#
+# Saves typing the `-unsigned` flag and the `LOAD '<abs path>'` every session.
+# Builds the extension first if it's missing.
+#
+#   pwsh ix-duck.ps1                       # interactive CLI, ix_* ready
+#   pwsh ix-duck.ps1 -Ui                   # browser UI (http://localhost:4213)
+#   pwsh ix-duck.ps1 -Database work.duckdb # open/persist a database file
+#   pwsh ix-duck.ps1 -Sql "SELECT ix_cosine([1,0]::DOUBLE[],[1,0]::DOUBLE[])"
+#
+# Tip: add this folder to PATH (or make an alias) so it's a one-word command:
+#   Set-Alias ixduck 'C:\Users\spare\source\repos\ix\crates\ix-duck-ext\ix-duck.ps1'
+[CmdletBinding()]
+param(
+    [switch]$Ui,                       # also start the browser UI
+    [string]$Database = '',            # optional database file (default: in-memory)
+    [string]$Sql = '',                 # run one SQL statement and exit (non-interactive)
+    [Parameter(ValueFromRemainingArguments = $true)]
+    $Rest                              # any extra duckdb args, passed through
+)
+$ErrorActionPreference = 'Stop'
+$root = $PSScriptRoot
+
+# duckdb.exe must be on PATH.
+if (-not (Get-Command duckdb -ErrorAction SilentlyContinue)) {
+    throw "duckdb.exe not found on PATH. Install DuckDB or add it to PATH."
+}
+
+# Build the extension on first use (or if it was cleaned away).
+$ext = Join-Path $root 'ix.duckdb_extension'
+if (-not (Test-Path $ext)) {
+    Write-Host "ix.duckdb_extension not found — building it…" -ForegroundColor Yellow
+    & (Join-Path $root 'build.ps1')
+    if (-not (Test-Path $ext)) { throw "build did not produce $ext" }
+}
+$extFwd = $ext -replace '\\', '/'   # LOAD wants forward slashes
+
+# -unsigned is required (local unsigned extension) and must be set at launch.
+# -cmd runs the LOAD before the prompt/UI/-c, so ix_* is ready immediately.
+$duckArgs = @('-unsigned', '-cmd', "LOAD '$extFwd'")
+if ($Ui)        { $duckArgs += '-ui' }
+if ($Sql)       { $duckArgs += @('-c', $Sql) }
+if ($Database)  { $duckArgs += $Database }   # positional db path
+if ($Rest)      { $duckArgs += $Rest }
+
+& duckdb @duckArgs
+exit $LASTEXITCODE

--- a/crates/ix-duck-ext/src/lib.rs
+++ b/crates/ix-duck-ext/src/lib.rs
@@ -1,0 +1,32 @@
+//! `ix-duck-ext` — loadable DuckDB C-API extension exposing IX algorithms as SQL.
+//!
+//! This cdylib is the `LOAD`-able sibling of the in-process `ix-duck` bench: it
+//! reuses the exact same UDF registration (`ix_duck::udf::register_all`) but ships
+//! as a standalone `ix.duckdb_extension` any `duckdb.exe` can load — no embedding
+//! host required.
+//!
+//! Built via the C-API (`C_STRUCT` ABI): DuckDB passes a struct of function
+//! pointers at LOAD time rather than the extension linking a specific engine, so
+//! one artifact is tolerant of engine versions >= the declared `min_duckdb_version`.
+//! A 512-byte metadata footer (appended by `build.ps1` /
+//! `append_extension_metadata.py`) is required before `LOAD` will accept the file.
+//!
+//! Usage:
+//! ```text
+//! duckdb -unsigned -c "LOAD 'ix.duckdb_extension';
+//!   SELECT ix_cosine([1,0]::DOUBLE[], [1,0]::DOUBLE[]);   -- 1.0
+//!   SELECT ix_euclidean([0,0]::DOUBLE[], [3,4]::DOUBLE[]); -- 5.0"
+//! ```
+
+use duckdb::{duckdb_entrypoint_c_api, Connection, Result};
+use std::error::Error;
+
+/// Extension entrypoint. The macro generates the C-API `ix_init_c_api` symbol
+/// DuckDB calls on `LOAD`; `ext_name` must match the metadata footer's name and
+/// the `ix.duckdb_extension` filename stem.
+#[duckdb_entrypoint_c_api(ext_name = "ix", min_duckdb_version = "v1.0.0")]
+pub fn ix_extension_init(con: Connection) -> Result<(), Box<dyn Error>> {
+    // Same registration the in-process bench uses — single source of truth.
+    ix_duck::udf::register_all(&con)?;
+    Ok(())
+}

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -8,17 +8,19 @@ repository.workspace = true
 description = "In-process DuckDB analyst bench over IX telemetry, with IX algorithms as SQL UDFs (optional `duck` feature)."
 
 [dependencies]
-# OPTIONAL, feature-gated: in-process DuckDB. The `bundled` feature compiles DuckDB
-# (C++) from source, so this is deliberately NOT in default features — the CI path
-# `cargo build --workspace` never pulls it. `json` enables read_json_auto over our
-# JSONL telemetry; `vscalar` enables scalar UDF registration (VScalar trait).
-# Build/run locally with `--features duck`. (Two-way door — optional dep; see docs/DUCKDB.md.)
+# OPTIONAL, feature-gated DuckDB. Features are routed through THIS crate's own
+# `udf` / `duck` features (below), NOT hardcoded here, so the loadable C-API
+# extension (ix-duck-ext) can pull the UDF surface WITHOUT a bundled engine:
+#   * `udf`  → duckdb/vscalar (+ vtab) only — pure-Rust, no C++ build. Compiles
+#              into the cdylib extension and registers ix_cosine/ix_euclidean.
+#   * `duck` → adds duckdb/bundled + json for the in-process analyst bench.
+# Deliberately NOT in default features — `cargo build --workspace` never pulls it.
 #
 # Pinned to an exact tested release: duckdb-rs + its arrow deps require a newer
-# toolchain than the workspace MSRV (1.80). That is acceptable because the `duck`
-# feature is opt-in and never built by the default/CI path — but we pin so the
+# toolchain than the workspace MSRV (1.80). That is acceptable because these
+# features are opt-in and never built by the default/CI path — but we pin so the
 # feature can't silently float onto a release needing an even newer rustc.
-duckdb = { version = "=1.10503.1", features = ["bundled", "json", "vscalar"], optional = true }
+duckdb = { version = "=1.10503.1", default-features = false, optional = true }
 ix-math = { workspace = true, optional = true }
 ix-unsupervised = { workspace = true, optional = true }
 ndarray = { workspace = true, optional = true }
@@ -28,8 +30,15 @@ serde_json = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 
 [features]
-# In-process DuckDB bench + IX UDFs. Off by default so the workspace/CI build stays clean.
-duck = ["dep:duckdb", "dep:ix-math", "dep:ix-unsupervised", "dep:ndarray", "dep:serde", "dep:serde_json", "dep:chrono"]
+# UDF-only surface: the IX scalar + table UDFs registrable on any DuckDB
+# connection. `duckdb/vscalar` implies vtab(-arrow) (covers both scalar and table
+# functions), so no bundled engine is pulled — this is the feature the loadable
+# C-API extension (ix-duck-ext) depends on. ix-unsupervised (PCA) + serde_json
+# (JSON params) are needed by the table functions.
+udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ndarray", "dep:serde_json"]
+# Full in-process DuckDB bench: UDFs + a bundled (C++) engine + json read + the
+# chatbot flight recorder. Off by default so the workspace/CI build stays clean.
+duck = ["udf", "duckdb/bundled", "duckdb/json", "dep:serde", "dep:chrono"]
 
 [[example]]
 name = "yield_analysis"

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -18,8 +18,16 @@
 //! # }
 //! ```
 
-#[cfg(feature = "duck")]
-mod udf;
+/// IX algorithms as DuckDB UDFs. Public + gated on `udf` (a subset of `duck`)
+/// so the loadable C-API extension crate can call [`udf::register_all`] without
+/// pulling a bundled engine.
+#[cfg(feature = "udf")]
+pub mod udf;
+
+/// IX algorithms as DuckDB *table* functions (ix_pca_project, ix_silhouette),
+/// registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod tablefn;
 
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
@@ -74,7 +82,11 @@ mod tests {
         let conn = open_bench().unwrap();
 
         let n: i64 = conn
-            .query_row(&format!("SELECT count(*) FROM read_json_auto('{path}')"), [], |r| r.get(0))
+            .query_row(
+                &format!("SELECT count(*) FROM read_json_auto('{path}')"),
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert_eq!(n, 3, "read_json_auto should see all 3 rows");
 
@@ -85,25 +97,43 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert!((avg - 0.6).abs() < 1e-9, "compiled yield should be 0.6, got {avg}");
+        assert!(
+            (avg - 0.6).abs() < 1e-9,
+            "compiled yield should be 0.6, got {avg}"
+        );
 
         // UDFs are registered + callable from SQL.
         let sim: f64 = conn
-            .query_row("SELECT ix_cosine([1.0, 0.0]::DOUBLE[], [1.0, 0.0]::DOUBLE[])", [], |r| r.get(0))
+            .query_row(
+                "SELECT ix_cosine([1.0, 0.0]::DOUBLE[], [1.0, 0.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
-        assert!((sim - 1.0).abs() < 1e-12, "ix_cosine should be registered, got {sim}");
+        assert!(
+            (sim - 1.0).abs() < 1e-12,
+            "ix_cosine should be registered, got {sim}"
+        );
     }
 
     #[test]
     fn ix_cosine_matches_ix_math() {
         let conn = open_bench().unwrap();
         let same: f64 = conn
-            .query_row("SELECT ix_cosine([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])", [], |r| r.get(0))
+            .query_row(
+                "SELECT ix_cosine([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!((same - 1.0).abs() < 1e-12, "identical → 1.0, got {same}");
 
         let orth: f64 = conn
-            .query_row("SELECT ix_cosine([1.0,0.0]::DOUBLE[], [0.0,1.0]::DOUBLE[])", [], |r| r.get(0))
+            .query_row(
+                "SELECT ix_cosine([1.0,0.0]::DOUBLE[], [0.0,1.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!(orth.abs() < 1e-12, "orthogonal → 0.0, got {orth}");
 
@@ -120,12 +150,20 @@ mod tests {
     fn ix_euclidean_matches_ix_math() {
         let conn = open_bench().unwrap();
         let d: f64 = conn
-            .query_row("SELECT ix_euclidean([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])", [], |r| r.get(0))
+            .query_row(
+                "SELECT ix_euclidean([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!((d - 5.0).abs() < 1e-12, "3-4-5 triangle → 5.0, got {d}");
 
         let z: f64 = conn
-            .query_row("SELECT ix_euclidean([1.0,2.0]::DOUBLE[], [1.0,2.0]::DOUBLE[])", [], |r| r.get(0))
+            .query_row(
+                "SELECT ix_euclidean([1.0,2.0]::DOUBLE[], [1.0,2.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
             .unwrap();
         assert!(z.abs() < 1e-12, "equal vectors → 0.0, got {z}");
     }

--- a/crates/ix-duck/src/tablefn.rs
+++ b/crates/ix-duck/src/tablefn.rs
@@ -1,0 +1,389 @@
+//! IX algorithms exposed as DuckDB *table* functions (via the `VTab` trait).
+//!
+//! - `ix_pca_project(json_vectors VARCHAR, n_components BIGINT)`
+//!     → `TABLE(row BIGINT, coords DOUBLE[])`. Fits PCA over the input vectors and
+//!     returns each projected onto the top `n_components` principal components.
+//!     Wraps `ix_unsupervised::pca::PCA` — no reimplementation.
+//! - `ix_silhouette(json_vectors VARCHAR, json_labels VARCHAR)`
+//!     → `TABLE(row BIGINT, label BIGINT, silhouette DOUBLE)`. Per-point silhouette
+//!     coefficient for the given clustering. Mean score:
+//!     `SELECT avg(silhouette) FROM ix_silhouette(...)`.
+//!
+//! A whole set enters in one SQL call as JSON scalar params (a 2-D number array
+//! for vectors, a 1-D int array for labels):
+//!   `SELECT * FROM ix_pca_project('[[1,2,3],[4,5,6]]', 2);`
+//!
+//! Rows are streamed in chunks of the output vector capacity, so result sets
+//! larger than one DuckDB vector are emitted correctly across repeated `func`
+//! calls via a cursor in the (Send+Sync) init data.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
+use duckdb::Connection;
+use ix_math::distance::euclidean;
+use ix_unsupervised::pca::PCA;
+use ix_unsupervised::traits::DimensionReducer;
+use ndarray::{Array1, Array2};
+
+/// Register every IX table function on `conn`.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_table_function::<IxPcaProject>("ix_pca_project")?;
+    conn.register_table_function::<IxSilhouette>("ix_silhouette")?;
+    Ok(())
+}
+
+/// Parse a JSON 2-D number array into a rectangular `(n_samples, n_features)` matrix.
+/// Errors (empty, ragged, non-JSON) surface as SQL errors, not panics.
+fn parse_matrix(json: &str) -> Result<Array2<f64>, Box<dyn std::error::Error>> {
+    let rows: Vec<Vec<f64>> =
+        serde_json::from_str(json).map_err(|e| format!("expected a JSON 2-D number array: {e}"))?;
+    if rows.is_empty() {
+        return Err("input vector set is empty".into());
+    }
+    let ncols = rows[0].len();
+    if ncols == 0 {
+        return Err("input vectors have zero dimensions".into());
+    }
+    if rows.iter().any(|r| r.len() != ncols) {
+        return Err("input vectors are not all the same length".into());
+    }
+    let n = rows.len();
+    let flat: Vec<f64> = rows.into_iter().flatten().collect();
+    Ok(Array2::from_shape_vec((n, ncols), flat)?)
+}
+
+// ── ix_pca_project ───────────────────────────────────────────────────────────
+
+#[repr(C)]
+struct PcaBind {
+    /// Projected coordinates: one inner Vec (length `k`) per input row.
+    projected: Vec<Vec<f64>>,
+    k: usize,
+}
+#[repr(C)]
+struct PcaInit {
+    cursor: AtomicUsize,
+}
+
+struct IxPcaProject;
+
+impl VTab for IxPcaProject {
+    type InitData = PcaInit;
+    type BindData = PcaBind;
+
+    // @ai:invariant ix_pca_project fits ix_unsupervised PCA over the JSON input vectors and emits one row per input with its projection onto min(n_components, n_features) components [T:test conf:0.85 src:ix_duck::tablefn::tests::pca_project_row_and_dim_count]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let json = bind.get_parameter(0).to_string();
+        let k_req = bind.get_parameter(1).to_int64();
+        if k_req < 1 {
+            return Err("n_components must be >= 1".into());
+        }
+        let x = parse_matrix(&json)?;
+        let k = (k_req as usize).min(x.ncols());
+
+        let mut pca = PCA::new(k);
+        let projected_mat = pca.fit_transform(&x); // (n_samples, k)
+        let projected: Vec<Vec<f64>> = (0..projected_mat.nrows())
+            .map(|r| projected_mat.row(r).to_vec())
+            .collect();
+
+        bind.add_result_column("row", LogicalTypeHandle::from(LogicalTypeId::Bigint));
+        bind.add_result_column(
+            "coords",
+            LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Double)),
+        );
+        Ok(PcaBind { projected, k })
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(PcaInit {
+            cursor: AtomicUsize::new(0),
+        })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        let init = func.get_init_data();
+        let n = bind.projected.len();
+        let start = init.cursor.load(Ordering::Relaxed);
+        if start >= n {
+            output.set_len(0);
+            return Ok(());
+        }
+        let cap = output.flat_vector(0).capacity();
+        let rows = (n - start).min(cap);
+
+        // col 0: row index (BIGINT)
+        {
+            let mut idx_vec = output.flat_vector(0);
+            let slice = unsafe { idx_vec.as_mut_slice_with_len::<i64>(rows) };
+            for (i, s) in slice.iter_mut().enumerate().take(rows) {
+                *s = (start + i) as i64;
+            }
+        }
+        // col 1: coords (LIST<DOUBLE>) — flatten this chunk's rows into the child
+        // buffer, then point each row's (offset, length) entry at its slice.
+        {
+            let k = bind.k;
+            let total = rows * k;
+            let flat: Vec<f64> = (0..rows)
+                .flat_map(|i| bind.projected[start + i].iter().copied())
+                .collect();
+            let mut lv = output.list_vector(1);
+            {
+                let mut child = lv.child(total);
+                let cslice = unsafe { child.as_mut_slice_with_len::<f64>(total) };
+                cslice[..total].copy_from_slice(&flat);
+            }
+            lv.set_len(total);
+            for i in 0..rows {
+                lv.set_entry(i, i * k, k);
+            }
+        }
+        output.set_len(rows);
+        init.cursor.store(start + rows, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        ])
+    }
+}
+
+// ── ix_silhouette ────────────────────────────────────────────────────────────
+
+#[repr(C)]
+struct SilBind {
+    labels: Vec<i64>,
+    sil: Vec<f64>,
+}
+#[repr(C)]
+struct SilInit {
+    cursor: AtomicUsize,
+}
+
+struct IxSilhouette;
+
+impl VTab for IxSilhouette {
+    type InitData = SilInit;
+    type BindData = SilBind;
+
+    // @ai:invariant ix_silhouette emits one row per point with its silhouette coefficient (b-a)/max(a,b); well-separated clusters -> ~1, single cluster -> 0 [T:test conf:0.85 src:ix_duck::tablefn::tests::silhouette_separated_clusters_near_one]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let x = parse_matrix(&bind.get_parameter(0).to_string())?;
+        let labels: Vec<i64> = serde_json::from_str(&bind.get_parameter(1).to_string())
+            .map_err(|e| format!("expected a JSON int array for labels: {e}"))?;
+        if labels.len() != x.nrows() {
+            return Err(format!(
+                "labels length ({}) != number of vectors ({})",
+                labels.len(),
+                x.nrows()
+            )
+            .into());
+        }
+        let sil = silhouette_per_point(&x, &labels)?;
+        bind.add_result_column("row", LogicalTypeHandle::from(LogicalTypeId::Bigint));
+        bind.add_result_column("label", LogicalTypeHandle::from(LogicalTypeId::Bigint));
+        bind.add_result_column("silhouette", LogicalTypeHandle::from(LogicalTypeId::Double));
+        Ok(SilBind { labels, sil })
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(SilInit {
+            cursor: AtomicUsize::new(0),
+        })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        let init = func.get_init_data();
+        let n = bind.sil.len();
+        let start = init.cursor.load(Ordering::Relaxed);
+        if start >= n {
+            output.set_len(0);
+            return Ok(());
+        }
+        let cap = output.flat_vector(0).capacity();
+        let rows = (n - start).min(cap);
+
+        {
+            let mut v = output.flat_vector(0);
+            let s = unsafe { v.as_mut_slice_with_len::<i64>(rows) };
+            for (i, slot) in s.iter_mut().enumerate().take(rows) {
+                *slot = (start + i) as i64;
+            }
+        }
+        {
+            let mut v = output.flat_vector(1);
+            let s = unsafe { v.as_mut_slice_with_len::<i64>(rows) };
+            for (i, slot) in s.iter_mut().enumerate().take(rows) {
+                *slot = bind.labels[start + i];
+            }
+        }
+        {
+            let mut v = output.flat_vector(2);
+            let s = unsafe { v.as_mut_slice_with_len::<f64>(rows) };
+            for (i, slot) in s.iter_mut().enumerate().take(rows) {
+                *slot = bind.sil[start + i];
+            }
+        }
+        output.set_len(rows);
+        init.cursor.store(start + rows, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        ])
+    }
+}
+
+/// Per-point silhouette coefficient `s(i) = (b - a) / max(a, b)`, where `a` is the
+/// mean intra-cluster distance and `b` the mean distance to the nearest other
+/// cluster. `s = 0` when the point's cluster is a singleton or is the only cluster
+/// (silhouette undefined there, by convention).
+fn silhouette_per_point(
+    x: &Array2<f64>,
+    labels: &[i64],
+) -> Result<Vec<f64>, Box<dyn std::error::Error>> {
+    let n = x.nrows();
+    let pts: Vec<Array1<f64>> = (0..n).map(|i| x.row(i).to_owned()).collect();
+    let mut clusters: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for (i, &l) in labels.iter().enumerate() {
+        clusters.entry(l).or_default().push(i);
+    }
+    let mut out = vec![0.0; n];
+    if clusters.len() < 2 {
+        return Ok(out); // undefined with a single cluster
+    }
+    for i in 0..n {
+        let li = labels[i];
+        let own = &clusters[&li];
+        let a = if own.len() <= 1 {
+            0.0
+        } else {
+            let mut sum = 0.0;
+            for &j in own {
+                if j != i {
+                    sum += euclidean(&pts[i], &pts[j])?;
+                }
+            }
+            sum / (own.len() - 1) as f64
+        };
+        let mut b = f64::INFINITY;
+        for (&l, members) in &clusters {
+            if l == li {
+                continue;
+            }
+            let mut sum = 0.0;
+            for &j in members {
+                sum += euclidean(&pts[i], &pts[j])?;
+            }
+            let mean = sum / members.len() as f64;
+            if mean < b {
+                b = mean;
+            }
+        }
+        let denom = a.max(b);
+        out[i] = if denom > 0.0 { (b - a) / denom } else { 0.0 };
+    }
+    Ok(out)
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    #[test]
+    fn pca_project_row_and_dim_count() {
+        let conn = open_bench().unwrap();
+        // 4 collinear 3-D points → project to 1 component.
+        let n: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM ix_pca_project('[[1,2,3],[2,4,6],[3,6,9],[4,8,12]]', 1)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 4, "one row per input vector");
+
+        let dim: i64 = conn
+            .query_row(
+                "SELECT len(coords) FROM ix_pca_project('[[1,2,3],[2,4,6],[3,6,9],[4,8,12]]', 1) LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dim, 1, "coords length == n_components");
+    }
+
+    #[test]
+    fn pca_project_caps_components_at_feature_count() {
+        let conn = open_bench().unwrap();
+        // Ask for 5 components on 2-D data → capped at 2.
+        let dim: i64 = conn
+            .query_row(
+                "SELECT len(coords) FROM ix_pca_project('[[0,0],[1,1],[2,2]]', 5) LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dim, 2, "n_components capped at n_features");
+    }
+
+    #[test]
+    fn silhouette_separated_clusters_near_one() {
+        let conn = open_bench().unwrap();
+        // Two tight, far-apart clusters → mean silhouette near 1.
+        let avg: f64 = conn
+            .query_row(
+                "SELECT avg(silhouette) FROM ix_silhouette('[[0,0],[0,1],[10,10],[10,11]]', '[0,0,1,1]')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            avg > 0.8,
+            "well-separated clusters → high silhouette, got {avg}"
+        );
+
+        let n: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM ix_silhouette('[[0,0],[0,1],[10,10],[10,11]]', '[0,0,1,1]')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 4, "one row per point");
+    }
+
+    #[test]
+    fn silhouette_single_cluster_is_zero() {
+        let conn = open_bench().unwrap();
+        let avg: f64 = conn
+            .query_row(
+                "SELECT avg(silhouette) FROM ix_silhouette('[[0,0],[1,1],[2,2]]', '[0,0,0]')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            avg.abs() < 1e-12,
+            "single cluster → silhouette 0, got {avg}"
+        );
+    }
+}

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -5,9 +5,8 @@
 //! reimplementation). `ix_euclidean` is the primitive for the kNN-distance / OOD
 //! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`).
 //!
-//! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions,
-//! deferred to a follow-up plan — see
-//! docs/plans/2026-06-14-001-feat-ix-duck-duckdb-udfs-plan.md.
+//! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions
+//! in the sibling `tablefn` module; [`register_all`] registers both surfaces.
 
 use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
@@ -35,7 +34,10 @@ fn read_list_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<Vec<f
     let cap = entries.iter().map(|(o, l)| o + l).max().unwrap_or(0);
     let child = lv.child(cap);
     let all = unsafe { child.as_slice_with_len::<f64>(cap) };
-    entries.iter().map(|&(o, l)| all[o..o + l].to_vec()).collect()
+    entries
+        .iter()
+        .map(|&(o, l)| all[o..o + l].to_vec())
+        .collect()
 }
 
 /// Shared row-wise driver: read two `LIST<DOUBLE>` columns, apply `metric`
@@ -107,9 +109,11 @@ impl VScalar for IxEuclidean {
     }
 }
 
-/// Register every IX UDF on `conn`.
+/// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`) and
+/// table (`ix_pca_project`, `ix_silhouette`) functions.
 pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxCosine>("ix_cosine")?;
     conn.register_scalar_function::<IxEuclidean>("ix_euclidean")?;
+    crate::tablefn::register(conn)?;
     Ok(())
 }


### PR DESCRIPTION
## What

Packages the in-process IX UDFs as a **`LOAD`-able DuckDB extension** so any bare `duckdb.exe` can use them — no embedding host required. Sibling of the `ix-duck` analyst bench; reuses the exact same registration (single source of truth).

```sql
LOAD 'ix.duckdb_extension';
SELECT ix_euclidean(q, r) FROM voicings ORDER BY 1 LIMIT 10;        -- kNN in a bare CLI
SELECT * FROM ix_pca_project('[[1,2,3],[4,5,6]]', 2);              -- table function
SELECT avg(silhouette) FROM ix_silhouette('[[0,0],[10,10]]','[0,1]');
```

## Functions (v0.1)

| Kind | UDF | Signature |
|---|---|---|
| scalar | `ix_cosine` / `ix_euclidean` | `(DOUBLE[], DOUBLE[]) -> DOUBLE` |
| table | `ix_pca_project` | `(json_vectors VARCHAR, n_components BIGINT) -> TABLE(row BIGINT, coords DOUBLE[])` |
| table | `ix_silhouette` | `(json_vectors VARCHAR, json_labels VARCHAR) -> TABLE(row BIGINT, label BIGINT, silhouette DOUBLE)` |

Scalars wrap `ix_math::distance`; PCA wraps `ix_unsupervised::pca::PCA`. Silhouette is implemented from scratch (it did not exist in ix) over `ix_math` euclidean.

## How

- **Feature refactor** in `ix-duck`: new `udf` feature pulls `duckdb/vscalar` only — **no bundled engine** (`--features udf` checks in 8.7s, no C++). `duck` = `udf` + bundled bench.
- **New crate `ix-duck-ext`** (cdylib): C-API extension via `#[duckdb_entrypoint_c_api]` → `ix_duck::udf::register_all`. **Excluded from the workspace** so `cargo build --workspace` still never compiles DuckDB (preserves the build invariant).
- **C-API (`C_STRUCT`) path → engine-version-tolerant**: built declaring `min_duckdb_version v1.0.0`, loads into the v1.5.3 CLI. No version lock, no C++ toolchain.
- `build.ps1`: `cargo build` → append DuckDB metadata footer (vendored MIT `append_extension_metadata.py`) → `ix.duckdb_extension`; `-SmokeTest` LOADs into `duckdb.exe` and asserts.

## Verification

- **16 bench tests pass** (`cargo test -p ix-duck --features duck`), +4 new table-function tests.
- Default `cargo build` of `ix-duck` (no features) pulls no DuckDB — invariant intact.
- Loadable smoke test in `duckdb.exe` v1.5.3: scalars `1.0|0.0|5.0`, table fns `4|1.0` — **PASS**.

Plan & design notes: GA `docs/plans/2026-06-15-tools-ix-duckdb-loadable-extension-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)