### PR TITLE
feat(ix-duck): maintain-gate Phase 1 — convergence + drift lenses (D/P reachable)

### DIFF
--- a/crates/ix-duck/examples/ix_maintain_gate.rs
+++ b/crates/ix-duck/examples/ix_maintain_gate.rs
@@ -18,16 +18,20 @@ fn default_hits() -> PathBuf {
     PathBuf::from("state/thinking-machine/hits.jsonl")
 }
 
-fn default_corpus() -> PathBuf {
+fn ga_quality() -> PathBuf {
     if let Ok(root) = std::env::var("GA_ROOT") {
-        return PathBuf::from(root).join("state/quality/chatbot-qa");
+        return PathBuf::from(root).join("state/quality");
     }
     let cwd = std::env::current_dir().unwrap_or_default();
     let ix_root = cwd.canonicalize().unwrap_or(cwd);
     ix_root
         .parent()
-        .map(|p| p.join("ga/state/quality/chatbot-qa"))
-        .unwrap_or_else(|| PathBuf::from("../ga/state/quality/chatbot-qa"))
+        .map(|p| p.join("ga/state/quality"))
+        .unwrap_or_else(|| PathBuf::from("../ga/state/quality"))
+}
+
+fn default_corpus() -> PathBuf {
+    ga_quality().join("chatbot-qa")
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -46,9 +50,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let conn = ix_duck::open_bench()?;
     let run_at = chrono::Utc::now().to_rfc3339();
+    // Phase 1: also consult the convergence + drift lenses (advisory — absent dirs
+    // degrade to "no data", never block).
+    let loops_dir = ga_quality().join("loops");
+    let emb_dir = ga_quality().join("query-embeddings");
     let inputs = MaintainInputs {
         hits_path: &hits,
         corpus_dir: &corpus,
+        loops_dir: Some(&loops_dir),
+        query_embeddings_dir: Some(&emb_dir),
         run_at: &run_at,
     };
     let verdict = maintain::evaluate(&conn, &MaintainConfig::default(), &inputs)?;

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -1,25 +1,33 @@
-//! `maintain-gate` — a fail-closed RSI evaluation oracle (Phase 0 tracer bullet).
+//! `maintain-gate` — a fail-closed RSI evaluation oracle (Phase 1).
 //!
 //! Fuses the DuckDB+IX maintain lenses into ONE hexavalent verdict (T/P/U/D/F/C)
-//! per self-improvement iteration. Phase 0 fuses the two **live** lenses:
+//! per self-improvement iteration:
 //! - **metric** — yield over an externally-derived `hits.jsonl` (harness-written),
 //!   split by `ts_ms` into earlier/later halves (NOT the cumulative mean).
 //! - **guardrail** — `chatbot::check_regressions` (held-capability regression gate).
+//! - **convergence** — `loops::oscillating_loops`: a loop that flips improve↔regress
+//!   is thrashing, not converging.
+//! - **drift** — `ood::flag_ood`: queries that fall out-of-distribution.
 //!
-//! The core anti-Goodhart rule is a **conjunction, never an average**:
+//! The core anti-Goodhart rule is a **conjunction, never an average**. The two hard
+//! lenses (metric ∧ guardrail) decide accept/reject/contradiction; the two soft
+//! lenses then downgrade an otherwise-clean accept:
 //!
-//!   ACCEPT (T)  iff  metric↑  AND  guardrail held
+//!   metric↑ ∧ guardrail held ∧ converging ∧ in-distribution → T (accept)
+//!   metric↑ ∧ guardrail held ∧ converging ∧ drifting        → P (accept w/ flag)
+//!   metric↑ ∧ guardrail held ∧ oscillating                  → D (escalate, disputed)
+//!   metric↑ ∧ guardrail broke                               → C (reject + alarm: reward-hack)
 //!
-//! The case that matters most is **C (contradiction)**: metric up *while* a held
-//! capability breaks — the reward-hack signature — which hard-fails + alarms, never
-//! averages out. Per panel review (2026-06-16, Codex + Gemini): the metric must be
-//! externally derived (never a self-declared delta), and the verdict records the
-//! **evidence provenance** (source + content hash), not just the verdict line.
+//! **C (contradiction)** is the case that matters most — metric up *while* a held
+//! capability breaks — which hard-fails + alarms, never averages out. Fail-closed:
+//! a required-but-dormant lens (`require_loops`/`require_ood`) escalates to **U**,
+//! never silent ACCEPT; soft lenses default off (advisory) so the gate is usable
+//! while `loops`/`ood` warm up. Per panel review (2026-06-16, Codex + Gemini): the
+//! metric must be externally derived (never a self-declared delta), and the verdict
+//! records **evidence provenance** (source + content hash), not just the verdict line.
 //!
-//! `loops` (convergence) and `ood` (drift) join in Phase 1; here they are off
-//! (`require_loops`/`require_ood` default false) so the gate never deadlocks on U
-//! while those lenses warm up. DuckDB is the referee, never the player: ground
-//! truth stays executable; this only aggregates evidence about it.
+//! DuckDB is the referee, never the player: ground truth stays executable; this only
+//! aggregates evidence about it.
 
 use std::path::Path;
 
@@ -34,6 +42,8 @@ pub enum MaintainError {
     Io(std::io::Error),
     Duck(duckdb::Error),
     Chatbot(chatbot::ChatbotError),
+    Loops(crate::loops::LoopError),
+    Ood(crate::ood::OodError),
 }
 impl std::fmt::Display for MaintainError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -41,6 +51,8 @@ impl std::fmt::Display for MaintainError {
             MaintainError::Io(e) => write!(f, "maintain I/O error: {e}"),
             MaintainError::Duck(e) => write!(f, "duckdb error: {e}"),
             MaintainError::Chatbot(e) => write!(f, "guardrail lens error: {e}"),
+            MaintainError::Loops(e) => write!(f, "convergence lens error: {e}"),
+            MaintainError::Ood(e) => write!(f, "drift lens error: {e}"),
         }
     }
 }
