### PR TITLE
feat(ix-duck): music-theory + graph + signal UDFs (8 new)

### DIFF
--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -13,6 +13,10 @@ exact same registration (`ix_duck::udf::register_all`) but ships as a standalone
 |---|---|---|
 | `ix_cosine` | `(DOUBLE[], DOUBLE[]) -> DOUBLE` | Cosine similarity in [-1, 1]. Dimension mismatch → SQL error. |
 | `ix_euclidean` | `(DOUBLE[], DOUBLE[]) -> DOUBLE` | L2 distance. Primitive for kNN / OOD: `ORDER BY ix_euclidean(q, r) LIMIT k`. |
+| `ix_forte_number` | `(BIGINT[]) -> VARCHAR` | Forte set-class of the notes (mod 12), e.g. `"3-11"`; NULL if unclassifiable. Wraps `ix-bracelet`. |
+| `ix_icv` | `(BIGINT[]) -> VARCHAR` | Interval-class vector, e.g. `"<0,0,1,1,1,0>"`. |
+| `ix_prime_form` | `(BIGINT[]) -> VARCHAR` | Bracelet prime form, e.g. `"[0,3,7]"`. |
+| `ix_classify_triad` | `(BIGINT[]) -> VARCHAR` | `"<root> major\|minor"`, or NULL if not a consonant triad. |
 
 ### Table
 
@@ -25,6 +29,10 @@ exact same registration (`ix_duck::udf::register_all`) but ships as a standalone
 | `ix_kmeans` | `(json_vectors VARCHAR, k BIGINT) -> TABLE(row BIGINT, cluster BIGINT)` | Centroid (k-means) labels `0..k-1`, deterministic (`k` capped at sample count). |
 | `ix_gmm` | `(json_vectors VARCHAR, k BIGINT) -> TABLE(row BIGINT, cluster BIGINT)` | Gaussian-mixture component labels `0..k-1` — soft-assignment counterpart to `ix_kmeans`. |
 | `ix_optick_scan` | `(index_path VARCHAR) -> TABLE(voicing BIGINT, instrument VARCHAR, embedding DOUBLE[])` | **Tier 3:** the production OPTIC-K `optick.index` mmap as a table — no Parquet export. Wraps `ix_optick::OptickIndex`. Voicing distance = `ix_euclidean` over two rows. |
+| `ix_pagerank` | `(edges_json VARCHAR, damping DOUBLE, iterations BIGINT) -> TABLE(node BIGINT, rank DOUBLE)` | PageRank over a JSON edge list `[[from,to(,w)],…]`. Wraps `ix-graph`. |
+| `ix_shortest_path` | `(edges_json VARCHAR, src BIGINT, dst BIGINT) -> TABLE(step BIGINT, node BIGINT)` | Dijkstra path src→dst (empty if unreachable). |
+| `ix_rfft` | `(series_json VARCHAR) -> TABLE(bin BIGINT, magnitude DOUBLE)` | Real-FFT magnitude spectrum of a JSON number series. Wraps `ix-signal`. |
+| `ix_autocorrelation` | `(series_json VARCHAR) -> TABLE(lag BIGINT, value DOUBLE)` | Two-sided normalized autocorrelation; lag 0 = 1.0 peak. |
 
 Scalars wrap `ix_math::distance` directly; the PCA table function wraps
 `ix_unsupervised` — no reimplementation, identical numbers to the in-process bench.

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -23,6 +23,9 @@ description = "In-process DuckDB analyst bench over IX telemetry, with IX algori
 duckdb = { version = "=1.10503.1", default-features = false, optional = true }
 ix-math = { workspace = true, optional = true }
 ix-unsupervised = { workspace = true, optional = true }
+ix-bracelet = { workspace = true, optional = true }
+ix-graph = { workspace = true, optional = true }
+ix-signal = { workspace = true, optional = true }
 ndarray = { workspace = true, optional = true }
 # Chatbot flight recorder (Slice A/B): the regression gate serializes a JSON contract.
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -35,7 +38,7 @@ chrono = { workspace = true, optional = true }
 # functions), so no bundled engine is pulled — this is the feature the loadable
 # C-API extension (ix-duck-ext) depends on. ix-unsupervised (PCA) + serde_json
 # (JSON params) are needed by the table functions.
-udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ndarray", "dep:serde_json"]
+udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ix-bracelet", "dep:ix-graph", "dep:ix-signal", "dep:ndarray", "dep:serde_json"]
 # Full in-process DuckDB bench: UDFs + a bundled (C++) engine + json read + the
 # chatbot flight recorder. Off by default so the workspace/CI build stays clean.
 duck = ["udf", "duckdb/bundled", "duckdb/json", "duckdb/parquet", "dep:serde", "dep:chrono"]

--- a/crates/ix-duck/src/bracelet.rs
+++ b/crates/ix-duck/src/bracelet.rs
@@ -1,0 +1,193 @@
+//! Music set-theory scalar UDFs over pitch-class sets (`ix-bracelet`).
+//!
+//! Each takes a `BIGINT[]` of pitch values (MIDI notes or pitch classes — values
+//! are reduced mod 12, so a voicing's `midiNotes` work directly) and returns a
+//! VARCHAR characterising the pitch-class *set*:
+//!
+//! - `ix_forte_number(notes)` → Forte set-class id, e.g. `"3-11"` (NULL if none).
+//! - `ix_icv(notes)`          → interval-class vector, e.g. `"<0,0,1,1,1,0>"`.
+//! - `ix_prime_form(notes)`   → bracelet prime form, e.g. `"[0,3,7]"`.
+//! - `ix_classify_triad(notes)` → `"<root> major|minor"` (NULL if not a triad).
+//!
+//! The headline use: annotate / group the OPTIC-K voicing corpus by music theory —
+//! `SELECT ix_forte_number(midiNotes) AS sc, count(*) FROM read_json_auto(
+//! 'state/voicings/raw/guitar.jsonl') GROUP BY sc ORDER BY count(*) DESC`. Nothing
+//! else does set-class analysis in SQL. Pure wraps of `ix_bracelet` — no math here.
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_bracelet::forte::forte_number;
+use ix_bracelet::grothendieck::icv;
+use ix_bracelet::neo_riemannian::{classify_triad, TriadKind};
+use ix_bracelet::pc_set::PcSet;
+use ix_bracelet::prime_form::bracelet_prime_form;
+use std::ffi::CString;
+
+fn list_bigint() -> LogicalTypeHandle {
+    LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Bigint))
+}
+
+/// Read a `LIST<BIGINT>` column into one [`PcSet`] per row (values reduced mod 12;
+/// `rem_euclid` so negative ints map correctly). Mirrors `udf::read_list_col` but
+/// for integers; reads entries before borrowing the child buffer (no aliasing).
+fn read_pcsets(input: &mut DataChunkHandle, n: usize) -> Vec<PcSet> {
+    let lv = input.list_vector(0);
+    let entries: Vec<(usize, usize)> = (0..n).map(|i| lv.get_entry(i)).collect();
+    let cap = entries.iter().map(|(o, l)| o + l).max().unwrap_or(0);
+    let child = lv.child(cap);
+    let all = unsafe { child.as_slice_with_len::<i64>(cap) };
+    entries
+        .iter()
+        .map(|&(o, l)| PcSet::from_pcs(all[o..o + l].iter().map(|&v| v.rem_euclid(12) as u8)))
+        .collect()
+}
+
+/// Shared driver: map each row's PcSet through `f`; `None` → SQL NULL.
+fn invoke_pcset_str(
+    input: &mut DataChunkHandle,
+    output: &mut dyn WritableVector,
+    f: impl Fn(PcSet) -> Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let n = input.len();
+    let sets = read_pcsets(input, n);
+    let mut out = output.flat_vector();
+    for (i, &s) in sets.iter().enumerate() {
+        match f(s) {
+            Some(v) => out.insert(i, CString::new(v)?),
+            None => out.set_null(i),
+        }
+    }
+    Ok(())
+}
+
+fn varchar_sig() -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![list_bigint()],
+        LogicalTypeHandle::from(LogicalTypeId::Varchar),
+    )]
+}
+
+struct IxForteNumber;
+impl VScalar for IxForteNumber {
+    type State = ();
+    // @ai:invariant ix_forte_number renders ix_bracelet forte_number of the PC-set (notes mod 12); {0,4,7} -> "3-11", non-classifiable -> SQL NULL [T:test conf:0.9 src:ix_duck::bracelet::tests::forte_number_major_triad]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pcset_str(input, output, |s| forte_number(s).map(|f| f.to_string()))
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxIcv;
+impl VScalar for IxIcv {
+    type State = ();
+    // @ai:invariant ix_icv renders ix_bracelet icv (6 interval-class counts) as "<a,b,c,d,e,f>"; major triad {0,4,7} -> "<0,0,1,1,1,0>" [T:test conf:0.9 src:ix_duck::bracelet::tests::icv_major_triad]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pcset_str(input, output, |s| {
+            let d = icv(s).data;
+            Some(format!("<{},{},{},{},{},{}>", d[0], d[1], d[2], d[3], d[4], d[5]))
+        })
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxPrimeForm;
+impl VScalar for IxPrimeForm {
+    type State = ();
+    // @ai:invariant ix_prime_form renders ix_bracelet bracelet_prime_form pitch classes as "[p,...]"; major triad {0,4,7} -> "[0,3,7]" [T:test conf:0.9 src:ix_duck::bracelet::tests::prime_form_major_triad]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pcset_str(input, output, |s| {
+            let pcs: Vec<String> = bracelet_prime_form(s).iter_pcs().map(|p| p.to_string()).collect();
+            Some(format!("[{}]", pcs.join(",")))
+        })
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxClassifyTriad;
+impl VScalar for IxClassifyTriad {
+    type State = ();
+    // @ai:invariant ix_classify_triad renders ix_bracelet classify_triad as "<root> major|minor"; {0,4,7} -> "0 major", non-triad -> SQL NULL [T:test conf:0.9 src:ix_duck::bracelet::tests::classify_triad_major_and_nontriad]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pcset_str(input, output, |s| {
+            classify_triad(s).map(|(root, kind)| {
+                let k = match kind {
+                    TriadKind::Major => "major",
+                    TriadKind::Minor => "minor",
+                };
+                format!("{root} {k}")
+            })
+        })
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+/// Register the music set-theory scalar UDFs.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxForteNumber>("ix_forte_number")?;
+    conn.register_scalar_function::<IxIcv>("ix_icv")?;
+    conn.register_scalar_function::<IxPrimeForm>("ix_prime_form")?;
+    conn.register_scalar_function::<IxClassifyTriad>("ix_classify_triad")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    // C major triad as MIDI notes (60,64,67) → pitch classes {0,4,7}.
+    const CMAJ: &str = "[60, 64, 67]";
+
+    fn scalar(sql: &str) -> Option<String> {
+        let conn = open_bench().unwrap();
+        conn.query_row(sql, [], |r| r.get::<_, Option<String>>(0)).unwrap()
+    }
+
+    #[test]
+    fn forte_number_major_triad() {
+        assert_eq!(scalar(&format!("SELECT ix_forte_number({CMAJ})")).as_deref(), Some("3-11"));
+    }
+
+    #[test]
+    fn icv_major_triad() {
+        // Major triad interval-class vector is <0,0,1,1,1,0>.
+        assert_eq!(scalar(&format!("SELECT ix_icv({CMAJ})")).as_deref(), Some("<0,0,1,1,1,0>"));
+    }
+
+    #[test]
+    fn prime_form_major_triad() {
+        assert_eq!(scalar(&format!("SELECT ix_prime_form({CMAJ})")).as_deref(), Some("[0,3,7]"));
+    }
+
+    #[test]
+    fn classify_triad_major_and_nontriad() {
+        assert_eq!(scalar(&format!("SELECT ix_classify_triad({CMAJ})")).as_deref(), Some("0 major"));
+        // A single dyad is not a triad → NULL.
+        assert_eq!(scalar("SELECT ix_classify_triad([0, 7])"), None);
+    }
+}

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -117,6 +117,11 @@ fn parse_graph(json: &str) -> Result<(Graph, usize), Box<dyn std::error::Error>>
     let mut g = Graph::with_nodes(max_id + 1);
     for e in &edges {
         let w = if e.len() >= 3 { e[2] } else { 1.0 };
+        // Dijkstra (ix_shortest_path) and PageRank require non-negative weights; a
+        // negative weight gives wrong paths and a negative cycle never settles.
+        if w < 0.0 || w.is_nan() {
+            return Err("edge weights must be finite and non-negative".into());
+        }
         g.add_edge(e[0] as usize, e[1] as usize, w);
     }
     Ok((g, max_id + 1))
