### PR TITLE
feat(ix-duck): code-analysis UDFs — complexity/smells + tree-sitter AST queries

### DIFF
--- a/crates/ix-duck-ext/Cargo.toml
+++ b/crates/ix-duck-ext/Cargo.toml
@@ -24,6 +24,8 @@ crate-type = ["cdylib"]
 # LOAD time, no bundled engine, engine-version-tolerant (declares min_duckdb_version).
 duckdb = { version = "=1.10503.1", default-features = false, features = ["loadable-extension"] }
 # The UDF surface, sans bundled engine (ix-duck's `udf` feature => duckdb/vscalar).
-ix-duck = { path = "../ix-duck", default-features = false, features = ["udf"] }
+# `code-semantic` adds the tree-sitter code-analysis UDFs (ix_ast_query, …) — it
+# pulls C-compiled grammars, hence opt-in, but the shipped extension carries them.
+ix-duck = { path = "../ix-duck", default-features = false, features = ["udf", "code-semantic"] }
 # Tier-3 OPTIC-K table function: read the production voicing index mmap directly.
 ix-optick = { path = "../ix-optick" }

--- a/crates/ix-duck-ext/README.md
+++ b/crates/ix-duck-ext/README.md
@@ -87,6 +87,36 @@ Two caveats:
   fingerprint) with a real entry can evict that entry — an inherent property of
   Cuckoo filters, not a bug. Don't run deletes on keys outside the inserted set.
 
