### PR TITLE
feat(ix-duck): maintain-gate Phase 2 — verdict contract + JSON schema

### DIFF
--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -622,6 +622,39 @@ mod tests {
         );
     }
 
+    /// Binds the emitted verdict to `docs/contracts/maintain-gate.contract.md`: the
+    /// required keys + the status enum must match the schema, so code/contract drift
+    /// is caught here rather than by a consumer.
+    #[test]
+    fn verdict_conforms_to_contract() {
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let v = evaluate(&conn, &MaintainConfig::default(), &inputs(&hits, &corpus)).unwrap();
+        let j: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&v).unwrap()).unwrap();
+        for key in [
+            "schema_version",
+            "run_at",
+            "status",
+            "decision",
+            "signals",
+            "evidence",
+            "reason",
+        ] {
+            assert!(j.get(key).is_some(), "contract requires key `{key}`");
+        }
+        assert_eq!(j["schema_version"], "maintain-gate.v0.1");
+        assert!(["T", "P", "U", "D", "F", "C"].contains(&j["status"].as_str().unwrap()));
+        assert!(["accept", "reject", "escalate"].contains(&j["decision"].as_str().unwrap()));
+        // Each evidence entry carries provenance (kind/source/hash).
+        for e in j["evidence"].as_array().unwrap() {
+            for k in ["kind", "source", "hash"] {
+                assert!(e.get(k).is_some(), "evidence entry needs `{k}`");
+            }
+        }
+    }
+
     #[test]
     fn ledger_append_is_additive() {
         let conn = crate::open_bench().unwrap();

--- a/docs/contracts/maintain-gate.contract.md
+++ b/docs/contracts/maintain-gate.contract.md
@@ -1,0 +1,106 @@
+# Contract: `maintain-gate` (v0.1 — draft)
+
+**Status:** v0.1 **draft** — documented shape + a companion `maintain-gate.schema.json`
+(draft-07, `additionalProperties: true`). Per CLAUDE.md, v0.1.x is a draft; the
+schema + exit-code semantics **freeze only at the named Phase-4 milestone**
+(`docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md`).
+**Producer:** `ix-duck` — `ix_duck::maintain::evaluate` (CLI: `ix_maintain_gate`).
+**Consumer:** none yet (intended: Demerzel governance + the bounded-RSI loop, read-only).
+**Location:** `state/thinking-machine/maintain-gate.jsonl` (**ix-side**, append-only,
+gitignored / regenerable). One verdict per line. Never written into a sibling tree.
+
+The verdict answers one question per self-improvement iteration: **accept, reject, or
+escalate?** — by fusing the DuckDB+IX maintain lenses into a single hexavalent value.
+DuckDB+IX is the *referee, never the player*: ground truth stays executable
+(compile/test/proof); the gate only aggregates evidence about it.
+
+## Why a documented shape, not yet a frozen schema
+
+The schema ships now (the plan calls for it in Phase 2) but stays **draft** until a
+consumer reads it. The `provenance{}`/freeze machinery lands in the **same PR that
+wires the first reader** (Phase 3 — Demerzel), matching the `chatbot-trace-regression`
+precedent — formalizing earlier freezes a surface still moving (e.g. soft-lens
+iteration-scoping is a known Phase-3 change). **Consumers MUST ignore unknown keys.**
+
+## The rule (conjunction, never an average)
+
+The two **hard** lenses decide; the two **soft** lenses only downgrade an accept:
+
+```
+metric↑ ∧ guardrail held ∧ converging ∧ in-distribution → T  accept
+metric↑ ∧ guardrail held ∧ converging ∧ drifting        → P  accept w/ flag
+metric↑ ∧ guardrail held ∧ oscillating                  → D  escalate (disputed)
+metric↑ ∧ guardrail broke                               → C  reject + ALARM (reward-hack)
+metric not↑                                             → F  reject
+metric or guardrail unknown, or a *required* dormant lens → U  escalate
+```
+
+**C (contradiction)** is the load-bearing case: a metric rising *while* a held
+capability breaks is the reward-hack signature — it hard-fails, never averages out.
+**Fail-closed:** missing metric/guardrail evidence, or a *required-but-dormant* lens,
+escalates to **U** — never a silent ACCEPT. A supplied-but-empty soft lens is
+*unknown* (advisory no-op), not a green light.
+
+## Status → decision → exit code
+
+| `status` | meaning | `decision` | exit |
+|---|---|---|---|
+| `T` | accept | `accept` | 0 |
+| `P` | accept with soft flag (drift) | `accept` | 0 |
+| `U` | unknown — escalate to human | `escalate` | 2 |
+| `D` | disputed (lenses disagree) — escalate | `escalate` | 2 |
+| `F` | reject (no improvement / guardrail broke) | `reject` | 1 |
+| `C` | contradiction (reward-hack) — reject + alarm | `reject` | 1 |
+
+Hexavalent per ecosystem T/P/U/D/F/C logic. Loop integration (Phase 3): exit 0 →
+propose-merge, 1 → reject + revert, 2 → human escalate.
+
+## Shape
+
+```jsonc
+{
+  "schema_version": "maintain-gate.v0.1",
+  "run_at": "2026-06-18T12:00:00+00:00",     // RFC3339
+  "status": "T",                              // T | P | U | D | F | C
+  "decision": "accept",                       // accept | reject | escalate
+  "metric_delta": 0.0184,                     // yield(later half) - yield(earlier half), omitted if unknown
+  "metric_up": true,                          // metric_delta >= min_metric_delta; omitted if unknown
+  "guardrail_held": true,                     // chatbot gate pass=true, regression=false; omitted if inconclusive
+  "converging": true,                         // loops not oscillating; omitted if lens not consulted / dormant
+  "drifting": false,                          // queries out-of-distribution; omitted if not consulted / <2 queries
+  "signals": [                                // one per lens consulted; ok=null means "no signal"
+    { "lens": "metric",      "ok": true,  "detail": "yield delta +0.0184" },
+    { "lens": "guardrail",   "ok": true,  "detail": "chatbot gate: pass (0 regression(s))" },
+    { "lens": "convergence", "ok": true,  "detail": "loops converging (no oscillation)" },
+    { "lens": "drift",       "ok": true,  "detail": "queries in-distribution" }
+  ],
+  "evidence": [                               // input provenance — hash the EVIDENCE, not just the verdict
+    { "kind": "metric",             "source": "state/thinking-machine/hits.jsonl", "hash": "fnv1a64:4e9e8d269a877fa7" },
+    { "kind": "guardrail-baseline", "source": ".../chatbot-qa",                    "hash": "fnv1a64:32a3940840062373" }
+  ],
+  "reason": "metric improved and guardrail held"
+}
+```
+
+### Field semantics
+- **`metric_delta` is externally derived** — yield over a harness-written `hits.jsonl`
+  split by `ts_ms` (NOT the cumulative mean). A self-declared delta from the proposing
+  agent is forbidden (panel review 2026-06-16): that would be the player scoring its
+  own game. Lens metrics carrying a recomputable-evidence pointer are acceptable.
+- **`signals[].ok`**: `true` = healthy, `false` = failed, `null` = no signal (a
+  required null caps the verdict at `U`).
+- **`evidence[].hash`**: FNV-1a-64 content hash of the input. Input provenance >
+  verdict provenance — it lets an audit detect a swapped/forged input. **Open
+  (Phase 3):** hashing metric + guardrail evidence is here; constitution-checksum is
+  v2; write-isolation of the ledgers from the proposing agent is a Phase-3 precondition
+  for the gate going *authoritative*.
+
+## Known limitation (Phase 1 → fixed in Phase 3)
+The soft lenses (convergence, drift) aggregate over the **whole** ledger / embedding
+history, not just the iteration under evaluation. Scoping them needs the
+iteration-correlation key (`loop_id` / `commit_sha`, never wall-clock) — Phase 3.
+
+## Locked-field discipline
+Changing `status`/`decision` value sets or the exit-code mapping after Phase-4 freeze
+needs cross-consumer (Demerzel) coordination. Until then, additive changes only;
+consumers ignore unknown keys.

--- a/docs/contracts/maintain-gate.schema.json
+++ b/docs/contracts/maintain-gate.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "maintain-gate-verdict-v0.1",
+  "title": "maintain-gate verdict",
+  "description": "One fail-closed RSI evaluation verdict per self-improvement iteration, fusing the DuckDB+IX maintain lenses. Producer: ix-duck ix_maintain_gate. Append-only at state/thinking-machine/maintain-gate.jsonl. v0.1 draft — consumers MUST ignore unknown keys.",
+  "type": "object",
+  "required": ["schema_version", "run_at", "status", "decision", "signals", "evidence", "reason"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": { "type": "string", "const": "maintain-gate.v0.1" },
+    "run_at": { "type": "string", "format": "date-time", "description": "RFC3339 timestamp." },
+    "status": {
+      "type": "string",
+      "enum": ["T", "P", "U", "D", "F", "C"],
+      "description": "Hexavalent: T accept | P accept-w/-flag | U escalate | D escalate(disputed) | F reject | C reject+alarm(reward-hack)."
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["accept", "reject", "escalate"],
+      "description": "Coarse action: T/P->accept, F/C->reject, U/D->escalate. Exit code: accept=0, reject=1, escalate=2."
+    },
+    "metric_delta": {
+      "type": "number",
+      "description": "Externally-derived yield delta (later half - earlier half, split by ts_ms). Omitted if unknown. NEVER an agent-declared delta."
+    },
+    "metric_up": { "type": "boolean", "description": "metric_delta >= min_metric_delta. Omitted if unknown." },
+    "guardrail_held": { "type": "boolean", "description": "Chatbot regression gate: pass=true, regression=false. Omitted if inconclusive." },
+    "converging": { "type": "boolean", "description": "Loops not oscillating. Omitted if the lens was not consulted or is dormant (no real data)." },
+    "drifting": { "type": "boolean", "description": "Queries out-of-distribution. Omitted if not consulted or <2 queries." },
+    "signals": {
+      "type": "array",
+      "description": "One entry per lens consulted.",
+      "items": { "$ref": "#/definitions/signal" }
+    },
+    "evidence": {
+      "type": "array",
+      "description": "Input provenance — the inputs the verdict was computed from, content-hashed so an audit can detect a swapped input.",
+      "items": { "$ref": "#/definitions/evidence" }
+    },
+    "reason": { "type": "string", "description": "Human-readable one-line justification." }
+  },
+  "definitions": {
+    "signal": {
+      "type": "object",
+      "required": ["lens", "detail"],
+      "additionalProperties": true,
+      "properties": {
+        "lens": { "type": "string", "description": "metric | guardrail | convergence | drift." },
+        "ok": {
+          "type": ["boolean", "null"],
+          "description": "true=healthy, false=failed, null=no signal (a required null caps the verdict at U)."
+        },
+        "detail": { "type": "string" }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["kind", "source", "hash"],
+      "additionalProperties": true,
+      "properties": {
+        "kind": { "type": "string", "description": "e.g. metric | guardrail-baseline." },
+        "source": { "type": "string", "description": "Path/identifier of the evidence input." },
+        "hash": { "type": "string", "description": "Content hash (e.g. fnv1a64:...) or 'absent'." }
+      }
+    }
+  }
+}

--- a/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
+++ b/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
@@ -144,11 +144,16 @@ This proves the anti-Goodhart conjunction before scaling.
       usable over the live lenses today; `ood_k`/`ood_threshold` added. Verified
       end-to-end over live `../ga` (T accept, all four signals green).
 
-### Phase 2 — Contract + tamper-evidence
-- [ ] `docs/contracts/maintain-gate.contract.md` + JSON schema (v0.1 draft).
-- [ ] Append-only ledger write + `baseline_ref` capture.
-- [ ] `ix_maintain_gate` example: `gate` (verdict + exit code) and `explain`
-      (per-signal breakdown).
+### Phase 2 — Contract + tamper-evidence ✅ shipped
+- [x] `docs/contracts/maintain-gate.contract.md` + `maintain-gate.schema.json`
+      (draft-07, v0.1 draft; live verdict validates via `jsonschema`).
+- [x] Append-only ledger write (`append_to_ledger`) + evidence provenance
+      (FNV-hashed metric + guardrail-baseline) — input provenance > verdict provenance.
+- [x] `ix_maintain_gate` example prints the per-signal breakdown + verdict + exit code.
+- [x] `verdict_conforms_to_contract` test binds the emitted JSON to the contract
+      (required keys + status/decision enums) so code/contract drift fails a test.
+- Deferred to Phase 3 (with the first reader, per the chatbot-contract precedent):
+  the `provenance{}`/freeze machinery + constitution checksum (v2).
 
 ### Phase 3 — Wire consumers
 - [ ] Demerzel governance reads the verdict (existing governance-check path or a


### PR DESCRIPTION
## Summary
Phase 2 of the maintain-gate: turn the `MaintainVerdict` from "a struct I serialize" into a **documented, schema-backed contract** other systems (Demerzel, the RSI loop) can depend on.

- **`docs/contracts/maintain-gate.contract.md`** — the verdict shape, the conjunction rule, the status→decision→exit-code table, evidence-provenance semantics, and the known Phase-1 limitation (soft lenses aggregate whole-history; scoped in Phase 3).
- **`docs/contracts/maintain-gate.schema.json`** — draft-07 JSON Schema, `additionalProperties: true` (consumers ignore unknown keys). v0.1 **draft** — freezes only at Phase 4.
- **`verdict_conforms_to_contract`** test binds the emitted JSON to the contract (required keys + status/decision enums), so code/contract drift fails a test rather than a consumer.

The live verdict validates against the schema via `jsonschema`.

Per the `chatbot-trace-regression` precedent, the `provenance{}`/freeze machinery + constitution checksum (v2) land with the **first reader** (Phase 3 — Demerzel), not now.

## Testing
- 12 `--features duck` maintain tests pass (+1 conformance); clippy (duck + default) + fmt clean.
- Schema + live ledger verdict validated with Python `jsonschema`.
- All behind the `duck` feature; default workspace build unaffected.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: docs + a draft schema + one test; no runtime/production impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)