@@ -60,16 +72,30 @@ impl From<chatbot::ChatbotError> for MaintainError {
         MaintainError::Chatbot(e)
     }
 }
+impl From<crate::loops::LoopError> for MaintainError {
+    fn from(e: crate::loops::LoopError) -> Self {
+        MaintainError::Loops(e)
+    }
+}
+impl From<crate::ood::OodError> for MaintainError {
+    fn from(e: crate::ood::OodError) -> Self {
+        MaintainError::Ood(e)
+    }
+}
 
 /// Gate thresholds + which lenses are required.
 #[derive(Debug, Clone)]
 pub struct MaintainConfig {
     /// Minimum metric delta to count as an improvement (anti-noise epsilon).
     pub min_metric_delta: f64,
-    /// Phase 1: require the convergence lens (dormant in Phase 0).
+    /// Require the convergence lens — a dormant/absent loop ledger then escalates (U).
     pub require_loops: bool,
-    /// Phase 1: require the drift lens (dormant in Phase 0).
+    /// Require the drift lens — a dormant/absent embedding sink then escalates (U).
     pub require_ood: bool,
+    /// Nearest-neighbour count for the OOD score (mean top-k cosine).
+    pub ood_k: i64,
+    /// OOD flag threshold — queries scoring below this are out-of-distribution.
+    pub ood_threshold: f64,
 }
 impl Default for MaintainConfig {
     fn default() -> Self {
@@ -77,6 +103,8 @@ impl Default for MaintainConfig {
             min_metric_delta: 1e-9,
             require_loops: false,
             require_ood: false,
+            ood_k: 3,
+            ood_threshold: 0.5,
         }
     }
 }
@@ -86,6 +114,10 @@ impl Default for MaintainConfig {
 pub struct MaintainInputs<'a> {
     pub hits_path: &'a Path,
     pub corpus_dir: &'a Path,
+    /// Loop-iteration ledger dir (convergence lens). `None` = lens not consulted.
+    pub loops_dir: Option<&'a Path>,
+    /// Query-embeddings dir (drift lens). `None` = lens not consulted.
+    pub query_embeddings_dir: Option<&'a Path>,
     pub run_at: &'a str,
 }
 
@@ -123,6 +155,12 @@ pub struct MaintainVerdict {
     pub metric_up: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub guardrail_held: Option<bool>,
+    /// `Some(true)` converging, `Some(false)` oscillating, `None` not consulted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub converging: Option<bool>,
+    /// `Some(true)` queries drifting out-of-distribution, `Some(false)` in-distribution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drifting: Option<bool>,
     pub signals: Vec<Signal>,
     pub evidence: Vec<Evidence>,
     pub reason: String,
@@ -207,55 +245,100 @@ pub fn evaluate(
             ),
         },
     ];