@@ -134,7 +139,7 @@ impl VTab for IxPagerank {
     type InitData = Cursor;
     type BindData = RowsF64;
 
-    // @ai:invariant ix_pagerank emits one (node,rank) per graph node from ix_graph pagerank; ranks are positive and sum to ~1 [T:test conf:0.8 src:ix_duck::graphsig::tests::pagerank_ranks_sum_to_one]
+    // @ai:invariant ix_pagerank emits one (node,rank) per graph node from ix_graph pagerank, normalized to sum to 1 (so dangling-node mass leakage doesn't break the probability-distribution contract) [T:test conf:0.8 src:ix_duck::graphsig::tests::pagerank_normalized_even_with_sink]
     fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
         let (g, n) = parse_graph(&bind.get_parameter(0).to_string())?;
         let damping = bind.get_parameter(1).to_string().parse::<f64>().unwrap_or(0.85);
@@ -148,6 +153,15 @@ impl VTab for IxPagerank {
         let pr = g.pagerank(damping, iters as usize);
         let mut rows: Vec<(i64, f64)> = (0..n).map(|i| (i as i64, *pr.get(&i).unwrap_or(&0.0))).collect();
         rows.sort_by_key(|r| r.0);
+        // ix-graph's pagerank doesn't redistribute dangling-node (sink) mass, so the
+        // raw vector can sum below 1. Normalize to a proper distribution at the UDF
+        // boundary so downstream SQL comparing/aggregating ranks stays sound.
+        let total: f64 = rows.iter().map(|r| r.1).sum();
+        if total > 0.0 {
+            for r in &mut rows {
+                r.1 /= total;
+            }
+        }
         two_cols(bind, "node", LogicalTypeId::Bigint, "rank", LogicalTypeId::Double);
         Ok(RowsF64 { rows })
     }
@@ -277,9 +291,9 @@ mod tests {
     use crate::open_bench;
 
     #[test]
-    fn pagerank_ranks_sum_to_one() {
+    fn pagerank_normalized_even_with_sink() {
         let conn = open_bench().unwrap();
-        // 3-cycle 0->1->2->0; symmetric → equal ranks summing to ~1.
+        // 3-cycle → ranks sum to ~1.
         let (n, total): (i64, f64) = conn
             .query_row(
                 "SELECT count(*), sum(rank) FROM ix_pagerank('[[0,1],[1,2],[2,0]]', 0.85, 100)",
@@ -289,6 +303,24 @@ mod tests {
             .unwrap();
         assert_eq!(n, 3, "one row per node");
         assert!((total - 1.0).abs() < 1e-6, "pageranks sum to ~1, got {total}");
+        // Sink graph 0->1 (node 1 dangling): ix-graph leaks mass, but the UDF
+        // normalizes → still a valid distribution summing to 1.
+        let sink_total: f64 = conn
+            .query_row("SELECT sum(rank) FROM ix_pagerank('[[0,1]]', 0.85, 100)", [], |r| r.get(0))
+            .unwrap();
+        assert!((sink_total - 1.0).abs() < 1e-6, "normalized despite the sink, got {sink_total}");
+    }
+
+    #[test]
+    fn graph_rejects_negative_weights() {
+        let conn = open_bench().unwrap();
+        // Negative weights break Dijkstra/PageRank — must be a SQL error, not a hang.
+        assert!(
+            conn.query_row("SELECT node FROM ix_pagerank('[[0,1,-1.0]]', 0.85, 10)", [], |r| r
+                .get::<_, i64>(0))
+                .is_err(),
+            "negative edge weight must be a SQL error"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -1,0 +1,336 @@
+//! Graph + signal IX algorithms as DuckDB table functions — capability classes
+//! DuckDB has nothing native for.
+//!
+//! Graph (`ix-graph`), input = a JSON edge list `[[from,to],…]` or `[[from,to,w],…]`
+//! (node ids are non-negative ints; node count = max id + 1):
+//! - `ix_pagerank(edges, damping DOUBLE, iterations BIGINT)` → `TABLE(node, rank)`.
+//! - `ix_shortest_path(edges, src BIGINT, dst BIGINT)` → `TABLE(step, node)` (the
+//!   Dijkstra path src→dst; empty if unreachable).
+//!
+//! Signal (`ix-signal`), input = a JSON number array (the series):
+//! - `ix_rfft(series)` → `TABLE(bin, magnitude)` — real FFT magnitude spectrum.
+//! - `ix_autocorrelation(series)` → `TABLE(lag, value)`.
+//!
+//! All wrap the real IX crates — no DSP/graph math reimplemented here.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
+use duckdb::Connection;
+use ix_graph::graph::Graph;
+use ix_signal::correlation::autocorrelation;
+use ix_signal::fft::rfft;
+
+// ── shared output plumbing ────────────────────────────────────────────────────
+
+#[repr(C)]
+struct RowsF64 {
+    rows: Vec<(i64, f64)>,
+}
+#[repr(C)]
+struct RowsI64 {
+    rows: Vec<(i64, i64)>,
+}
+#[repr(C)]
+struct Cursor {
+    at: AtomicUsize,
+}
+
+fn new_cursor() -> Cursor {
+    Cursor { at: AtomicUsize::new(0) }
+}
+
+/// Stream `(BIGINT, DOUBLE)` rows in output-vector-sized chunks.
+fn emit_f64(rows: &[(i64, f64)], cur: &Cursor, output: &mut DataChunkHandle) {
+    let n = rows.len();
+    let start = cur.at.load(Ordering::Relaxed);
+    if start >= n {
+        output.set_len(0);
+        return;
+    }
+    let cap = output.flat_vector(0).capacity();
+    let take = (n - start).min(cap);
+    {
+        let mut v = output.flat_vector(0);
+        let s = unsafe { v.as_mut_slice_with_len::<i64>(take) };
+        for (i, slot) in s.iter_mut().enumerate().take(take) {
+            *slot = rows[start + i].0;
+        }
+    }
+    {
+        let mut v = output.flat_vector(1);
+        let s = unsafe { v.as_mut_slice_with_len::<f64>(take) };
+        for (i, slot) in s.iter_mut().enumerate().take(take) {
+            *slot = rows[start + i].1;
+        }
+    }
+    output.set_len(take);
+    cur.at.store(start + take, Ordering::Relaxed);
+}
+
+/// Stream `(BIGINT, BIGINT)` rows in output-vector-sized chunks.
+fn emit_i64(rows: &[(i64, i64)], cur: &Cursor, output: &mut DataChunkHandle) {
+    let n = rows.len();
+    let start = cur.at.load(Ordering::Relaxed);
+    if start >= n {
+        output.set_len(0);
+        return;
+    }
+    let cap = output.flat_vector(0).capacity();
+    let take = (n - start).min(cap);
+    for col in 0..2 {
+        let mut v = output.flat_vector(col);
+        let s = unsafe { v.as_mut_slice_with_len::<i64>(take) };
+        for (i, slot) in s.iter_mut().enumerate().take(take) {
+            *slot = if col == 0 { rows[start + i].0 } else { rows[start + i].1 };
+        }
+    }
+    output.set_len(take);
+    cur.at.store(start + take, Ordering::Relaxed);
+}
+
+/// Parse a JSON series (`[..numbers..]`) into `Vec<f64>`.
+fn parse_series(json: &str) -> Result<Vec<f64>, Box<dyn std::error::Error>> {
+    let v: Vec<f64> =
+        serde_json::from_str(json).map_err(|e| format!("expected a JSON number array: {e}"))?;
+    if v.is_empty() {
+        return Err("series is empty".into());
+    }
+    Ok(v)
+}
+
+/// Build a directed graph from a JSON edge list; returns the graph and node count.
+fn parse_graph(json: &str) -> Result<(Graph, usize), Box<dyn std::error::Error>> {
+    let edges: Vec<Vec<f64>> =
+        serde_json::from_str(json).map_err(|e| format!("expected a JSON edge list [[from,to(,w)],…]: {e}"))?;
+    let mut max_id = 0usize;
+    for e in &edges {
+        if e.len() < 2 {
+            return Err("each edge needs at least [from, to]".into());
+        }
+        if e[0] < 0.0 || e[1] < 0.0 {
+            return Err("node ids must be non-negative".into());
+        }
+        max_id = max_id.max(e[0] as usize).max(e[1] as usize);
+    }
+    let mut g = Graph::with_nodes(max_id + 1);
+    for e in &edges {
+        let w = if e.len() >= 3 { e[2] } else { 1.0 };
+        g.add_edge(e[0] as usize, e[1] as usize, w);
+    }
+    Ok((g, max_id + 1))
+}
+
+fn two_cols(bind: &BindInfo, a: &str, a_ty: LogicalTypeId, b: &str, b_ty: LogicalTypeId) {
+    bind.add_result_column(a, LogicalTypeHandle::from(a_ty));
+    bind.add_result_column(b, LogicalTypeHandle::from(b_ty));
+}
+
+// ── ix_pagerank ────────────────────────────────────────────────────────────────
+
+struct IxPagerank;
+impl VTab for IxPagerank {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_pagerank emits one (node,rank) per graph node from ix_graph pagerank; ranks are positive and sum to ~1 [T:test conf:0.8 src:ix_duck::graphsig::tests::pagerank_ranks_sum_to_one]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let (g, n) = parse_graph(&bind.get_parameter(0).to_string())?;
+        let damping = bind.get_parameter(1).to_string().parse::<f64>().unwrap_or(0.85);
+        if !(0.0..=1.0).contains(&damping) {
+            return Err("damping must be in [0, 1]".into());
+        }
+        let iters = bind.get_parameter(2).to_int64();
+        if iters < 1 {
+            return Err("iterations must be >= 1".into());
+        }
+        let pr = g.pagerank(damping, iters as usize);
+        let mut rows: Vec<(i64, f64)> = (0..n).map(|i| (i as i64, *pr.get(&i).unwrap_or(&0.0))).collect();
+        rows.sort_by_key(|r| r.0);
+        two_cols(bind, "node", LogicalTypeId::Bigint, "rank", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        ])
+    }
+}
+
+// ── ix_shortest_path ─────────────────────────────────────────────────────────────
+
+struct IxShortestPath;
+impl VTab for IxShortestPath {
+    type InitData = Cursor;
+    type BindData = RowsI64;
+
+    // @ai:invariant ix_shortest_path emits the Dijkstra path src->dst as (step,node) in order from ix_graph shortest_path; unreachable -> no rows [T:test conf:0.8 src:ix_duck::graphsig::tests::shortest_path_orders_nodes]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let (g, n) = parse_graph(&bind.get_parameter(0).to_string())?;
+        let src = bind.get_parameter(1).to_int64();
+        let dst = bind.get_parameter(2).to_int64();
+        if src < 0 || dst < 0 || src as usize >= n || dst as usize >= n {
+            return Err(format!("src/dst out of range 0..{n}").into());
+        }
+        let path = g.shortest_path(src as usize, dst as usize).unwrap_or_default();
+        let rows: Vec<(i64, i64)> = path.iter().enumerate().map(|(i, &node)| (i as i64, node as i64)).collect();
+        two_cols(bind, "step", LogicalTypeId::Bigint, "node", LogicalTypeId::Bigint);
+        Ok(RowsI64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_i64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        ])
+    }
+}
+
+// ── ix_rfft ──────────────────────────────────────────────────────────────────────
+
+struct IxRfft;
+impl VTab for IxRfft {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_rfft emits (bin,magnitude) for the real-FFT spectrum of the series via ix_signal rfft; a pure tone has its energy at the matching bin [T:test conf:0.8 src:ix_duck::graphsig::tests::rfft_peaks_at_tone_bin]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let rows: Vec<(i64, f64)> =
+            rfft(&series).iter().enumerate().map(|(i, c)| (i as i64, c.magnitude())).collect();
+        two_cols(bind, "bin", LogicalTypeId::Bigint, "magnitude", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::Varchar)])
+    }
+}
+
+// ── ix_autocorrelation ────────────────────────────────────────────────────────────
+
+struct IxAutocorrelation;
+impl VTab for IxAutocorrelation {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_autocorrelation emits (lag,value) from ix_signal autocorrelation, normalized so lag 0 = 1.0 and is the maximum; lags run -(n-1)..=(n-1) (two-sided, zero-lag centered) [T:test conf:0.8 src:ix_duck::graphsig::tests::autocorrelation_peaks_at_lag_zero]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        // ix_signal returns a two-sided result (len 2n-1) with zero-lag at the
+        // centre (index n-1); map the index to the true lag so lag 0 = peak (1.0).
+        let center = series.len() as i64 - 1;
+        let rows: Vec<(i64, f64)> = autocorrelation(&series)
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| (i as i64 - center, v))
+            .collect();
+        two_cols(bind, "lag", LogicalTypeId::Bigint, "value", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::Varchar)])
+    }
+}
+
+/// Register the graph + signal table functions.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_table_function::<IxPagerank>("ix_pagerank")?;
+    conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
+    conn.register_table_function::<IxRfft>("ix_rfft")?;
+    conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    #[test]
+    fn pagerank_ranks_sum_to_one() {
+        let conn = open_bench().unwrap();
+        // 3-cycle 0->1->2->0; symmetric → equal ranks summing to ~1.
+        let (n, total): (i64, f64) = conn
+            .query_row(
+                "SELECT count(*), sum(rank) FROM ix_pagerank('[[0,1],[1,2],[2,0]]', 0.85, 100)",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(n, 3, "one row per node");
+        assert!((total - 1.0).abs() < 1e-6, "pageranks sum to ~1, got {total}");
+    }
+
+    #[test]
+    fn shortest_path_orders_nodes() {
+        let conn = open_bench().unwrap();
+        // 0->1->2->3 chain; path 0..3 visits 0,1,2,3 in order.
+        let path: Vec<i64> = {
+            let conn2 = open_bench().unwrap();
+            let mut stmt = conn2
+                .prepare("SELECT node FROM ix_shortest_path('[[0,1],[1,2],[2,3]]', 0, 3) ORDER BY step")
+                .unwrap();
+            stmt.query_map([], |r| r.get::<_, i64>(0)).unwrap().map(|x| x.unwrap()).collect()
+        };
+        assert_eq!(path, vec![0, 1, 2, 3]);
+        let _ = conn;
+    }
+
+    #[test]
+    fn rfft_peaks_at_tone_bin() {
+        let conn = open_bench().unwrap();
+        // 8-sample signal with 1 full cycle → spectral peak at bin 1.
+        let series = "[0, 0.707, 1, 0.707, 0, -0.707, -1, -0.707]";
+        let peak_bin: i64 = conn
+            .query_row(
+                &format!("SELECT bin FROM ix_rfft('{series}') ORDER BY magnitude DESC LIMIT 1"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(peak_bin, 1, "one-cycle tone peaks at bin 1");
+    }
+
+    #[test]
+    fn autocorrelation_peaks_at_lag_zero() {
+        let conn = open_bench().unwrap();
+        let max_lag: i64 = conn
+            .query_row(
+                "SELECT lag FROM ix_autocorrelation('[1,2,3,4,3,2,1]') ORDER BY value DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(max_lag, 0, "autocorrelation is maximal at lag 0");
+    }
+}

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -29,6 +29,16 @@ pub mod udf;
 #[cfg(feature = "udf")]
 mod tablefn;
 
+/// Music set-theory scalar UDFs over pitch-class sets (ix_forte_number, ix_icv,
+/// ix_prime_form, ix_classify_triad), registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod bracelet;
+
+/// Graph (ix_pagerank, ix_shortest_path) + signal (ix_rfft, ix_autocorrelation)
+/// table functions over JSON edge-lists / series, registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod graphsig;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -115,5 +115,7 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxCosine>("ix_cosine")?;
     conn.register_scalar_function::<IxEuclidean>("ix_euclidean")?;
     crate::tablefn::register(conn)?;
+    crate::bracelet::register(conn)?;
+    crate::graphsig::register(conn)?;
     Ok(())
 }

--- a/docs/DUCKDB.md
+++ b/docs/DUCKDB.md
@@ -40,6 +40,9 @@ data. Integration is by **format contract** (clean stable-schema JSONL/Parquet),
   - `ix_silhouette(json_vectors, json_labels)` — clustering quality ✅ (table fn)
   - `ix_dbscan(json_vectors, eps, min_points)` — density clustering labels ✅ (table fn; `0` = noise/OOD; composes with `ix_silhouette`)
   - `ix_kmeans(json_vectors, k)` / `ix_gmm(json_vectors, k)` — centroid / mixture clustering labels ✅ (table fn; labels `0..k-1`, deterministic; complete the cluster→`ix_silhouette` loop)
+  - `ix_forte_number` / `ix_icv` / `ix_prime_form` / `ix_classify_triad(notes)` — music set-theory ✅ (scalar over `BIGINT[]` notes mod 12; wraps `ix-bracelet`; makes the voicing corpus queryable by set-class)
+  - `ix_pagerank(edges, damping, iters)` / `ix_shortest_path(edges, src, dst)` — graph analytics ✅ (table fn over a JSON edge list; wraps `ix-graph`; DuckDB has no graph algos)
+  - `ix_rfft(series)` / `ix_autocorrelation(series)` — signal ✅ (table fn over a JSON series; wraps `ix-signal`; FFT magnitude spectrum / two-sided autocorrelation)
 
 - **Crate structure:** new `crates/ix-duck` (library only), `duckdb` as an **optional dep** behind a
   `duck` cargo feature. Mirrors the established `fastembed`/`embeddings` pattern in `ix-skill`


### PR DESCRIPTION
Three differentiated UDF families (#1/#2/#3 from the shortlist), all pure wraps of existing IX crates, auto-exposed by the loadable extension via `register_all`.

## #1 Music set-theory (`ix-bracelet`) — scalar over `BIGINT[]` notes (mod 12)
`ix_forte_number`, `ix_icv`, `ix_prime_form`, `ix_classify_triad` → VARCHAR. **Makes the OPTIC-K voicing corpus queryable by music theory** — e.g. `SELECT ix_forte_number(midiNotes) sc, count(*) FROM read_json_auto('state/voicings/raw/guitar.jsonl') GROUP BY sc`. Nothing else does set-class analysis in SQL. Composes with the Tier-3 `ix_optick_scan` thread.

## #2 Graph (`ix-graph`) — table fns over a JSON edge list
`ix_pagerank(edges, damping, iters)`, `ix_shortest_path(edges, src, dst)`. DuckDB has **zero** graph algorithms; IX has 10 modules.

## #3 Signal (`ix-signal`) — table fns over a JSON series
`ix_rfft` (magnitude spectrum), `ix_autocorrelation` (two-sided, zero-lag-centred so lag 0 = 1.0 peak). DuckDB can't FFT.

## Testing
8 new tests (forte/icv/prime/triad incl. NULL non-triad; pagerank ranks sum ~1; shortest-path order; rfft peak bin; autocorrelation lag-0 peak). Found + fixed a real semantics bug: `ix-signal`'s autocorrelation is two-sided with zero-lag centred — the UDF now maps index→true lag. clippy `--features duck --all-targets -D warnings` clean; **30/30** ix-duck lib tests.

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required`: additive UDFs behind the opt-in `duck` feature; not in default CI, no runtime/production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)