+### Code analysis (SQL over a codebase, incl. tree-sitter)
+
+Pair with DuckDB's `read_text('crates/**/*.rs')` (rows of `filename, content`) and
+these scalar UDFs give you SQL over an entire codebase — wraps `ix-code`.
+
+| tier | UDF | returns |
+|---|---|---|
+| **A** | `ix_code_complexity(source VARCHAR, language VARCHAR) -> DOUBLE` | file-scope cyclomatic complexity |
+| **A** | `ix_code_metrics(source VARCHAR, language VARCHAR) -> VARCHAR` | JSON `FileMetrics` (complexity + Halstead + SLOC, per function) |
+| **A** | `ix_code_smells(source VARCHAR, language VARCHAR) -> VARCHAR` | JSON `[{name,line,severity,message}]` |
+| **B** | `ix_semantic_metrics(source VARCHAR, language VARCHAR) -> VARCHAR` | JSON — parse_quality, AST node count, nesting, error-handling density, unsafe blocks, call graph |
+| **B** | `ix_ast_query(source VARCHAR, language VARCHAR, query VARCHAR) -> VARCHAR` | JSON `[{capture,text,start_line,end_line,start_col}]` for a tree-sitter S-expression query |
+
+```sql
+-- Rank a codebase by complexity (Tier A — no tree-sitter):
+SELECT filename, ix_code_complexity(content, filename) AS cc
+FROM read_text('crates/**/*.rs') ORDER BY cc DESC LIMIT 20;
+
+-- Find every function definition via a tree-sitter query (Tier B):
+SELECT filename, ix_ast_query(content, 'rust', '(function_item name:(identifier) @fn)') AS fns
+FROM read_text('crates/ix-duck/src/*.rs');
+```
+
+The `language` arg is flexible — an extension (`'rs'`), a path/filename (so
+`read_text`'s `filename` column works directly), or a name (`'rust'`); an
+unrecognised value is a SQL error. Tier A is keyword-based and always present.
+**Tier B** (`ix_ast_query`, `ix_semantic_metrics`) needs the `code-semantic`
+cargo feature (enabled in this extension's build) — it pulls C-compiled
+tree-sitter grammars (Rust/C#/TS/JS/F#); other languages return `parse_quality 0`.
+
 ## Build
 
 ```powershell
@@ -94,7 +124,8 @@ pwsh crates/ix-duck-ext/build.ps1              # → ix.duckdb_extension
 pwsh crates/ix-duck-ext/build.ps1 -SmokeTest   # also LOAD into duckdb.exe and assert
 ```
 
-Requires `cargo`, `python` (for the metadata footer), and `duckdb.exe` on PATH.
+Requires `cargo`, `python` (for the metadata footer), `duckdb.exe` on PATH, and a
+C compiler (the `code-semantic` tree-sitter grammars build from C).
 This crate is **excluded** from the ix workspace, so `cargo build --workspace`
 never compiles it (preserving the "default/CI build never pulls DuckDB" invariant).
 

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -28,6 +28,7 @@ ix-bracelet = { workspace = true, optional = true }
 ix-graph = { workspace = true, optional = true }
 ix-signal = { workspace = true, optional = true }
 ix-probabilistic = { workspace = true, optional = true }
+ix-code = { workspace = true, optional = true }
 ndarray = { workspace = true, optional = true }
 # Chatbot flight recorder (Slice A/B): the regression gate serializes a JSON contract.
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -40,7 +41,12 @@ chrono = { workspace = true, optional = true }
 # functions), so no bundled engine is pulled — this is the feature the loadable
 # C-API extension (ix-duck-ext) depends on. ix-unsupervised (PCA) + serde_json
 # (JSON params) are needed by the table functions.
-udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ix-supervised", "dep:ix-bracelet", "dep:ix-graph", "dep:ix-signal", "dep:ix-probabilistic", "dep:ndarray", "dep:serde_json"]
+udf = ["dep:duckdb", "duckdb/vscalar", "dep:ix-math", "dep:ix-unsupervised", "dep:ix-supervised", "dep:ix-bracelet", "dep:ix-graph", "dep:ix-signal", "dep:ix-probabilistic", "dep:ix-code", "dep:ndarray", "dep:serde_json"]
+# Tier B code analysis: adds tree-sitter AST queries + semantic metrics
+# (ix_ast_query, ix_semantic_metrics) by enabling ix-code's `semantic` feature.
+# Separate because it pulls C-compiled tree-sitter grammars; Tier A
+# (ix_code_complexity/metrics/smells) is in `udf` and needs no grammars.
+code-semantic = ["udf", "ix-code/semantic"]
 # Full in-process DuckDB bench: UDFs + a bundled (C++) engine + json read + the
 # chatbot flight recorder. Off by default so the workspace/CI build stays clean.
 duck = ["udf", "duckdb/bundled", "duckdb/json", "duckdb/parquet", "dep:serde", "dep:chrono"]

--- a/crates/ix-duck/src/code.rs
+++ b/crates/ix-duck/src/code.rs
@@ -1,0 +1,316 @@
+//! Code-analysis UDFs over `ix-code` — SQL over a whole codebase.
+//!
+//! Pair these with DuckDB's `read_text('crates/**/*.rs')` (which yields
+//! `(filename, content)` rows) to query complexity, smells, and — with the
+//! `code-semantic` feature — tree-sitter AST matches across a corpus:
+//!
+//! ```sql
+//! SELECT filename, ix_code_complexity(content, filename) AS cc
+//! FROM read_text('crates/**/*.rs') ORDER BY cc DESC LIMIT 20;
+//! ```
+//!
+//! All are **scalar** UDFs `(source VARCHAR, language VARCHAR[, query]) -> …` so
+//! they run row-wise over a source column (table functions can't take a column
+//! argument). The `language` arg is flexible: an extension (`'rs'`), a path/
+//! filename (`'src/x.rs'`, so `read_text`'s `filename` works directly), or a
+//! name (`'rust'`). Pure wraps of `ix-code` — no analysis logic here.
+//!
+//! | tier | UDF | wraps |
+//! |---|---|---|
+//! | A | `ix_code_complexity(src, lang) -> DOUBLE` | `analyze_source` file-scope cyclomatic |
+//! | A | `ix_code_metrics(src, lang) -> VARCHAR` (JSON `FileMetrics`) | `analyze_source` |
+//! | A | `ix_code_smells(src, lang) -> VARCHAR` (JSON `[CodeSmell]`) | `detect_smells` |
+//! | B | `ix_semantic_metrics(src, lang) -> VARCHAR` (JSON) | `extract_semantic_metrics_for` (tree-sitter) |
+//! | B | `ix_ast_query(src, lang, query) -> VARCHAR` (JSON `[AstMatch]`) | `run_ast_query` (tree-sitter) |
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::ffi::duckdb_string_t;
+use duckdb::types::DuckString;
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_code::analyze::{analyze_source, Language};
+use ix_code::smells::detect_smells;
+use std::error::Error;
+use std::ffi::CString;
+use std::path::Path;
+
+type Res = Result<(), Box<dyn Error>>;
+
+fn ty(id: LogicalTypeId) -> LogicalTypeHandle {
+    LogicalTypeHandle::from(id)
+}
+
+/// Read a `VARCHAR` column into owned `String`s (one per row).
+fn read_varchar_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<String> {
+    let v = input.flat_vector(col);
+    let slice = unsafe { v.as_slice_with_len::<duckdb_string_t>(n) };
+    slice
+        .iter()
+        .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string())
+        .collect()
+}
+
+fn write_varchar(output: &mut dyn WritableVector, vals: &[String]) -> Res {
+    let out = output.flat_vector();
+    for (i, v) in vals.iter().enumerate() {
+        out.insert(i, CString::new(v.as_str())?);
+    }
+    Ok(())
+}
+
+fn write_f64(output: &mut dyn WritableVector, vals: &[f64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<f64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+/// Resolve a language token: an extension (`rs`), a path/filename (`a/b.rs`), or
+/// a language name (`rust`). `None` if unrecognised.
+fn parse_language(tok: &str) -> Option<Language> {
+    let t = tok.trim();
+    Language::from_extension(t)
+        .or_else(|| Language::from_path(Path::new(t)))
+        .or_else(|| match t.to_lowercase().as_str() {
+            "rust" => Some(Language::Rust),
+            "python" => Some(Language::Python),
+            "javascript" => Some(Language::JavaScript),
+            "typescript" => Some(Language::TypeScript),
+            "cpp" | "c" | "c++" => Some(Language::Cpp),
+            "java" => Some(Language::Java),
+            "go" | "golang" => Some(Language::Go),
+            "csharp" | "c#" => Some(Language::CSharp),
+            "fsharp" | "f#" => Some(Language::FSharp),
+            "php" => Some(Language::Php),
+            "ruby" => Some(Language::Ruby),
+            _ => None,
+        })
+}
+
+/// Resolve the language token or produce a SQL error naming the offending value.
+fn lang_or_err(fname: &str, tok: &str) -> Result<Language, Box<dyn Error>> {
+    parse_language(tok)
+        .ok_or_else(|| format!("{fname}: unrecognised language/extension {tok:?}").into())
+}
+
+fn src_lang_sig(ret: LogicalTypeId) -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+        ty(ret),
+    )]
+}
+
+// ── Tier A: metrics / smells (no tree-sitter) ────────────────────────────────
+
+struct IxCodeComplexity;
+impl VScalar for IxCodeComplexity {
+    type State = ();
+    // @ai:invariant ix_code_complexity returns the file-scope cyclomatic complexity from ix_code::analyze_source for the source+language; unrecognised language -> SQL error [T:test conf:0.85 src:ix_duck::code::tests::complexity_counts_branches]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let src = read_varchar_col(input, 0, n);
+        let lang = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let l = lang_or_err("ix_code_complexity", &lang[i])?;
+            out.push(analyze_source(&src[i], l, Path::new(&lang[i])).file_scope.cyclomatic);
+        }
+        write_f64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        src_lang_sig(LogicalTypeId::Double)
+    }
+}
+
+struct IxCodeMetrics;
+impl VScalar for IxCodeMetrics {
+    type State = ();
+    // @ai:invariant ix_code_metrics returns the full ix_code::FileMetrics (file_scope + per-function complexity/Halstead/SLOC) as JSON; unrecognised language -> SQL error [T:test conf:0.85 src:ix_duck::code::tests::metrics_json_has_fields]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let src = read_varchar_col(input, 0, n);
+        let lang = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let l = lang_or_err("ix_code_metrics", &lang[i])?;
+            let fm = analyze_source(&src[i], l, Path::new(&lang[i]));
+            out.push(serde_json::to_string(&fm)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        src_lang_sig(LogicalTypeId::Varchar)
+    }
+}
+
+struct IxCodeSmells;
+impl VScalar for IxCodeSmells {
+    type State = ();
+    // @ai:invariant ix_code_smells returns ix_code::detect_smells (lexical; AST-based too under code-semantic) as a JSON array of {name,line,severity,message}; unrecognised language -> SQL error [T:test conf:0.85 src:ix_duck::code::tests::smells_flags_todo]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let src = read_varchar_col(input, 0, n);
+        let lang = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let l = lang_or_err("ix_code_smells", &lang[i])?;
+            out.push(serde_json::to_string(&detect_smells(&src[i], l))?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        src_lang_sig(LogicalTypeId::Varchar)
+    }
+}
+
+// ── Tier B: tree-sitter AST queries + semantic metrics ───────────────────────
+
+#[cfg(feature = "code-semantic")]
+struct IxSemanticMetrics;
+#[cfg(feature = "code-semantic")]
+impl VScalar for IxSemanticMetrics {
+    type State = ();
+    // @ai:invariant ix_semantic_metrics returns ix_code::extract_semantic_metrics_for (tree-sitter) as JSON — parse_quality, ast_node_count, nesting, error-handling density, unsafe_blocks, call graph; languages without a bundled grammar yield parse_quality 0 [T:test conf:0.8 src:ix_duck::code::tests::semantic_metrics_parses_rust]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let src = read_varchar_col(input, 0, n);
+        let lang = read_varchar_col(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let l = lang_or_err("ix_semantic_metrics", &lang[i])?;
+            let m = ix_code::semantic::extract_semantic_metrics_for(&src[i], l);
+            out.push(serde_json::to_string(&m)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        src_lang_sig(LogicalTypeId::Varchar)
+    }
+}
+
+#[cfg(feature = "code-semantic")]
+struct IxAstQuery;
+#[cfg(feature = "code-semantic")]
+impl VScalar for IxAstQuery {
+    type State = ();
+    // @ai:invariant ix_ast_query runs a tree-sitter S-expression query (arg 3) against the source for the language, returning matches as a JSON array of {capture,text,start_line,end_line,start_col}; invalid query or grammar-less language -> SQL error [T:test conf:0.8 src:ix_duck::code::tests::ast_query_finds_functions]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let src = read_varchar_col(input, 0, n);
+        let lang = read_varchar_col(input, 1, n);
+        let query = read_varchar_col(input, 2, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let l = lang_or_err("ix_ast_query", &lang[i])?;
+            let matches = ix_code::semantic::run_ast_query(&src[i], l, &query[i])
+                .map_err(|e| format!("ix_ast_query: {e}"))?;
+            out.push(serde_json::to_string(&matches)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![
+                ty(LogicalTypeId::Varchar),
+                ty(LogicalTypeId::Varchar),
+                ty(LogicalTypeId::Varchar),
+            ],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+/// Register the code-analysis UDFs (Tier A always; Tier B under `code-semantic`).
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxCodeComplexity>("ix_code_complexity")?;
+    conn.register_scalar_function::<IxCodeMetrics>("ix_code_metrics")?;
+    conn.register_scalar_function::<IxCodeSmells>("ix_code_smells")?;
+    #[cfg(feature = "code-semantic")]
+    {
+        conn.register_scalar_function::<IxSemanticMetrics>("ix_semantic_metrics")?;
+        conn.register_scalar_function::<IxAstQuery>("ix_ast_query")?;
+    }
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    fn s(sql: &str) -> String {
+        open_bench()
+            .unwrap()
+            .query_row(sql, [], |r| r.get::<_, String>(0))
+            .unwrap()
+    }
+    fn f(sql: &str) -> f64 {
+        open_bench()
+            .unwrap()
+            .query_row(sql, [], |r| r.get::<_, f64>(0))
+            .unwrap()
+    }
+
+    const BRANCHY: &str = "fn f(x:i32)->i32{ if x>0 { 1 } else if x<0 { 2 } else { 3 } }";
+
+    #[test]
+    fn complexity_counts_branches() {
+        // Multiple branches → cyclomatic well above 1.
+        assert!(f(&format!("SELECT ix_code_complexity('{BRANCHY}', 'rust')")) > 1.0);
+        // Extension and path tokens resolve the same language.
+        assert!(f(&format!("SELECT ix_code_complexity('{BRANCHY}', 'rs')")) > 1.0);
+        assert!(f(&format!("SELECT ix_code_complexity('{BRANCHY}', 'a/b.rs')")) > 1.0);
+    }
+
+    #[test]
+    fn metrics_json_has_fields() {
+        let j = s(&format!("SELECT ix_code_metrics('{BRANCHY}', 'rust')"));
+        assert!(j.contains("cyclomatic") && j.contains("maintainability_index"));
+    }
+
+    #[test]
+    fn smells_flags_todo() {
+        // A TODO marker is a lexical smell, available without tree-sitter.
+        let j = s("SELECT ix_code_smells('// TODO: fix this\nlet y = 1;', 'rust')");
+        assert!(j.contains("todo") || j.to_lowercase().contains("todo"));
+    }
+
+    #[test]
+    fn unrecognised_language_errors() {
+        let conn = open_bench().unwrap();
+        let r = conn.query_row("SELECT ix_code_complexity('x', 'klingon')", [], |r| {
+            r.get::<_, f64>(0)
+        });
+        assert!(r.is_err(), "unknown language should be a SQL error");
+    }
+
+    #[cfg(feature = "code-semantic")]
+    #[test]
+    fn semantic_metrics_parses_rust() {
+        let j = s("SELECT ix_semantic_metrics('fn main(){ let x: i32 = 1; }', 'rust')");
+        assert!(j.contains("parse_quality") && j.contains("ast_node_count"));
+    }
+
+    #[cfg(feature = "code-semantic")]
+    #[test]
+    fn ast_query_finds_functions() {
+        // Tree-sitter query for Rust function names.
+        let j = s(
+            "SELECT ix_ast_query('fn add(){} fn main(){}', 'rust', \
+             '(function_item name: (identifier) @fn)')",
+        );
+        assert!(j.contains("add") && j.contains("main"));
+    }
+
+    #[cfg(feature = "code-semantic")]
+    #[test]
+    fn ast_query_invalid_query_errors() {
+        let conn = open_bench().unwrap();
+        let r = conn.query_row(
+            "SELECT ix_ast_query('fn main(){}', 'rust', '(this is not valid')",
+            [],
+            |r| r.get::<_, String>(0),
+        );
+        assert!(r.is_err(), "invalid tree-sitter query should be a SQL error");
+    }
+}

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -50,6 +50,12 @@ mod eval;
 #[cfg(feature = "udf")]
 mod sketch;
 
+/// Code-analysis UDFs over `ix-code` — complexity/metrics/smells (Tier A) and,
+/// under the `code-semantic` feature, tree-sitter AST queries + semantic metrics
+/// (ix_code_*, ix_ast_query, ix_semantic_metrics). Registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod code;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -119,5 +119,6 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     crate::graphsig::register(conn)?;
     crate::eval::register(conn)?;
     crate::sketch::register(conn)?;
+    crate::code::register(conn)?;
     Ok(())
 }

--- a/docs/DUCKDB.md
+++ b/docs/DUCKDB.md
@@ -47,6 +47,7 @@ data. Integration is by **format contract** (clean stable-schema JSONL/Parquet),
   - `ix_classification_report(predicted_json, actual_json)` — per-class precision/recall/f1/support ✅ (table fn; wraps `ix-supervised::metrics`; GA routing per-intent eval)
   - `ix_knn_leakage(vectors_json, labels_json, k)` — embedding separability/leakage ✅ (table fn; mean k-NN label agreement vs `random_baseline`; the lightweight form of GA's embeddings diagnostic)
   - `ix_bloom_*` / `ix_hll_*` / `ix_cms_*` / `ix_cuckoo_*` — probabilistic sketches ✅ (scalar **build → probe/merge** triads over `BIGINT[]` items; wraps `ix-probabilistic`; sketches are portable JSON blobs — set membership / cardinality / frequency / membership-with-delete that DuckDB exposes none of). Items are `BIGINT`; text keys bridge via `(hash(x) & 9223372036854775807)::BIGINT`. See `crates/ix-duck-ext/README.md` → *Probabilistic sketches*.
+  - `ix_code_complexity` / `ix_code_metrics` / `ix_code_smells` (Tier A) + `ix_semantic_metrics` / `ix_ast_query` (Tier B, `code-semantic` feature) — code analysis ✅ (scalar over a source-`VARCHAR` column; pair with `read_text('**/*.rs')` for SQL over a whole codebase; wraps `ix-code`. Tier B is real **tree-sitter** AST queries / semantic metrics — C-compiled grammars for Rust/C#/TS/JS/F#). See `crates/ix-duck-ext/README.md` → *Code analysis*.
 
 - **Crate structure:** new `crates/ix-duck` (library only), `duckdb` as an **optional dep** behind a
   `duck` cargo feature. Mirrors the established `fastembed`/`embeddings` pattern in `ix-skill`

--- a/docs/duck/pipelines.sql
+++ b/docs/duck/pipelines.sql
@@ -91,3 +91,21 @@ SET VARIABLE hll_a = (SELECT ix_hll_build(list(r), 14) FROM range(0, 700)   t(r)
 SET VARIABLE hll_b = (SELECT ix_hll_build(list(r), 14) FROM range(300, 1000) t(r));
 SELECT ix_hll_count(getvariable('hll_a'))                                AS distinct_a,   -- ~700
        ix_hll_count(ix_hll_merge(getvariable('hll_a'), getvariable('hll_b'))) AS distinct_union; -- ~1000 (overlap 300..700 counted once)
+
+-- ── Pipeline 7: SQL over a codebase (ix-code; Tier B needs code-semantic) ─────
+-- read_text() yields (filename, content) rows; the scalar ix_code_* / ix_ast_query
+-- UDFs then analyse each file. Nothing else does code analysis in SQL.
+
+-- 7a. Complexity hot-spots across the crate (Tier A — no tree-sitter).
+SELECT filename, round(ix_code_complexity(content, filename), 0) AS cyclomatic
+FROM read_text('crates/ix-duck/src/*.rs')
+ORDER BY cyclomatic DESC
+LIMIT 5;
+
+-- 7b. Tree-sitter AST query: count function definitions per file (Tier B).
+SELECT regexp_replace(filename, '.*[\\/]', '') AS file,
+       len(from_json(ix_ast_query(content, 'rust',
+            '(function_item name:(identifier) @fn)'), '["json"]')) AS fn_defs
+FROM read_text('crates/ix-duck/src/*.rs')
+ORDER BY fn_defs DESC
+LIMIT 5;


### PR DESCRIPTION
## Summary

Exposes `ix-code` as DuckDB SQL UDFs, so `read_text('crates/**/*.rs')` + a scalar gives **SQL over an entire codebase** — the offline-catalog lane CLAUDE.md assigns to the `ix-code-*` crates (sentrux owns realtime). Answers "can we get tree-sitter / IX code analysis from DuckDB?" — now yes.

**Tier A** (in the `udf` feature, keyword-based, no tree-sitter):
| UDF | returns |
|---|---|
| `ix_code_complexity(src, lang) -> DOUBLE` | file-scope cyclomatic |
| `ix_code_metrics(src, lang) -> VARCHAR` | JSON `FileMetrics` (complexity + Halstead + SLOC, per function) |
| `ix_code_smells(src, lang) -> VARCHAR` | JSON `[{name,line,severity,message}]` |

**Tier B** (new `code-semantic` feature → `ix-code/semantic`; C-compiled tree-sitter grammars for Rust/C#/TS/JS/F#):
| UDF | returns |
|---|---|
| `ix_semantic_metrics(src, lang) -> VARCHAR` | parse_quality, AST node count, nesting, error-handling density, unsafe blocks, call graph |
| `ix_ast_query(src, lang, query) -> VARCHAR` | JSON matches for a tree-sitter S-expression query |

```sql
SELECT filename, ix_code_complexity(content, filename) AS cc
FROM read_text('crates/**/*.rs') ORDER BY cc DESC LIMIT 20;

SELECT ix_ast_query(content, 'rust', '(function_item name:(identifier) @fn)')
FROM read_text('crates/ix-duck/src/*.rs');
```

## Key decisions
- **All scalars over a source `VARCHAR` column** (table fns can't take a column arg) — composes with `read_text`.
- **Flexible `language` arg**: extension (`'rs'`), path/filename (so `read_text`'s `filename` works directly), or name (`'rust'`); unrecognised → SQL error.
- **`code-semantic` is separate from `udf`** because of the C grammar build; the loadable extension enables it so the shipped artifact carries Tier B. Tier A needs no grammars.
- Pure wraps of `ix-code` — zero analysis logic in ix-duck.

## Testing
- 7 new tests; ix-duck suite 47 → **54** with `code-semantic`. Tier A's 4 run under `duck` alone with Tier B **correctly gated out**. clippy clean in both `duck,code-semantic` and `udf`-only combos; default featureless ix-duck still compiles.
- **End-to-end through the rebuilt loadable extension over this repo**: complexity ranking of `crates/ix-duck/src` (chatbot.rs 87), a tree-sitter query counting **46 fn defs** in sketch.rs, semantic `parse_quality 1.0`.
- Verified `docs/duck/pipelines.sql` Pipeline 7 (complexity hot-spots + AST fn-count).

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: opt-in `udf` / `code-semantic` cargo features, never compiled by the default/CI path; new UDFs, no runtime/service impact. Validate via `pwsh crates/ix-duck-ext/build.ps1` then the `read_text` queries in `crates/ix-duck-ext/README.md` → *Code analysis*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)