-    if cfg.require_loops {
-        signals.push(Signal {
-            lens: "loops".into(),
-            ok: None,
-            detail: "required but Phase 0 dormant".into(),
-        });
-    }
-    if cfg.require_ood {
-        signals.push(Signal {
-            lens: "ood".into(),
-            ok: None,
-            detail: "required but Phase 0 dormant".into(),
-        });
-    }
+    // --- convergence lens (loops) + drift lens (ood) ---
+    let converging = match inputs.loops_dir {
+        Some(dir) => {
+            crate::loops::build_loop_iterations(conn, dir)?;
+            Some(crate::loops::oscillating_loops(conn)?.is_empty())
+        }
+        None => None,
+    };
+    let drifting = match inputs.query_embeddings_dir {
+        Some(dir) => {
+            crate::ood::build_query_embeddings(conn, dir)?;
+            Some(!crate::ood::flag_ood(conn, cfg.ood_k, cfg.ood_threshold)?.is_empty())
+        }
+        None => None,
+    };
+    signals.push(Signal {
+        lens: "convergence".into(),
+        ok: converging,
+        detail: match converging {
+            Some(true) => "loops converging (no oscillation)".into(),
+            Some(false) => "loops OSCILLATING — thrash, not convergence".into(),
+            None if cfg.require_loops => "required but loop ledger dormant".into(),
+            None => "no loop data (advisory)".into(),
+        },
+    });
+    signals.push(Signal {
+        lens: "drift".into(),
+        ok: drifting.map(|d| !d),
+        detail: match drifting {
+            Some(true) => "queries DRIFTING out-of-distribution".into(),
+            Some(false) => "queries in-distribution".into(),
+            None if cfg.require_ood => "required but embedding sink dormant".into(),
+            None => "no query embeddings (advisory)".into(),
+        },
+    });
 
     // --- conjunction → hexavalent status (fail-closed) ---
