### PR TITLE
feat(ix-duck): probabilistic-sketch UDFs (Bloom / HyperLogLog / Count-Min / Cuckoo)

### DIFF
--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -78,6 +78,15 @@ overflows `BIGINT`): `ix_bloom_contains(bf, (hash(q) & 9223372036854775807)::BIG
 Blobs are JSON and portable: `ix-probabilistic` hashes with a fixed-seed
 `DefaultHasher`, so a blob probes identically on any machine (same Rust std version).
 
+Two caveats:
+- **Blob trust.** A non-JSON blob is a SQL error; a structurally-degenerate blob
+  (e.g. mismatched array lengths) probes to a safe empty result rather than
+  panicking, so a corrupt column never crashes the query.
+- **`ix_cuckoo_remove` is safe only for keys you inserted.** Cuckoo deletion works
+  on fingerprints, so removing a never-inserted key that collides (bucket +
+  fingerprint) with a real entry can evict that entry — an inherent property of
+  Cuckoo filters, not a bug. Don't run deletes on keys outside the inserted set.
+
 ## Build
 
 ```powershell

--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -46,6 +46,38 @@ Table functions take a whole set as a JSON param (2-D number array; labels a 1-D
 array), so one SQL call processes the set:
 `SELECT * FROM ix_pca_project('[[1,2,3],[4,5,6]]', 2);`
 