-    let required_unknown = cfg.require_loops || cfg.require_ood;
-    let (status, decision, reason) = match (metric_up, guardrail_held) {
-        _ if required_unknown => (
+    // A required-but-dormant lens escalates before anything else.
+    let dormant_required =
+        (cfg.require_loops && converging.is_none()) || (cfg.require_ood && drifting.is_none());
+    let (status, decision, reason) = if dormant_required {
+        (
             "U",
             "escalate",
             "a required lens is dormant (no signal)".to_string(),
-        ),
-        (None, _) => (
-            "U",
-            "escalate",
-            "metric evidence missing — cannot decide".to_string(),
-        ),
-        (_, None) => (
-            "U",
-            "escalate",
-            format!("guardrail inconclusive ({})", report.status),
-        ),
-        (Some(true), Some(false)) => (
-            "C",
-            "reject",
-            "REWARD-HACK: metric improved while a held capability regressed".to_string(),
-        ),
-        (Some(true), Some(true)) => (
-            "T",
-            "accept",
-            "metric improved and guardrail held".to_string(),
-        ),
-        (Some(false), Some(false)) => (
-            "F",
-            "reject",
-            "no improvement and guardrail regressed".to_string(),
-        ),
-        (Some(false), Some(true)) => ("F", "reject", "no metric improvement".to_string()),
+        )
+    } else {
+        match (metric_up, guardrail_held) {
+            (None, _) => (
+                "U",
+                "escalate",
+                "metric evidence missing — cannot decide".to_string(),
+            ),
+            (_, None) => (
+                "U",
+                "escalate",
+                format!("guardrail inconclusive ({})", report.status),
+            ),
+            (Some(true), Some(false)) => (
+                "C",
+                "reject",
+                "REWARD-HACK: metric improved while a held capability regressed".to_string(),
+            ),
+            (Some(false), Some(false)) => (
+                "F",
+                "reject",
+                "no improvement and guardrail regressed".to_string(),
+            ),
+            (Some(false), Some(true)) => ("F", "reject", "no metric improvement".to_string()),
+            // Hard conjunction holds — the soft lenses can downgrade an accept.
+            (Some(true), Some(true)) => {
+                if converging == Some(false) {
+                    (
+                        "D",
+                        "escalate",
+                        "metric improved but the loop is oscillating (not converging)".to_string(),
+                    )
+                } else if drifting == Some(true) {
+                    (
+                        "P",
+                        "accept",
+                        "metric improved and guardrail held, but queries are drifting \
+                         out-of-distribution"
+                            .to_string(),
+                    )
+                } else {
+                    (
+                        "T",
+                        "accept",
+                        "metric improved and guardrail held".to_string(),
+                    )
+                }
+            }
+        }
     };
 
     // --- evidence provenance (hash the inputs, not just the verdict) ---
@@ -280,6 +363,8 @@ pub fn evaluate(
         metric_delta: delta,
         metric_up,
         guardrail_held,
+        converging,
+        drifting,
         signals,
         evidence,
         reason,
@@ -324,8 +409,17 @@ mod tests {
         MaintainInputs {
             hits_path: hits,
             corpus_dir: corpus,
+            loops_dir: None,
+            query_embeddings_dir: None,
             run_at: "2026-06-16T00:00:00Z",
         }
+    }
+
+    /// Path to a sibling lens fixture dir (loops / query-embeddings live one level up).
+    fn lens_fx(rel: &str) -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures")
+            .join(rel)
     }
 
     #[test]
@@ -399,6 +493,72 @@ mod tests {
             "metric evidence is content-hashed"
         );
         assert!(v.evidence.iter().any(|e| e.kind == "guardrail-baseline"));
+    }
+
+    #[test]
+    fn oscillating_loop_disputes_an_accept() {
+        // metric↑ + guardrail held, but the loop ledger is oscillating → D (disputed).
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let loops = lens_fx("loops"); // contains chatbot-oscillating
+        let i = MaintainInputs {
+            hits_path: &hits,
+            corpus_dir: &corpus,
+            loops_dir: Some(&loops),
+            query_embeddings_dir: None,
+            run_at: "2026-06-16T00:00:00Z",
+        };
+        let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
+        assert_eq!(v.status, "D", "{}", v.reason);
+        assert_eq!(v.decision, "escalate");
+        assert_eq!(v.converging, Some(false));
+        assert_eq!(exit_code(&v.status), 2);
+    }
+
+    #[test]
+    fn drift_flags_accept_as_probable() {
+        // metric↑ + guardrail held + converging, but queries drift OOD → P (accept w/ flag).
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let emb = lens_fx("query-embeddings"); // q-oos is out-of-distribution
+        let i = MaintainInputs {
+            hits_path: &hits,
+            corpus_dir: &corpus,
+            loops_dir: None,
+            query_embeddings_dir: Some(&emb),
+            run_at: "2026-06-16T00:00:00Z",
+        };
+        let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
+        assert_eq!(v.status, "P", "{}", v.reason);
+        assert_eq!(v.decision, "accept");
+        assert_eq!(v.drifting, Some(true));
+        assert_eq!(exit_code(&v.status), 0);
+    }
+
+    #[test]
+    fn converging_in_distribution_stays_true() {
+        // All four lenses positive → clean T. Loop dir is converging-only (a tempdir).
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("good.iterations.jsonl"),
+            "{\"loop_id\":\"l\",\"domain\":\"chatbot\",\"iteration\":1,\"ts\":\"2026-06-16T00:00:00Z\",\"oracle_status\":\"ok\",\"metric_name\":\"p\",\"metric_before\":0.8,\"metric_after\":0.9,\"metric_delta\":0.1,\"verdict\":\"improved\",\"worst_item\":\"x\",\"artifact_edited\":\"a.cs\",\"commit_sha\":\"c\",\"roundtrip_passed\":true}\n",
+        )
+        .unwrap();
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let i = MaintainInputs {
+            hits_path: &hits,
+            corpus_dir: &corpus,
+            loops_dir: Some(dir.path()),
+            query_embeddings_dir: None,
+            run_at: "2026-06-16T00:00:00Z",
+        };
+        let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
+        assert_eq!(v.status, "T", "{}", v.reason);
+        assert_eq!(v.converging, Some(true));
     }
 
     #[test]

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -246,17 +246,34 @@ pub fn evaluate(
         },
     ];
     // --- convergence lens (loops) + drift lens (ood) ---
+    // KNOWN LIMITATION (Phase 1): the soft lenses aggregate over the *whole* ledger /
+    // embedding history, not just the iteration under evaluation. Scoping them to the
+    // current iteration needs the iteration-correlation key (loop_id / commit_sha,
+    // never wall-clock) the panel logged for Phase 3 — deferred there, not half-built.
+    //
+    // A supplied-but-empty/dormant lens is *unknown* (None), NOT a positive signal:
+    // reading "no data" as converging / in-distribution would be a green light from
+    // no evidence — the opposite of fail-closed (and, when required, must escalate).
     let converging = match inputs.loops_dir {
         Some(dir) => {
             crate::loops::build_loop_iterations(conn, dir)?;
-            Some(crate::loops::oscillating_loops(conn)?.is_empty())
+            // loop_summary excludes seed/test rows → empty means no real iterations yet.
+            if crate::loops::loop_summary(conn)?.is_empty() {
+                None
+            } else {
+                Some(crate::loops::oscillating_loops(conn)?.is_empty())
+            }
         }
         None => None,
     };
     let drifting = match inputs.query_embeddings_dir {
         Some(dir) => {
-            crate::ood::build_query_embeddings(conn, dir)?;
-            Some(!crate::ood::flag_ood(conn, cfg.ood_k, cfg.ood_threshold)?.is_empty())
+            // Need ≥2 queries to score nearest-neighbour density; fewer → unknown.
+            if crate::ood::build_query_embeddings(conn, dir)? < 2 {
+                None
+            } else {
+                Some(!crate::ood::flag_ood(conn, cfg.ood_k, cfg.ood_threshold)?.is_empty())
+            }
         }
         None => None,
     };
@@ -559,6 +576,50 @@ mod tests {
         let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
         assert_eq!(v.status, "T", "{}", v.reason);
         assert_eq!(v.converging, Some(true));
+    }
+
+    #[test]
+    fn dormant_lens_is_unknown_not_a_green_light() {
+        // A supplied loops dir with only the seed row → converging is unknown (None),
+        // not Some(true). Advisory → verdict still T; but required → escalates to U.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("__seed__.iterations.jsonl"),
+            "{\"loop_id\":\"__seed__\",\"domain\":\"__seed__\",\"iteration\":0,\"ts\":\"1970-01-01T00:00:00Z\",\"oracle_status\":\"ok\",\"metric_name\":\"none\",\"metric_before\":0.0,\"metric_after\":0.0,\"metric_delta\":0.0,\"verdict\":\"improved\",\"worst_item\":\"none\",\"artifact_edited\":\"none\",\"commit_sha\":\"none\",\"roundtrip_passed\":false}\n",
+        )
+        .unwrap();
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let mk = |cfg: &MaintainConfig| {
+            let i = MaintainInputs {
+                hits_path: &hits,
+                corpus_dir: &corpus,
+                loops_dir: Some(dir.path()),
+                query_embeddings_dir: None,
+                run_at: "2026-06-16T00:00:00Z",
+            };
+            evaluate(&conn, cfg, &i).unwrap()
+        };
+        let advisory = mk(&MaintainConfig::default());
+        assert_eq!(
+            advisory.converging, None,
+            "seed-only is unknown, not converging"
+        );
+        assert_eq!(
+            advisory.status, "T",
+            "advisory dormant lens doesn't block: {}",
+            advisory.reason
+        );
+        let required = mk(&MaintainConfig {
+            require_loops: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            required.status, "U",
+            "required dormant lens escalates: {}",
+            required.reason
+        );
     }
 
     #[test]

--- a/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
+++ b/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
@@ -126,20 +126,23 @@ reimplemented**:
 
 ## Implementation phases
 
-### Phase 0 — Tracer bullet (the vertical slice)
+### Phase 0 — Tracer bullet (the vertical slice) ✅ shipped (#119)
 The smallest end-to-end that touches every layer, per aihero discipline:
 `evaluate()` fusing **only two** lenses (yield metric ∧ chatbot guardrail) →
-`MaintainVerdict` → `write_contract` → `exit_code`, tested against:
-- [ ] a **pass** fixture (metric↑, guardrail held) → **T**
-- [ ] a **reward-hack** fixture (metric↑, guardrail broke) → **C**, exit 1
+`MaintainVerdict` → `append_to_ledger` → `exit_code`, tested against:
+- [x] a **pass** fixture (metric↑, guardrail held) → **T**
+- [x] a **reward-hack** fixture (metric↑, guardrail broke) → **C**, exit 1
 This proves the anti-Goodhart conjunction before scaling.
 