+### Probabilistic sketches
+
+DuckDB has `approx_count_distinct` (a HyperLogLog) and uses Bloom filters
+internally for joins, but exposes none of them as **queryable, persistable,
+mergeable** objects. These do: each sketch is a portable column value — build once
+(scalar over a `BIGINT[]`, paired with `list()`), store the JSON blob, then probe
+cheaply or merge across partitions / repos. (duckdb-rs has no aggregate-UDF API, so
+each structure is a **build → probe/merge** triad of scalars. Wraps `ix-probabilistic`.)
+
+| structure | build | query | combine |
+|---|---|---|---|
+| **Bloom** (set membership) | `ix_bloom_build(items BIGINT[], capacity BIGINT, fp_rate DOUBLE) -> VARCHAR` | `ix_bloom_contains(sketch VARCHAR, item BIGINT) -> BOOLEAN` | `ix_bloom_union(a VARCHAR, b VARCHAR) -> VARCHAR` |
+| **HyperLogLog** (cardinality) | `ix_hll_build(items BIGINT[], precision BIGINT) -> VARCHAR` | `ix_hll_count(sketch VARCHAR) -> BIGINT` | `ix_hll_merge(a VARCHAR, b VARCHAR) -> VARCHAR` |
+| **Count-Min** (frequency) | `ix_cms_build(items BIGINT[], epsilon DOUBLE, delta DOUBLE) -> VARCHAR` | `ix_cms_estimate(sketch VARCHAR, item BIGINT) -> BIGINT` | `ix_cms_merge(a VARCHAR, b VARCHAR) -> VARCHAR` |
+| **Cuckoo** (membership + delete) | `ix_cuckoo_build(items BIGINT[], capacity BIGINT) -> VARCHAR` | `ix_cuckoo_contains(sketch VARCHAR, item BIGINT) -> BOOLEAN` | `ix_cuckoo_remove(sketch VARCHAR, item BIGINT) -> VARCHAR` |
+
+```sql
+-- Build a Bloom filter over a column, then probe a whole other column against it:
+SELECT q.id
+FROM queries q, (SELECT ix_bloom_build(list(seen_id), 100000, 0.01) AS bf FROM history) h
+WHERE ix_bloom_contains(h.bf, q.id);
+
+-- Distinct-count without a GROUP BY DISTINCT scan; merge two partitions' sketches:
+SELECT ix_hll_count(ix_hll_merge(part_a.s, part_b.s)) AS approx_distinct ...;
+```
+
+Items are `BIGINT` so build-vs-probe hashing is identical. **Text keys** bridge
+through DuckDB's deterministic `hash()` (mask to 63 bits — `hash()` is `UBIGINT` and
+overflows `BIGINT`): `ix_bloom_contains(bf, (hash(q) & 9223372036854775807)::BIGINT)`.
+Blobs are JSON and portable: `ix-probabilistic` hashes with a fixed-seed
+`DefaultHasher`, so a blob probes identically on any machine (same Rust std version).
+
 ## Build
 
 ```powershell

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -27,6 +27,7 @@ ix-supervised = { workspace = true, optional = true }
 ix-bracelet = { workspace = true, optional = true }
 ix-graph = { workspace = true, optional = true }
 ix-signal = { workspace = true, optional = true }
+ix-probabilistic = { workspace = true, optional = true }
 ndarray = { workspace = true, optional = true }
 # Chatbot flight recorder (Slice A/B): the regression gate serializes a JSON contract.
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -39,7 +40,7 @@ chrono = { workspace = true, optional = true }
 # functions), so no bundled engine is pulled — this is the feature the loadable
 # C-API extension (ix-duck-ext) depends on. ix-unsupervised (PCA) + serde_json
 # (JSON params) are needed by the table functions.
-udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ix-supervised", "dep:ix-bracelet", "dep:ix-graph", "dep:ix-signal", "dep:ndarray", "dep:serde_json"]
+udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ix-supervised", "dep:ix-bracelet", "dep:ix-graph", "dep:ix-signal", "dep:ix-probabilistic", "dep:ndarray", "dep:serde_json"]
 # Full in-process DuckDB bench: UDFs + a bundled (C++) engine + json read + the
 # chatbot flight recorder. Off by default so the workspace/CI build stays clean.
 duck = ["udf", "duckdb/bundled", "duckdb/json", "duckdb/parquet", "dep:serde", "dep:chrono"]

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -44,6 +44,12 @@ mod graphsig;
 #[cfg(feature = "udf")]
 mod eval;
 
+/// Probabilistic data-structure UDFs — Bloom / HyperLogLog / Count-Min / Cuckoo
+/// sketches as portable blobs (ix_bloom_*, ix_hll_*, ix_cms_*, ix_cuckoo_*),
+/// registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod sketch;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/sketch.rs
+++ b/crates/ix-duck/src/sketch.rs
@@ -1,0 +1,542 @@
+//! Probabilistic data-structure UDFs over `ix-probabilistic`.
+//!
+//! DuckDB natively has `approx_count_distinct` (a HyperLogLog) and uses Bloom
+//! filters internally for joins, but it exposes **none** of them as queryable,
+//! persistable, mergeable objects. These UDFs do: each sketch is a *portable
+//! column value* you build once, store as a tiny JSON blob, then probe cheaply
+//! with a scalar — or merge across partitions / repos.
+//!
+//! The duckdb-rs build has no aggregate-UDF support, so every structure follows a
+//! **build → blob → probe/merge** triad of scalar functions (build materialises a
+//! column via `list()`):
+//!
+//! | structure | build | query | combine |
+//! |---|---|---|---|
+//! | Bloom    | `ix_bloom_build(items, capacity, fp_rate)` | `ix_bloom_contains(sketch, item)` | `ix_bloom_union(a, b)` |
+//! | HLL      | `ix_hll_build(items, precision)`          | `ix_hll_count(sketch)`            | `ix_hll_merge(a, b)`   |
+//! | Count-Min| `ix_cms_build(items, epsilon, delta)`     | `ix_cms_estimate(sketch, item)`   | `ix_cms_merge(a, b)`   |
+//! | Cuckoo   | `ix_cuckoo_build(items, capacity)`        | `ix_cuckoo_contains(sketch, item)`| `ix_cuckoo_remove(sketch, item)` |
+//!
+//! Items are `BIGINT` so build-vs-probe hashing is identical; for text keys bridge
+//! through DuckDB's own deterministic `hash()`: `ix_bloom_contains(s, hash(q)::BIGINT)`.
+//! Blobs are JSON (`serde`); `ix-probabilistic` hashes with a fixed-seed
+//! `DefaultHasher`, so a blob probes identically on any machine (same Rust std).
+//! Pure wraps of `ix-probabilistic` — no algorithm code here.
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::ffi::duckdb_string_t;
+use duckdb::types::DuckString;
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_probabilistic::bloom::BloomFilter;
+use ix_probabilistic::count_min::CountMinSketch;
+use ix_probabilistic::cuckoo::CuckooFilter;
+use ix_probabilistic::hyperloglog::HyperLogLog;
+use std::error::Error;
+use std::ffi::CString;
+
+type Res = Result<(), Box<dyn Error>>;
+
+fn list_bigint() -> LogicalTypeHandle {
+    LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Bigint))
+}
+fn ty(id: LogicalTypeId) -> LogicalTypeHandle {
+    LogicalTypeHandle::from(id)
+}
+
+// ── readers ──────────────────────────────────────────────────────────────────
+
+/// Read a `LIST<BIGINT>` column into one owned `Vec<i64>` per row (raw values, no
+/// reduction). Reads the per-row `(offset, length)` entries before borrowing the
+/// child buffer so the slices never alias; `cap = max(offset + length)` keeps
+/// every `all[o..o+l]` in bounds.
+fn read_bigint_list(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<Vec<i64>> {
+    let lv = input.list_vector(col);
+    let entries: Vec<(usize, usize)> = (0..n).map(|i| lv.get_entry(i)).collect();
+    let cap = entries.iter().map(|(o, l)| o + l).max().unwrap_or(0);
+    let child = lv.child(cap);
+    let all = unsafe { child.as_slice_with_len::<i64>(cap) };
+    entries.iter().map(|&(o, l)| all[o..o + l].to_vec()).collect()
+}
+
+/// Read a `VARCHAR` column into owned `String`s (one per row).
+fn read_varchar_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<String> {
+    let v = input.flat_vector(col);
+    let slice = unsafe { v.as_slice_with_len::<duckdb_string_t>(n) };
+    slice
+        .iter()
+        .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string())
+        .collect()
+}
+
+/// Read a flat `BIGINT` column into `Vec<i64>` (copied out of the borrowed buffer).
+fn read_i64_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<i64> {
+    let v = input.flat_vector(col);
+    unsafe { v.as_slice_with_len::<i64>(n) }.to_vec()
+}
+
+/// Read a flat `DOUBLE` column into `Vec<f64>`.
+fn read_f64_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<f64> {
+    let v = input.flat_vector(col);
+    unsafe { v.as_slice_with_len::<f64>(n) }.to_vec()
+}
+
+// ── writers ──────────────────────────────────────────────────────────────────
+
+fn write_varchar(output: &mut dyn WritableVector, vals: &[String]) -> Res {
+    let out = output.flat_vector();
+    for (i, v) in vals.iter().enumerate() {
+        out.insert(i, CString::new(v.as_str())?);
+    }
+    Ok(())
+}
+
+fn write_bool(output: &mut dyn WritableVector, vals: &[bool]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<bool>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+fn write_i64(output: &mut dyn WritableVector, vals: &[i64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<i64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+// ── signatures ───────────────────────────────────────────────────────────────
+
+/// `(VARCHAR sketch, BIGINT item) -> ret`.
+fn probe_sig(ret: LogicalTypeId) -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Bigint)],
+        ty(ret),
+    )]
+}
+/// `(VARCHAR a, VARCHAR b) -> VARCHAR`.
+fn combine_sig() -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+        ty(LogicalTypeId::Varchar),
+    )]
+}
+
+// ── Bloom filter ─────────────────────────────────────────────────────────────
+
+struct IxBloomBuild;
+impl VScalar for IxBloomBuild {
+    type State = ();
+    // @ai:invariant ix_bloom_build wraps ix_probabilistic BloomFilter::new(capacity, fp_rate) + insert each BIGINT item, returns a JSON blob; capacity<1 or fp_rate∉(0,1) -> SQL error (no panic on size 0) [T:test conf:0.85 src:ix_duck::sketch::tests::bloom_roundtrip_no_false_negative]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let lists = read_bigint_list(input, 0, n);
+        let caps = read_i64_col(input, 1, n);
+        let fps = read_f64_col(input, 2, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            if caps[i] < 1 {
+                return Err("ix_bloom_build: capacity must be >= 1".into());
+            }
+            if !(fps[i] > 0.0 && fps[i] < 1.0) {
+                return Err("ix_bloom_build: fp_rate must be in (0, 1)".into());
+            }
+            let mut bf = BloomFilter::new(caps[i] as usize, fps[i]);
+            for v in &lists[i] {
+                bf.insert(v);
+            }
+            out.push(serde_json::to_string(&bf)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_bigint(), ty(LogicalTypeId::Bigint), ty(LogicalTypeId::Double)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxBloomContains;
+impl VScalar for IxBloomContains {
+    type State = ();
+    // @ai:invariant ix_bloom_contains deserializes the blob and returns BloomFilter::contains(item); every inserted item -> true (no false negatives); malformed blob -> SQL error [T:test conf:0.9 src:ix_duck::sketch::tests::bloom_roundtrip_no_false_negative]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let sketches = read_varchar_col(input, 0, n);
+        let items = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let bf: BloomFilter = serde_json::from_str(&sketches[i])
+                .map_err(|e| format!("ix_bloom_contains: invalid sketch blob: {e}"))?;
+            out.push(bf.contains(&items[i]));
+        }
+        write_bool(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        probe_sig(LogicalTypeId::Boolean)
+    }
+}
+
+struct IxBloomUnion;
+impl VScalar for IxBloomUnion {
+    type State = ();
+    // @ai:invariant ix_bloom_union returns BloomFilter::union of two blobs; mismatched parameters (capacity/fp_rate) -> SQL error; result contains every item from both [T:test conf:0.85 src:ix_duck::sketch::tests::bloom_union]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let a = read_varchar_col(input, 0, n);
+        let b = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let fa: BloomFilter = serde_json::from_str(&a[i])
+                .map_err(|e| format!("ix_bloom_union: invalid sketch blob (arg 1): {e}"))?;
+            let fb: BloomFilter = serde_json::from_str(&b[i])
+                .map_err(|e| format!("ix_bloom_union: invalid sketch blob (arg 2): {e}"))?;
+            let u = fa
+                .union(&fb)
+                .ok_or("ix_bloom_union: filters differ in capacity/fp_rate (must match to union)")?;
+            out.push(serde_json::to_string(&u)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        combine_sig()
+    }
+}
+
+// ── HyperLogLog ──────────────────────────────────────────────────────────────
+
+struct IxHllBuild;
+impl VScalar for IxHllBuild {
+    type State = ();
+    // @ai:invariant ix_hll_build wraps HyperLogLog::new(precision) + add each BIGINT item; precision is clamped to [4,18] by the lib; precision<1 -> SQL error [T:test conf:0.8 src:ix_duck::sketch::tests::hll_count_estimate]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let lists = read_bigint_list(input, 0, n);
+        let precisions = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            if precisions[i] < 1 {
+                return Err("ix_hll_build: precision must be >= 1".into());
+            }
+            let mut hll = HyperLogLog::new(precisions[i] as usize);
+            for v in &lists[i] {
+                hll.add(v);
+            }
+            out.push(serde_json::to_string(&hll)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_bigint(), ty(LogicalTypeId::Bigint)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxHllCount;
+impl VScalar for IxHllCount {
+    type State = ();
+    // @ai:invariant ix_hll_count returns the rounded HyperLogLog::count cardinality estimate of the blob; ~within the lib's error bound of the true distinct count [T:test conf:0.8 src:ix_duck::sketch::tests::hll_count_estimate]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let sketches = read_varchar_col(input, 0, n);
+        let mut out = Vec::with_capacity(n);
+        for s in &sketches {
+            let hll: HyperLogLog = serde_json::from_str(s)
+                .map_err(|e| format!("ix_hll_count: invalid sketch blob: {e}"))?;
+            out.push(hll.count().round() as i64);
+        }
+        write_i64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Bigint),
+        )]
+    }
+}
+
+struct IxHllMerge;
+impl VScalar for IxHllMerge {
+    type State = ();
+    // @ai:invariant ix_hll_merge returns HyperLogLog::merge of two blobs (bucket-wise max); differing precision -> SQL error; merged count estimates the union cardinality [T:test conf:0.8 src:ix_duck::sketch::tests::hll_merge]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let a = read_varchar_col(input, 0, n);
+        let b = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut fa: HyperLogLog = serde_json::from_str(&a[i])
+                .map_err(|e| format!("ix_hll_merge: invalid sketch blob (arg 1): {e}"))?;
+            let fb: HyperLogLog = serde_json::from_str(&b[i])
+                .map_err(|e| format!("ix_hll_merge: invalid sketch blob (arg 2): {e}"))?;
+            fa.merge(&fb).map_err(|e| format!("ix_hll_merge: {e}"))?;
+            out.push(serde_json::to_string(&fa)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        combine_sig()
+    }
+}
+
+// ── Count-Min Sketch ─────────────────────────────────────────────────────────
+
+struct IxCmsBuild;
+impl VScalar for IxCmsBuild {
+    type State = ();
+    // @ai:invariant ix_cms_build wraps CountMinSketch::with_error(epsilon, delta) + add each BIGINT item; epsilon<=0 or delta∉(0,1) -> SQL error [T:test conf:0.85 src:ix_duck::sketch::tests::cms_estimate]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let lists = read_bigint_list(input, 0, n);
+        let eps = read_f64_col(input, 1, n);
+        let delta = read_f64_col(input, 2, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            if eps[i] <= 0.0 {
+                return Err("ix_cms_build: epsilon must be > 0".into());
+            }
+            if !(delta[i] > 0.0 && delta[i] < 1.0) {
+                return Err("ix_cms_build: delta must be in (0, 1)".into());
+            }
+            let mut cms = CountMinSketch::with_error(eps[i], delta[i]);
+            for v in &lists[i] {
+                cms.add(v);
+            }
+            out.push(serde_json::to_string(&cms)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_bigint(), ty(LogicalTypeId::Double), ty(LogicalTypeId::Double)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxCmsEstimate;
+impl VScalar for IxCmsEstimate {
+    type State = ();
+    // @ai:invariant ix_cms_estimate returns CountMinSketch::estimate(item) frequency from the blob; always >= the true count (Count-Min never undercounts) [T:test conf:0.85 src:ix_duck::sketch::tests::cms_estimate]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let sketches = read_varchar_col(input, 0, n);
+        let items = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let cms: CountMinSketch = serde_json::from_str(&sketches[i])
+                .map_err(|e| format!("ix_cms_estimate: invalid sketch blob: {e}"))?;
+            out.push(cms.estimate(&items[i]) as i64);
+        }
+        write_i64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        probe_sig(LogicalTypeId::Bigint)
+    }
+}
+
+struct IxCmsMerge;
+impl VScalar for IxCmsMerge {
+    type State = ();
+    // @ai:invariant ix_cms_merge returns CountMinSketch::merge of two blobs (cell-wise add); differing dimensions -> SQL error; estimates of the combined stream [T:test conf:0.85 src:ix_duck::sketch::tests::cms_merge]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let a = read_varchar_col(input, 0, n);
+        let b = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut fa: CountMinSketch = serde_json::from_str(&a[i])
+                .map_err(|e| format!("ix_cms_merge: invalid sketch blob (arg 1): {e}"))?;
+            let fb: CountMinSketch = serde_json::from_str(&b[i])
+                .map_err(|e| format!("ix_cms_merge: invalid sketch blob (arg 2): {e}"))?;
+            fa.merge(&fb).map_err(|e| format!("ix_cms_merge: {e}"))?;
+            out.push(serde_json::to_string(&fa)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        combine_sig()
+    }
+}
+
+// ── Cuckoo filter (supports deletion) ────────────────────────────────────────
+
+struct IxCuckooBuild;
+impl VScalar for IxCuckooBuild {
+    type State = ();
+    // @ai:invariant ix_cuckoo_build wraps CuckooFilter::new(capacity) + insert each BIGINT item; capacity<1 -> SQL error; a full filter (insert returns false) -> SQL error asking for more capacity (never silently drops -> no false negatives) [T:test conf:0.85 src:ix_duck::sketch::tests::cuckoo_build_contains_remove]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let lists = read_bigint_list(input, 0, n);
+        let caps = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            if caps[i] < 1 {
+                return Err("ix_cuckoo_build: capacity must be >= 1".into());
+            }
+            let mut cf = CuckooFilter::new(caps[i] as usize);
+            for v in &lists[i] {
+                if !cf.insert(v) {
+                    return Err(format!(
+                        "ix_cuckoo_build: filter full at capacity {} ({} items); increase capacity",
+                        caps[i], lists[i].len()
+                    )
+                    .into());
+                }
+            }
+            out.push(serde_json::to_string(&cf)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_bigint(), ty(LogicalTypeId::Bigint)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxCuckooContains;
+impl VScalar for IxCuckooContains {
+    type State = ();
+    // @ai:invariant ix_cuckoo_contains deserializes the blob and returns CuckooFilter::contains(item); inserted-and-not-removed items -> true [T:test conf:0.9 src:ix_duck::sketch::tests::cuckoo_build_contains_remove]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let sketches = read_varchar_col(input, 0, n);
+        let items = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let cf: CuckooFilter = serde_json::from_str(&sketches[i])
+                .map_err(|e| format!("ix_cuckoo_contains: invalid sketch blob: {e}"))?;
+            out.push(cf.contains(&items[i]));
+        }
+        write_bool(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        probe_sig(LogicalTypeId::Boolean)
+    }
+}
+
+struct IxCuckooRemove;
+impl VScalar for IxCuckooRemove {
+    type State = ();
+    // @ai:invariant ix_cuckoo_remove returns a new blob with item deleted (CuckooFilter::remove — the deletion the Bloom filter can't do); removing an absent item is a no-op [T:test conf:0.85 src:ix_duck::sketch::tests::cuckoo_build_contains_remove]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let sketches = read_varchar_col(input, 0, n);
+        let items = read_i64_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let mut cf: CuckooFilter = serde_json::from_str(&sketches[i])
+                .map_err(|e| format!("ix_cuckoo_remove: invalid sketch blob: {e}"))?;
+            cf.remove(&items[i]);
+            out.push(serde_json::to_string(&cf)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        probe_sig(LogicalTypeId::Varchar)
+    }
+}
+
+/// Register the probabilistic-sketch scalar UDFs (build / probe / merge triads).
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxBloomBuild>("ix_bloom_build")?;
+    conn.register_scalar_function::<IxBloomContains>("ix_bloom_contains")?;
+    conn.register_scalar_function::<IxBloomUnion>("ix_bloom_union")?;
+    conn.register_scalar_function::<IxHllBuild>("ix_hll_build")?;
+    conn.register_scalar_function::<IxHllCount>("ix_hll_count")?;
+    conn.register_scalar_function::<IxHllMerge>("ix_hll_merge")?;
+    conn.register_scalar_function::<IxCmsBuild>("ix_cms_build")?;
+    conn.register_scalar_function::<IxCmsEstimate>("ix_cms_estimate")?;
+    conn.register_scalar_function::<IxCmsMerge>("ix_cms_merge")?;
+    conn.register_scalar_function::<IxCuckooBuild>("ix_cuckoo_build")?;
+    conn.register_scalar_function::<IxCuckooContains>("ix_cuckoo_contains")?;
+    conn.register_scalar_function::<IxCuckooRemove>("ix_cuckoo_remove")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    fn b(sql: &str) -> bool {
+        open_bench()
+            .unwrap()
+            .query_row(sql, [], |r| r.get::<_, bool>(0))
+            .unwrap()
+    }
+    fn i(sql: &str) -> i64 {
+        open_bench()
+            .unwrap()
+            .query_row(sql, [], |r| r.get::<_, i64>(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn bloom_roundtrip_no_false_negative() {
+        // Every inserted item must probe true (Bloom has no false negatives).
+        assert!(b("SELECT ix_bloom_contains(ix_bloom_build([10, 20, 30], 100, 0.01), 20)"));
+        assert!(b("SELECT ix_bloom_contains(ix_bloom_build([10, 20, 30], 100, 0.01), 30)"));
+    }
+
+    #[test]
+    fn bloom_union() {
+        // Same params → unionable; the union contains items from both filters.
+        let sql = "SELECT ix_bloom_contains(
+                       ix_bloom_union(ix_bloom_build([1], 100, 0.01),
+                                      ix_bloom_build([2], 100, 0.01)), {})";
+        assert!(b(&sql.replace("{}", "1")));
+        assert!(b(&sql.replace("{}", "2")));
+    }
+
+    #[test]
+    fn hll_count_estimate() {
+        // 1000 distinct values, p=12 → estimate within ~10%.
+        let est = i("SELECT ix_hll_count(ix_hll_build(
+                        (SELECT list(r)::BIGINT[] FROM range(1000) t(r)), 12))");
+        assert!((est - 1000).abs() < 150, "HLL estimate {est} too far from 1000");
+    }
+
+    #[test]
+    fn hll_merge() {
+        // Disjoint halves merged → estimates the 1000-cardinality union.
+        let est = i("SELECT ix_hll_count(ix_hll_merge(
+                        ix_hll_build((SELECT list(r)::BIGINT[] FROM range(0, 500) t(r)), 12),
+                        ix_hll_build((SELECT list(r)::BIGINT[] FROM range(500, 1000) t(r)), 12)))");
+        assert!((est - 1000).abs() < 150, "merged HLL estimate {est} too far from 1000");
+    }
+
+    #[test]
+    fn cms_estimate() {
+        // "7" added 4×, "9" once → estimates never undercount.
+        assert!(i("SELECT ix_cms_estimate(ix_cms_build([7,7,7,7,9], 0.01, 0.01), 7)") >= 4);
+        assert!(i("SELECT ix_cms_estimate(ix_cms_build([7,7,7,7,9], 0.01, 0.01), 9)") >= 1);
+    }
+
+    #[test]
+    fn cms_merge() {
+        // Same item counted in both sketches → merged estimate sums.
+        let est = i("SELECT ix_cms_estimate(ix_cms_merge(
+                        ix_cms_build([5,5,5], 0.01, 0.01),
+                        ix_cms_build([5,5], 0.01, 0.01)), 5)");
+        assert!(est >= 5, "merged CMS estimate {est} should be >= 5");
+    }
+
+    #[test]
+    fn cuckoo_build_contains_remove() {
+        // Present after build; absent after remove (Cuckoo's deletion).
+        assert!(b("SELECT ix_cuckoo_contains(ix_cuckoo_build([1,2,3], 100), 2)"));
+        assert!(!b("SELECT ix_cuckoo_contains(
+                        ix_cuckoo_remove(ix_cuckoo_build([1,2,3], 100), 2), 2)"));
+        // Removing 2 leaves the others intact.
+        assert!(b("SELECT ix_cuckoo_contains(
+                       ix_cuckoo_remove(ix_cuckoo_build([1,2,3], 100), 2), 1)"));
+    }
+}

--- a/crates/ix-duck/src/sketch.rs
+++ b/crates/ix-duck/src/sketch.rs
@@ -159,7 +159,7 @@ impl VScalar for IxBloomBuild {
 struct IxBloomContains;
 impl VScalar for IxBloomContains {
     type State = ();
-    // @ai:invariant ix_bloom_contains deserializes the blob and returns BloomFilter::contains(item); every inserted item -> true (no false negatives); malformed blob -> SQL error [T:test conf:0.9 src:ix_duck::sketch::tests::bloom_roundtrip_no_false_negative]
+    // @ai:invariant ix_bloom_contains deserializes the blob and returns BloomFilter::contains(item); every inserted item -> true (no false negatives); non-JSON blob -> SQL error; structurally-degenerate filter -> false (never panics) [T:test conf:0.9 src:ix_duck::sketch::tests::bloom_degenerate_blob_no_panic]
     unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
         let n = input.len();
         let sketches = read_varchar_col(input, 0, n);
@@ -426,7 +426,7 @@ impl VScalar for IxCuckooContains {
 struct IxCuckooRemove;
 impl VScalar for IxCuckooRemove {
     type State = ();
-    // @ai:invariant ix_cuckoo_remove returns a new blob with item deleted (CuckooFilter::remove — the deletion the Bloom filter can't do); removing an absent item is a no-op [T:test conf:0.85 src:ix_duck::sketch::tests::cuckoo_build_contains_remove]
+    // @ai:invariant ix_cuckoo_remove returns a new blob with item deleted (CuckooFilter::remove — the deletion the Bloom filter can't do); SAFE ONLY for previously-inserted keys: a never-inserted key colliding on bucket+fingerprint with a real entry can evict it (inherent Cuckoo behavior) [T:test conf:0.85 src:ix_duck::sketch::tests::cuckoo_build_contains_remove]
     unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
         let n = input.len();
         let sketches = read_varchar_col(input, 0, n);
@@ -484,6 +484,15 @@ mod tests {
         // Every inserted item must probe true (Bloom has no false negatives).
         assert!(b("SELECT ix_bloom_contains(ix_bloom_build([10, 20, 30], 100, 0.01), 20)"));
         assert!(b("SELECT ix_bloom_contains(ix_bloom_build([10, 20, 30], 100, 0.01), 30)"));
+    }
+
+    #[test]
+    fn bloom_degenerate_blob_no_panic() {
+        // A hand-crafted/file-sourced blob with size 0 must not panic the FFI
+        // callback (`% 0`) — the probe safely returns false.
+        assert!(!b(
+            r#"SELECT ix_bloom_contains('{"bits":[],"num_hashes":1,"size":0,"count":0}', 5)"#
+        ));
     }
 
     #[test]

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -118,5 +118,6 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     crate::bracelet::register(conn)?;
     crate::graphsig::register(conn)?;
     crate::eval::register(conn)?;
+    crate::sketch::register(conn)?;
     Ok(())
 }

--- a/crates/ix-probabilistic/Cargo.toml
+++ b/crates/ix-probabilistic/Cargo.toml
@@ -12,3 +12,6 @@ description = "Probabilistic data structures: Bloom filters, Count-Min Sketch, H
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/ix-probabilistic/Cargo.toml
+++ b/crates/ix-probabilistic/Cargo.toml
@@ -11,4 +11,4 @@ description = "Probabilistic data structures: Bloom filters, Count-Min Sketch, H
 
 [dependencies]
 thiserror = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }

--- a/crates/ix-probabilistic/src/bloom.rs
+++ b/crates/ix-probabilistic/src/bloom.rs
@@ -7,11 +7,17 @@
 //! Use case for agents: quickly check "has this query been seen before?"
 //! or "does this skill exist?" without loading full data.
 
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 /// A Bloom filter.
-#[derive(Debug, Clone)]
+///
+/// Serialization (`serde`) lets the filter round-trip to a portable blob — e.g.
+/// the `ix-duck` `ix_bloom_*` SQL UDFs persist it as a column value. Hashing uses
+/// `DefaultHasher` (fixed seed), so a serialized filter probes identically on any
+/// machine running the same Rust std version.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BloomFilter {
     bits: Vec<bool>,
     num_hashes: usize,

--- a/crates/ix-probabilistic/src/bloom.rs
+++ b/crates/ix-probabilistic/src/bloom.rs
@@ -58,9 +58,21 @@ impl BloomFilter {
         self.count += 1;
     }
 
+    /// Whether the internal arrays are self-consistent. A filter built via the
+    /// constructors always is, but one *deserialized* from an untrusted blob may
+    /// not be — guarding keeps query methods total (no `% 0` / out-of-bounds panic).
+    fn consistent(&self) -> bool {
+        self.size > 0 && self.num_hashes > 0 && self.bits.len() == self.size
+    }
+
     /// Check if an item *might* be in the set.
     /// Returns false = definitely not in set, true = probably in set.
+    /// A structurally-degenerate filter (e.g. from a malformed blob) returns false
+    /// rather than panicking.
     pub fn contains<T: Hash>(&self, item: &T) -> bool {
+        if !self.consistent() {
+            return false;
+        }
         (0..self.num_hashes).all(|i| {
             let idx = self.hash_index(item, i);
             self.bits[idx]
@@ -179,6 +191,18 @@ mod tests {
         for i in 0..100 {
             assert!(bf.contains(&i), "False negative for {}", i);
         }
+    }
+
+    #[test]
+    fn test_bloom_degenerate_blob_no_panic() {
+        // A malformed blob (size 0, empty bits) must not panic on probe (`% 0`).
+        let bf: BloomFilter =
+            serde_json::from_str(r#"{"bits":[],"num_hashes":1,"size":0,"count":0}"#).unwrap();
+        assert!(!bf.contains(&"anything"));
+        // size > 0 but bits shorter than size would index out of bounds.
+        let bf2: BloomFilter =
+            serde_json::from_str(r#"{"bits":[true],"num_hashes":2,"size":8,"count":1}"#).unwrap();
+        assert!(!bf2.contains(&42));
     }
 
     #[test]

--- a/crates/ix-probabilistic/src/count_min.rs
+++ b/crates/ix-probabilistic/src/count_min.rs
@@ -3,11 +3,15 @@
 //! Use case for agents: track how often each skill is invoked,
 //! estimate query frequencies for caching decisions — all in O(1) space.
 
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 /// Count-Min Sketch for frequency estimation.
-#[derive(Debug, Clone)]
+///
+/// `serde`-serializable so the sketch can be persisted/merged as a portable blob
+/// (see the `ix-duck` `ix_cms_*` SQL UDFs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CountMinSketch {
     table: Vec<Vec<u64>>,
     width: usize,

--- a/crates/ix-probabilistic/src/count_min.rs
+++ b/crates/ix-probabilistic/src/count_min.rs
@@ -51,8 +51,21 @@ impl CountMinSketch {
         }
     }
 
-    /// Estimate the frequency of an item (always >= true count).
+    /// Whether the table matches the declared dimensions. A deserialized blob may
+    /// violate this; guarding keeps `estimate`/`merge`/`total_count` total.
+    fn consistent(&self) -> bool {
+        self.width > 0
+            && self.depth > 0
+            && self.table.len() == self.depth
+            && self.table.iter().all(|row| row.len() == self.width)
+    }
+
+    /// Estimate the frequency of an item (always >= true count). A degenerate
+    /// sketch returns 0.
     pub fn estimate<T: Hash>(&self, item: &T) -> u64 {
+        if !self.consistent() {
+            return 0;
+        }
         (0..self.depth)
             .map(|row| {
                 let col = self.hash_index(item, row);
@@ -64,14 +77,17 @@ impl CountMinSketch {
 
     /// Total count of all items.
     pub fn total_count(&self) -> u64 {
-        // Sum of any single row equals total count
-        self.table[0].iter().sum()
+        // Sum of any single row equals total count.
+        self.table.first().map(|row| row.iter().sum()).unwrap_or(0)
     }
 
     /// Merge another sketch (must have same dimensions).
     pub fn merge(&mut self, other: &Self) -> Result<(), &'static str> {
         if self.width != other.width || self.depth != other.depth {
             return Err("Sketches must have same dimensions");
+        }
+        if !self.consistent() || !other.consistent() {
+            return Err("Sketches are structurally inconsistent");
         }
         for row in 0..self.depth {
             for col in 0..self.width {
@@ -128,6 +144,15 @@ mod tests {
         assert!(rare_est >= 10);
         // Overcount should be bounded
         assert!(freq_est < 1050, "Overcount too high: {}", freq_est);
+    }
+
+    #[test]
+    fn test_count_min_degenerate_blob_no_panic() {
+        // width 0 / empty table must not panic on estimate (`% 0`) or total_count.
+        let cms: CountMinSketch =
+            serde_json::from_str(r#"{"table":[],"width":0,"depth":0}"#).unwrap();
+        assert_eq!(cms.estimate(&"x"), 0);
+        assert_eq!(cms.total_count(), 0);
     }
 
     #[test]

--- a/crates/ix-probabilistic/src/cuckoo.rs
+++ b/crates/ix-probabilistic/src/cuckoo.rs
@@ -3,11 +3,15 @@
 //! Use case for agents: track active sessions, skill availability,
 //! or active tool registrations with the ability to remove entries.
 
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 /// A Cuckoo Filter supporting insert, lookup, and delete.
-#[derive(Debug, Clone)]
+///
+/// `serde`-serializable so the filter can be persisted as a portable blob (see
+/// the `ix-duck` `ix_cuckoo_*` SQL UDFs — `remove` is its differentiator vs Bloom).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CuckooFilter {
     buckets: Vec<Vec<u16>>, // Each bucket holds up to BUCKET_SIZE fingerprints
     num_buckets: usize,

--- a/crates/ix-probabilistic/src/cuckoo.rs
+++ b/crates/ix-probabilistic/src/cuckoo.rs
@@ -75,14 +75,32 @@ impl CuckooFilter {
         false // Filter is too full
     }
 
-    /// Check if an item might be in the filter.
+    /// Whether the buckets match the declared bucket count. A deserialized blob
+    /// may violate this; guarding keeps `contains`/`remove` total (no `% 0` /
+    /// out-of-bounds panic).
+    fn consistent(&self) -> bool {
+        self.num_buckets > 0 && self.buckets.len() == self.num_buckets
+    }
+
+    /// Check if an item might be in the filter. A degenerate filter returns false.
     pub fn contains<T: Hash>(&self, item: &T) -> bool {
+        if !self.consistent() {
+            return false;
+        }
         let (fp, i1, i2) = self.indices(item);
         self.buckets[i1].contains(&fp) || self.buckets[i2].contains(&fp)
     }
 
     /// Remove an item. Returns true if found and removed.
+    ///
+    /// Cuckoo deletion is only safe for items known to have been inserted: a
+    /// never-inserted key that shares a bucket+fingerprint with a real entry will
+    /// evict that real entry (a fingerprint collision). Callers must not delete
+    /// keys they did not add.
     pub fn remove<T: Hash>(&mut self, item: &T) -> bool {
+        if !self.consistent() {
+            return false;
+        }
         let (fp, i1, i2) = self.indices(item);
 
         if let Some(pos) = self.buckets[i1].iter().position(|&f| f == fp) {
@@ -164,6 +182,16 @@ mod tests {
         assert!(cf.remove(&"hello"));
         assert!(!cf.contains(&"hello"));
         assert_eq!(cf.len(), 0);
+    }
+
+    #[test]
+    fn test_cuckoo_degenerate_blob_no_panic() {
+        // num_buckets 0 / empty buckets must not panic on contains/remove (`% 0`).
+        let mut cf: CuckooFilter =
+            serde_json::from_str(r#"{"buckets":[],"num_buckets":0,"max_kicks":500,"count":0}"#)
+                .unwrap();
+        assert!(!cf.contains(&"x"));
+        assert!(!cf.remove(&"x"));
     }
 
     #[test]

--- a/crates/ix-probabilistic/src/hyperloglog.rs
+++ b/crates/ix-probabilistic/src/hyperloglog.rs
@@ -53,8 +53,17 @@ impl HyperLogLog {
         self.registers[bucket] = self.registers[bucket].max(leading_zeros);
     }
 
-    /// Estimate the number of distinct items.
+    /// Whether the registers match the declared bucket count. A deserialized blob
+    /// may violate this; guarding keeps `count`/`merge` total (no NaN / panic).
+    fn consistent(&self) -> bool {
+        self.num_buckets > 0 && self.registers.len() == self.num_buckets
+    }
+
+    /// Estimate the number of distinct items. A degenerate sketch returns 0.0.
     pub fn count(&self) -> f64 {
+        if !self.consistent() {
+            return 0.0;
+        }
         let m = self.num_buckets as f64;
         let alpha = match self.num_buckets {
             16 => 0.673,
@@ -86,6 +95,9 @@ impl HyperLogLog {
     pub fn merge(&mut self, other: &Self) -> Result<(), &'static str> {
         if self.precision != other.precision {
             return Err("HyperLogLog instances must have same precision");
+        }
+        if !self.consistent() || !other.consistent() {
+            return Err("HyperLogLog instances are structurally inconsistent");
         }
         for (i, &r) in other.registers.iter().enumerate() {
             self.registers[i] = self.registers[i].max(r);
@@ -157,6 +169,17 @@ mod tests {
             "Merged estimate {} too far from 1000",
             estimate
         );
+    }
+
+    #[test]
+    fn test_hll_degenerate_blob_no_panic() {
+        // num_buckets 0 / empty registers must not produce a panic or NaN count.
+        let hll: HyperLogLog =
+            serde_json::from_str(r#"{"registers":[],"precision":0,"num_buckets":0}"#).unwrap();
+        assert_eq!(hll.count(), 0.0);
+        // merging an inconsistent sketch is rejected, not panicked.
+        let mut ok = HyperLogLog::new(10);
+        assert!(ok.merge(&hll).is_err());
     }
 
     #[test]

--- a/crates/ix-probabilistic/src/hyperloglog.rs
+++ b/crates/ix-probabilistic/src/hyperloglog.rs
@@ -3,11 +3,15 @@
 //! Use case for agents: estimate unique queries, unique skills used,
 //! unique error types — without storing all values.
 
+use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 /// HyperLogLog cardinality estimator.
-#[derive(Debug, Clone)]
+///
+/// `serde`-serializable so the sketch can be persisted/merged as a portable blob
+/// (see the `ix-duck` `ix_hll_*` SQL UDFs).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HyperLogLog {
     registers: Vec<u8>,
     precision: usize,   // p: number of bits for bucket index

--- a/docs/DUCKDB.md
+++ b/docs/DUCKDB.md
@@ -46,6 +46,7 @@ data. Integration is by **format contract** (clean stable-schema JSONL/Parquet),
   - `ix_ndcg(rels,k)` / `ix_reciprocal_rank(rels)` / `ix_precision_at_k(rels,k)` / `ix_recall_at_k(rels,k,total)` — IR ranking metrics ✅ (scalar over a `DOUBLE[]` relevance list; powers the GA retrieval/routing oracles — `avg(ix_reciprocal_rank)` = MRR)
   - `ix_classification_report(predicted_json, actual_json)` — per-class precision/recall/f1/support ✅ (table fn; wraps `ix-supervised::metrics`; GA routing per-intent eval)
   - `ix_knn_leakage(vectors_json, labels_json, k)` — embedding separability/leakage ✅ (table fn; mean k-NN label agreement vs `random_baseline`; the lightweight form of GA's embeddings diagnostic)
+  - `ix_bloom_*` / `ix_hll_*` / `ix_cms_*` / `ix_cuckoo_*` — probabilistic sketches ✅ (scalar **build → probe/merge** triads over `BIGINT[]` items; wraps `ix-probabilistic`; sketches are portable JSON blobs — set membership / cardinality / frequency / membership-with-delete that DuckDB exposes none of). Items are `BIGINT`; text keys bridge via `(hash(x) & 9223372036854775807)::BIGINT`. See `crates/ix-duck-ext/README.md` → *Probabilistic sketches*.
 
 - **Crate structure:** new `crates/ix-duck` (library only), `duckdb` as an **optional dep** behind a
   `duck` cargo feature. Mirrors the established `fastembed`/`embeddings` pattern in `ix-skill`

--- a/docs/duck/pipelines.sql
+++ b/docs/duck/pipelines.sql
@@ -70,3 +70,24 @@ ORDER BY n DESC;
 -- SELECT instrument, count(*) AS voicings, any_value(len(embedding)) AS dim
 -- FROM ix_optick_scan('C:/Users/you/source/repos/ga/state/voicings/optick.index')
 -- GROUP BY instrument;
+
+-- ── Pipeline 6: probabilistic sketches (build → blob → probe / merge) ─────────
+-- Portable sketches as column values — things DuckDB exposes natively for none of:
+-- set membership (Bloom), cardinality (HLL), frequency (Count-Min), delete (Cuckoo).
+-- Build is a scalar over list(); the JSON blob then probes/merges cheaply.
+
+-- 6a. Bloom: which candidates are NOT already in the seen-set (one filter, scanned).
+WITH seen(id) AS (VALUES (1),(2),(3),(5),(8)),
+     cand(id) AS (VALUES (2),(4),(8),(9)),
+     filt AS (SELECT ix_bloom_build(list(id), 1000, 0.01) AS bf FROM seen)
+SELECT cand.id,
+       ix_bloom_contains(filt.bf, cand.id) AS probably_seen
+FROM cand, filt
+ORDER BY cand.id;
+
+-- 6b. HyperLogLog: approx distinct count, and merge two partitions' sketches into
+-- one cardinality estimate — without re-scanning either partition (~p=14, <1% err).
+SET VARIABLE hll_a = (SELECT ix_hll_build(list(r), 14) FROM range(0, 700)   t(r));
+SET VARIABLE hll_b = (SELECT ix_hll_build(list(r), 14) FROM range(300, 1000) t(r));
+SELECT ix_hll_count(getvariable('hll_a'))                                AS distinct_a,   -- ~700
+       ix_hll_count(ix_hll_merge(getvariable('hll_a'), getvariable('hll_b'))) AS distinct_union; -- ~1000 (overlap 300..700 counted once)


### PR DESCRIPTION
## Summary

Exposes the existing `ix-probabilistic` crate (Bloom, HyperLogLog, Count-Min, Cuckoo) as DuckDB SQL UDFs. DuckDB natively has `approx_count_distinct` (an HLL) and uses Bloom filters internally for joins, but exposes **none** of them as queryable, persistable, mergeable objects — these do: each sketch is a **portable column value** you build once (a tiny JSON blob), then probe cheaply or merge across partitions / repos.

`duckdb-rs` has no aggregate-UDF API, so each structure is a **build → probe/merge** triad of scalars (build is a scalar over `BIGINT[]`, paired with `list()`):

| structure | build | query | combine |
|---|---|---|---|
| **Bloom** (membership) | `ix_bloom_build` | `ix_bloom_contains` | `ix_bloom_union` |
| **HyperLogLog** (cardinality) | `ix_hll_build` | `ix_hll_count` | `ix_hll_merge` |
| **Count-Min** (frequency) | `ix_cms_build` | `ix_cms_estimate` | `ix_cms_merge` |
| **Cuckoo** (membership + delete) | `ix_cuckoo_build` | `ix_cuckoo_contains` | `ix_cuckoo_remove` |

## Key decisions
- **Items are `BIGINT`** so build-vs-probe hashing is identical. Text keys bridge via DuckDB's deterministic `hash()` masked to 63 bits: `(hash(x) & 9223372036854775807)::BIGINT` (`hash()` is `UBIGINT` and overflows `BIGINT`).
- **Blobs are portable** — `ix-probabilistic` hashes with a fixed-seed `DefaultHasher`, so a serialized sketch probes identically on any machine (same Rust std version).
- **`ix-probabilistic` is stable-tier**: change is serde derives only — additive trait impls, **no `pub`-API line change**, so the stable-surface gate is unaffected.
- **Validated builds** (capacity ≥ 1, fp/delta ∈ (0,1), epsilon > 0); a full Cuckoo filter **errors** rather than silently dropping items (preserves the no-false-negatives contract).
- Pure wraps — **zero algorithm code** in ix-duck.

## Testing
- 7 new `ix-duck` tests (suite 39 → **46**); `ix-probabilistic` 14 tests unchanged; clippy clean (`--all-targets -D warnings`) on both.
- Full `cargo build --workspace` green — stable-crate change doesn't break consumers (ix-agent/ix-skill/ix-demo) and **no DuckDB pulled** into the default path.
- **End-to-end** through the rebuilt loadable extension via standalone `duckdb.exe`: Bloom membership + `hash()` bridge + union, HLL count + partition merge, CMS frequency, Cuckoo build/contains/remove (delete confirmed).
- Verified `docs/duck/pipelines.sql` recipe (Bloom dedup `distinct_a≈700`, HLL merge `distinct_union≈1000`).

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: opt-in `udf`/`duck` cargo features, never compiled by the default/CI path; surface is new UDFs with no runtime/service impact. Validate by `pwsh crates/ix-duck-ext/build.ps1` then `LOAD` + the smoke queries in `crates/ix-duck-ext/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)