-### Phase 1 — Add convergence + drift
-- [ ] Fold in `loops` (converging) and `ood` (drifting) signals.
-- [ ] Graceful-degrade: dormant lens (absent data) → that signal is **U**, which
-      caps the overall verdict at **U** (escalate), never silently ACCEPT.
-- [ ] `require_loops`/`require_ood` config: when false, a dormant lens is advisory
-      not blocking (so the gate is usable today over the live lenses only).
+### Phase 1 — Add convergence + drift ✅ shipped
+- [x] Fold in `loops` (converging) and `ood` (drifting) signals — the two soft
+      lenses downgrade an otherwise-clean accept: oscillating → **D** (escalate),
+      drifting → **P** (accept w/ flag). Makes D/P reachable (Phase 0 was T/C/F/U).
+- [x] Graceful-degrade: a *required* dormant lens caps the verdict at **U**
+      (escalate), never silent ACCEPT; an *advisory* dormant lens is a no-op signal.
+- [x] `require_loops`/`require_ood` config: default false (advisory) so the gate is
+      usable over the live lenses today; `ood_k`/`ood_threshold` added. Verified
+      end-to-end over live `../ga` (T accept, all four signals green).
 
 ### Phase 2 — Contract + tamper-evidence
 - [ ] `docs/contracts/maintain-gate.contract.md` + JSON schema (v0.1 draft).

--- a/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
+++ b/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
@@ -155,6 +155,10 @@ This proves the anti-Goodhart conjunction before scaling.
       new MCP tool — **open question**, see below).
 - [ ] Document the loop integration: an RSI loop calls `gate` after each iteration;
       exit 1 → reject + revert, exit 2 → human escalate, exit 0 → propose-merge.
+- [ ] **Scope soft lenses to the current iteration** via the iteration-correlation
+      key (loop_id / commit_sha, never wall-clock). Phase 1 aggregates convergence +
+      drift over the *whole* history (known limitation, flagged in `maintain.rs`);
+      this is where it gets fixed, alongside the same key the panel required.
 
 ### Phase 4 — Freeze (one-way door)
 - [ ] Freeze contract schema + exit-code semantics only here. Log sign-off.


### PR DESCRIPTION
## Summary
Advances the maintain-gate RSI oracle from Phase 0 (2 lenses) to **Phase 1 (4 lenses)**, making the **D** and **P** hexavalent statuses reachable.

- **convergence** ← `loops::oscillating_loops`, **drift** ← `ood::flag_ood`.
- Two **hard** lenses (metric ∧ guardrail) decide accept/reject/contradiction; the two **soft** lenses downgrade an otherwise-clean accept:

| metric | guardrail | convergence | drift | verdict |
|---|---|---|---|---|
| ↑ | held | converging | in-dist | **T** accept |
| ↑ | held | converging | drifting | **P** accept w/ flag |
| ↑ | held | oscillating | — | **D** escalate (disputed) |
| ↑ | broke | — | — | **C** reject + alarm (reward-hack) |

- **Fail-closed preserved**: a *required* dormant lens → **U**; *advisory* dormant lens → no-op. `require_loops`/`require_ood` default false, so the gate runs over the live lenses today.
- `MaintainInputs` gains `loops_dir`/`query_embeddings_dir` (Option); `MaintainConfig` gains `ood_k`/`ood_threshold`; the verdict records `converging`/`drifting`.
- No lens logic reimplemented — `maintain` only composes existing functions.

## Verified
Live end-to-end over `../ga` + IX `hits.jsonl`: **T (accept)**, all four signals green (metric +0.0184, guardrail pass, converging, in-distribution), evidence hashed, appended to the ledger.

- 83 `--features duck` tests pass (+3: D-disputed, P-probable, converging-T); clippy (duck + default) + fmt clean.
- All behind the `duck` feature; default workspace build unaffected.

## Plan
`docs/plans/2026-06-16-002-…` Phase 0 + Phase 1 now marked shipped. Remaining: Phase 2 (contract + schema doc), Phase 3 (Demerzel wiring + loop integration), Phase 4 (freeze). The authoritative-gate preconditions (write-isolated telemetry, externally-derived metric) stay logged as Phase-3 gates.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: opt-in `duck`-feature analyst tooling, not built by the default/CI path or any production runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)