### PR TITLE
feat(ix-duck): maintain-gate Phase 3a — iteration correlation + verified provenance

### DIFF
--- a/crates/ix-duck/examples/ix_maintain_gate.rs
+++ b/crates/ix-duck/examples/ix_maintain_gate.rs
@@ -12,7 +12,7 @@
 
 use std::path::PathBuf;
 
-use ix_duck::maintain::{self, MaintainConfig, MaintainInputs};
+use ix_duck::maintain::{self, IterationScope, MaintainConfig, MaintainInputs};
 
 fn default_hits() -> PathBuf {
     PathBuf::from("state/thinking-machine/hits.jsonl")
@@ -41,6 +41,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .next()
         .map(PathBuf::from)
         .unwrap_or_else(default_corpus);
+    // Optional Phase-3a iteration correlation: <loop_id> <commit_sha>.
+    let loop_id = args.next();
+    let commit_sha = args.next();
     for p in [&hits, &corpus] {
         if p.to_string_lossy().contains("://") {
             eprintln!("refusing non-local path: {}", p.display());
@@ -54,11 +57,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // degrade to "no data", never block).
     let loops_dir = ga_quality().join("loops");
     let emb_dir = ga_quality().join("query-embeddings");
+    let ga_root = ga_quality()
+        .parent()
+        .and_then(|p| p.parent())
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    let iteration = match (&loop_id, &commit_sha) {
+        (Some(l), Some(c)) => Some(IterationScope {
+            loop_id: l,
+            commit_sha: c,
+            repo_dir: &ga_root,
+        }),
+        _ => None,
+    };
     let inputs = MaintainInputs {
         hits_path: &hits,
         corpus_dir: &corpus,
         loops_dir: Some(&loops_dir),
         query_embeddings_dir: Some(&emb_dir),
+        iteration,
         run_at: &run_at,
     };
     let verdict = maintain::evaluate(&conn, &MaintainConfig::default(), &inputs)?;

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -311,6 +311,32 @@ pub fn evaluate(
         .as_ref()
         .map(|s| verify_commit(s.repo_dir, s.commit_sha));
 
+    // Build the loop ledger once — both the key match and the convergence lens use it.
+    let loops_built = match inputs.loops_dir {
+        Some(dir) => {
+            crate::loops::build_loop_iterations(conn, dir)?;
+            true
+        }
+        None => false,
+    };
+
+    // Correlation: a scope must match a REAL recorded row for (loop_id, commit_sha).
+    // Verifying the commit exists in git is NOT enough — a clean but unrelated commit
+    // for a loop with earlier improving rows would otherwise be scored as that loop and
+    // wrongly return T (Codex P1). Parameterised query — `loop_id` is caller-supplied.
+    let key_matched = match (&inputs.iteration, loops_built) {
+        (Some(scope), true) => {
+            let n: i64 = conn.query_row(
+                "SELECT count(*) FROM loop_iterations WHERE loop_id = ? AND commit_sha = ?",
+                duckdb::params![scope.loop_id, scope.commit_sha],
+                |r| r.get(0),
+            )?;
+            Some(n > 0)
+        }
+        (Some(_), false) => Some(false), // scope given but no ledger to match against
+        (None, _) => None,
+    };
+
     // --- convergence lens (loops) + drift lens (ood) ---
     // Phase 3a: convergence is scoped to the iteration's `loop_id` when a scope is
     // given (Phase 1 aggregated the whole ledger). Drift scoping awaits a query→loop
@@ -319,25 +345,23 @@ pub fn evaluate(
     // A supplied-but-empty/dormant lens is *unknown* (None), NOT a positive signal:
     // reading "no data" as converging / in-distribution would be a green light from
     // no evidence — the opposite of fail-closed (and, when required, must escalate).
-    let converging = match inputs.loops_dir {
-        Some(dir) => {
-            crate::loops::build_loop_iterations(conn, dir)?;
-            let summaries = crate::loops::loop_summary(conn)?; // excludes seed/test rows
-            match &inputs.iteration {
-                Some(scope) => {
-                    if summaries.iter().any(|s| s.loop_id == scope.loop_id) {
-                        // This loop is converging iff it is not in the oscillating set.
-                        let osc = crate::loops::oscillating_loops(conn)?;
-                        Some(!osc.iter().any(|(id, _, _)| id == scope.loop_id))
-                    } else {
-                        None // no real rows for this loop yet
-                    }
+    let converging = if loops_built {
+        let summaries = crate::loops::loop_summary(conn)?; // excludes seed/test rows
+        match &inputs.iteration {
+            Some(scope) => {
+                if summaries.iter().any(|s| s.loop_id == scope.loop_id) {
+                    // This loop is converging iff it is not in the oscillating set.
+                    let osc = crate::loops::oscillating_loops(conn)?;
+                    Some(!osc.iter().any(|(id, _, _)| id == scope.loop_id))
+                } else {
+                    None // no real rows for this loop yet
                 }
-                None if summaries.is_empty() => None,
-                None => Some(crate::loops::oscillating_loops(conn)?.is_empty()),
             }
+            None if summaries.is_empty() => None,
+            None => Some(crate::loops::oscillating_loops(conn)?.is_empty()),
         }
-        None => None,
+    } else {
+        None
     };
     let drifting = match inputs.query_embeddings_dir {
         Some(dir) => {
@@ -370,31 +394,40 @@ pub fn evaluate(
             None => "no query embeddings (advisory)".into(),
         },
     });
-    if let Some(c) = trust {
+    // Provenance is trusted only if the commit is real + clean AND a recorded loop row
+    // exists for (loop_id, commit_sha) — verifying the commit alone is not enough.
+    let provenance_fail: Option<&str> = match (&inputs.iteration, trust) {
+        (Some(_), Some(c)) if !c.exists => {
+            Some("commit_sha is not a real commit (untrusted/forged)")
+        }
+        (Some(_), Some(c)) if !c.clean => Some("worktree dirty at commit_sha (untrusted WIP)"),
+        (Some(_), _) if key_matched != Some(true) => {
+            Some("no recorded loop row for this loop_id/commit_sha")
+        }
+        _ => None,
+    };
+    if inputs.iteration.is_some() {
         signals.push(Signal {
             lens: "provenance".into(),
-            ok: Some(c.exists && c.clean),
-            detail: match (c.exists, c.clean) {
-                (true, true) => "iteration commit verified, worktree clean".into(),
-                (false, _) => "commit_sha NOT a real commit — untrusted/forged".into(),
-                (true, false) => "commit exists but worktree dirty — untrusted WIP".into(),
-            },
+            ok: Some(provenance_fail.is_none()),
+            detail: provenance_fail
+                .unwrap_or("iteration commit verified, worktree clean, loop row matched")
+                .to_string(),
         });
     }
 
     // --- conjunction → hexavalent status (fail-closed) ---
-    // Untrusted iteration provenance escalates before any lens verdict — a forged or
-    // dirty correlation key means we cannot attribute the evidence to a real iteration.
-    let untrusted = trust.map(|c| !(c.exists && c.clean)).unwrap_or(false);
+    // Untrusted iteration provenance escalates before any lens verdict — a forged,
+    // dirty, or unmatched correlation key means we cannot attribute the evidence to a
+    // real iteration.
     // A required-but-dormant lens escalates next.
     let dormant_required =
         (cfg.require_loops && converging.is_none()) || (cfg.require_ood && drifting.is_none());
-    let (status, decision, reason) = if untrusted {
+    let (status, decision, reason) = if let Some(why) = provenance_fail {
         (
             "U",
             "escalate",
-            "iteration provenance untrusted (commit_sha absent/invalid or worktree dirty)"
-                .to_string(),
+            format!("iteration provenance untrusted: {why}"),
         )
     } else if dormant_required {
         (
@@ -795,18 +828,49 @@ mod tests {
         (dir, sha)
     }
 
+    /// A loops ledger whose rows carry `sha` as their commit (so both git-verify and
+    /// the (loop_id, commit_sha) match succeed). `l-good` converges, `l-osc` oscillates.
+    fn loops_with_sha(sha: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let row = |lid: &str, it: i32, v: &str, before: f64, after: f64| {
+            format!(
+                "{{\"loop_id\":\"{lid}\",\"domain\":\"chatbot\",\"iteration\":{it},\"ts\":\"2026-06-18T00:0{it}:00Z\",\"oracle_status\":\"ok\",\"metric_name\":\"p\",\"metric_before\":{before},\"metric_after\":{after},\"metric_delta\":{},\"verdict\":\"{v}\",\"worst_item\":\"x\",\"artifact_edited\":\"a.cs\",\"commit_sha\":\"{sha}\",\"roundtrip_passed\":true}}\n",
+                after - before
+            )
+        };
+        std::fs::write(
+            dir.path().join("good.iterations.jsonl"),
+            format!(
+                "{}{}",
+                row("l-good", 1, "improved", 0.80, 0.90),
+                row("l-good", 2, "improved", 0.90, 0.95)
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("osc.iterations.jsonl"),
+            format!(
+                "{}{}",
+                row("l-osc", 1, "improved", 0.90, 0.92),
+                row("l-osc", 2, "regressed", 0.92, 0.88)
+            ),
+        )
+        .unwrap();
+        dir
+    }
+
     #[test]
     fn scoped_convergence_with_verified_commit() {
         let conn = crate::open_bench().unwrap();
         let hits = fx("hits_up.jsonl");
         let corpus = fx("corpus-pass");
-        let loops = lens_fx("loops"); // has chatbot-improving (converging) + chatbot-oscillating
         let (repo, sha) = temp_git_repo();
+        let loops = loops_with_sha(&sha); // rows carry the real commit → verify + match both pass
         let eval = |loop_id: &str| {
             let i = MaintainInputs {
                 hits_path: &hits,
                 corpus_dir: &corpus,
-                loops_dir: Some(&loops),
+                loops_dir: Some(loops.path()),
                 query_embeddings_dir: None,
                 iteration: Some(IterationScope {
                     loop_id,
@@ -817,14 +881,44 @@ mod tests {
             };
             evaluate(&conn, &MaintainConfig::default(), &i).unwrap()
         };
-        // Scope targets the converging loop → T (verified commit, scoped convergence).
-        let t = eval("chatbot-improving");
+        // Scope targets the converging loop → T (verified commit, matched row, scoped).
+        let t = eval("l-good");
         assert_eq!(t.status, "T", "{}", t.reason);
         assert_eq!(t.converging, Some(true));
-        // Same ledger, scope the oscillating loop → D. Proves per-iteration scoping.
-        let d = eval("chatbot-oscillating");
+        // Same ledger + commit, scope the oscillating loop → D. Proves per-iteration scoping.
+        let d = eval("l-osc");
         assert_eq!(d.status, "D", "{}", d.reason);
         assert_eq!(d.converging, Some(false));
+    }
+
+    #[test]
+    fn real_commit_without_matching_row_escalates() {
+        // Codex P1: a real, clean commit whose sha matches NO loop row must NOT be
+        // scored against that loop's earlier rows — it escalates to U.
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let (repo, sha) = temp_git_repo(); // real clean commit
+        let loops = lens_fx("loops"); // rows carry "aaa1111"… — NOT `sha`
+        let i = MaintainInputs {
+            hits_path: &hits,
+            corpus_dir: &corpus,
+            loops_dir: Some(&loops),
+            query_embeddings_dir: None,
+            iteration: Some(IterationScope {
+                loop_id: "chatbot-improving",
+                commit_sha: &sha,
+                repo_dir: repo.path(),
+            }),
+            run_at: "2026-06-18T00:00:00Z",
+        };
+        let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
+        assert_eq!(v.status, "U", "{}", v.reason);
+        assert!(
+            v.reason.contains("no recorded loop row"),
+            "reason: {}",
+            v.reason
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -1,4 +1,11 @@
-//! `maintain-gate` — a fail-closed RSI evaluation oracle (Phase 1).
+//! `maintain-gate` — a fail-closed RSI evaluation oracle (Phase 3a).
+//!
+//! When given an [`IterationScope`] (`loop_id` + `commit_sha`), the gate **externally
+//! verifies** the commit against real git state and **scopes** convergence to that
+//! loop — an unverified/forged or dirty correlation key fail-closes to **U** before
+//! any lens verdict (the key is minted by the loop being judged, so it gets the same
+//! external-derivation discipline as the metric). Without a scope it behaves as
+//! Phase 1 (whole-history advisory).
 //!
 //! Fuses the DuckDB+IX maintain lenses into ONE hexavalent verdict (T/P/U/D/F/C)
 //! per self-improvement iteration:
@@ -109,6 +116,18 @@ impl Default for MaintainConfig {
     }
 }
 
+/// Correlates the verdict to a specific loop iteration, and lets the gate
+/// **externally verify** the iteration's provenance. The `commit_sha` is minted
+/// GA-side by the loop being judged, so the gate trusts it only after checking it
+/// against real git state (Phase-3 panel: an unverified key is as forgeable as the
+/// self-declared metric we already rejected).
+pub struct IterationScope<'a> {
+    pub loop_id: &'a str,
+    pub commit_sha: &'a str,
+    /// Repo to verify `commit_sha` against (the loop's own repo).
+    pub repo_dir: &'a Path,
+}
+
 /// What the gate reads for one iteration. The metric source is externally derived
 /// (harness-written `hits.jsonl`), never a delta declared by the proposing agent.
 pub struct MaintainInputs<'a> {
@@ -118,7 +137,48 @@ pub struct MaintainInputs<'a> {
     pub loops_dir: Option<&'a Path>,
     /// Query-embeddings dir (drift lens). `None` = lens not consulted.
     pub query_embeddings_dir: Option<&'a Path>,
+    /// Iteration correlation + provenance. `None` = whole-history (Phase-1 behaviour).
+    pub iteration: Option<IterationScope<'a>>,
     pub run_at: &'a str,
+}
+
+/// Result of externally verifying an iteration's `commit_sha` against git.
+#[derive(Debug, Clone, Copy)]
+struct CommitCheck {
+    /// The sha is a real commit object in the repo.
+    exists: bool,
+    /// The repo worktree is clean (the change is a committed state, not a dirty WIP).
+    clean: bool,
+}
+
+/// Verify `sha` against real git state in `repo_dir` — the anti-forgery check for the
+/// correlation key. Hex-validates first (so a `sha` like `--help` can't reach git as a
+/// flag), then `git cat-file -e <sha>^{commit}` (exists) + `git status --porcelain`
+/// (clean). Any failure → not-trusted (caller fail-closes to U).
+fn verify_commit(repo_dir: &Path, sha: &str) -> CommitCheck {
+    use std::process::Command;
+    let hex = !sha.is_empty() && sha.len() <= 64 && sha.bytes().all(|b| b.is_ascii_hexdigit());
+    if !hex {
+        return CommitCheck {
+            exists: false,
+            clean: false,
+        };
+    }
+    let exists = Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    let clean = Command::new("git")
+        .arg("-C")
+        .arg(repo_dir)
+        .args(["status", "--porcelain"])
+        .output()
+        .map(|o| o.status.success() && o.stdout.is_empty())
+        .unwrap_or(false);
+    CommitCheck { exists, clean }
 }
 
 /// Provenance of one piece of evidence — what the verdict was computed from, hashed
@@ -245,11 +305,16 @@ pub fn evaluate(
             ),
         },
     ];
+    // --- iteration provenance (Phase 3a): verify the correlation key against git ---
+    let trust = inputs
+        .iteration
+        .as_ref()
+        .map(|s| verify_commit(s.repo_dir, s.commit_sha));
+
     // --- convergence lens (loops) + drift lens (ood) ---
-    // KNOWN LIMITATION (Phase 1): the soft lenses aggregate over the *whole* ledger /
-    // embedding history, not just the iteration under evaluation. Scoping them to the
-    // current iteration needs the iteration-correlation key (loop_id / commit_sha,
-    // never wall-clock) the panel logged for Phase 3 — deferred there, not half-built.
+    // Phase 3a: convergence is scoped to the iteration's `loop_id` when a scope is
+    // given (Phase 1 aggregated the whole ledger). Drift scoping awaits a query→loop
+    // tag in Contract B — until then drift stays corpus-level advisory (documented).
     //
     // A supplied-but-empty/dormant lens is *unknown* (None), NOT a positive signal:
     // reading "no data" as converging / in-distribution would be a green light from
@@ -257,11 +322,19 @@ pub fn evaluate(
     let converging = match inputs.loops_dir {
         Some(dir) => {
             crate::loops::build_loop_iterations(conn, dir)?;
-            // loop_summary excludes seed/test rows → empty means no real iterations yet.
-            if crate::loops::loop_summary(conn)?.is_empty() {
-                None
-            } else {
-                Some(crate::loops::oscillating_loops(conn)?.is_empty())
+            let summaries = crate::loops::loop_summary(conn)?; // excludes seed/test rows
+            match &inputs.iteration {
+                Some(scope) => {
+                    if summaries.iter().any(|s| s.loop_id == scope.loop_id) {
+                        // This loop is converging iff it is not in the oscillating set.
+                        let osc = crate::loops::oscillating_loops(conn)?;
+                        Some(!osc.iter().any(|(id, _, _)| id == scope.loop_id))
+                    } else {
+                        None // no real rows for this loop yet
+                    }
+                }
+                None if summaries.is_empty() => None,
+                None => Some(crate::loops::oscillating_loops(conn)?.is_empty()),
             }
         }
         None => None,
@@ -297,12 +370,33 @@ pub fn evaluate(
             None => "no query embeddings (advisory)".into(),
         },
     });
+    if let Some(c) = trust {
+        signals.push(Signal {
+            lens: "provenance".into(),
+            ok: Some(c.exists && c.clean),
+            detail: match (c.exists, c.clean) {
+                (true, true) => "iteration commit verified, worktree clean".into(),
+                (false, _) => "commit_sha NOT a real commit — untrusted/forged".into(),
+                (true, false) => "commit exists but worktree dirty — untrusted WIP".into(),
+            },
+        });
+    }
 
     // --- conjunction → hexavalent status (fail-closed) ---
-    // A required-but-dormant lens escalates before anything else.
+    // Untrusted iteration provenance escalates before any lens verdict — a forged or
+    // dirty correlation key means we cannot attribute the evidence to a real iteration.
+    let untrusted = trust.map(|c| !(c.exists && c.clean)).unwrap_or(false);
+    // A required-but-dormant lens escalates next.
     let dormant_required =
         (cfg.require_loops && converging.is_none()) || (cfg.require_ood && drifting.is_none());
-    let (status, decision, reason) = if dormant_required {
+    let (status, decision, reason) = if untrusted {
+        (
+            "U",
+            "escalate",
+            "iteration provenance untrusted (commit_sha absent/invalid or worktree dirty)"
+                .to_string(),
+        )
+    } else if dormant_required {
         (
             "U",
             "escalate",
@@ -359,7 +453,7 @@ pub fn evaluate(
     };
 
     // --- evidence provenance (hash the inputs, not just the verdict) ---
-    let evidence = vec![
+    let mut evidence = vec![
         Evidence {
             kind: "metric".into(),
             source: inputs.hits_path.to_string_lossy().into_owned(),
@@ -371,6 +465,14 @@ pub fn evaluate(
             hash: report.baseline_ref.clone(),
         },
     ];
+    // The correlation key IS provenance — it ties this verdict to a verified commit.
+    if let Some(scope) = &inputs.iteration {
+        evidence.push(Evidence {
+            kind: format!("iteration-commit:{}", scope.loop_id),
+            source: scope.repo_dir.to_string_lossy().into_owned(),
+            hash: format!("git:{}", scope.commit_sha),
+        });
+    }
 
     Ok(MaintainVerdict {
         schema_version: "maintain-gate.v0.1".into(),
@@ -428,6 +530,7 @@ mod tests {
             corpus_dir: corpus,
             loops_dir: None,
             query_embeddings_dir: None,
+            iteration: None,
             run_at: "2026-06-16T00:00:00Z",
         }
     }
@@ -524,6 +627,7 @@ mod tests {
             corpus_dir: &corpus,
             loops_dir: Some(&loops),
             query_embeddings_dir: None,
+            iteration: None,
             run_at: "2026-06-16T00:00:00Z",
         };
         let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
@@ -545,6 +649,7 @@ mod tests {
             corpus_dir: &corpus,
             loops_dir: None,
             query_embeddings_dir: Some(&emb),
+            iteration: None,
             run_at: "2026-06-16T00:00:00Z",
         };
         let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
@@ -571,6 +676,7 @@ mod tests {
             corpus_dir: &corpus,
             loops_dir: Some(dir.path()),
             query_embeddings_dir: None,
+            iteration: None,
             run_at: "2026-06-16T00:00:00Z",
         };
         let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
@@ -597,6 +703,7 @@ mod tests {
                 corpus_dir: &corpus,
                 loops_dir: Some(dir.path()),
                 query_embeddings_dir: None,
+                iteration: None,
                 run_at: "2026-06-16T00:00:00Z",
             };
             evaluate(&conn, cfg, &i).unwrap()
@@ -653,6 +760,100 @@ mod tests {
                 assert!(e.get(k).is_some(), "evidence entry needs `{k}`");
             }
         }
+    }
+
+    /// A throwaway git repo with one clean commit; returns (dir, HEAD sha).
+    fn temp_git_repo() -> (tempfile::TempDir, String) {
+        use std::process::Command;
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().to_path_buf();
+        let git = |args: &[&str]| {
+            Command::new("git")
+                .arg("-C")
+                .arg(&p)
+                .args(args)
+                .output()
+                .unwrap()
+        };
+        git(&["init", "-q"]);
+        std::fs::write(p.join("f.txt"), "x").unwrap();
+        git(&["add", "."]);
+        git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+        ]);
+        let sha = String::from_utf8(git(&["rev-parse", "HEAD"]).stdout)
+            .unwrap()
+            .trim()
+            .to_string();
+        (dir, sha)
+    }
+
+    #[test]
+    fn scoped_convergence_with_verified_commit() {
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let loops = lens_fx("loops"); // has chatbot-improving (converging) + chatbot-oscillating
+        let (repo, sha) = temp_git_repo();
+        let eval = |loop_id: &str| {
+            let i = MaintainInputs {
+                hits_path: &hits,
+                corpus_dir: &corpus,
+                loops_dir: Some(&loops),
+                query_embeddings_dir: None,
+                iteration: Some(IterationScope {
+                    loop_id,
+                    commit_sha: &sha,
+                    repo_dir: repo.path(),
+                }),
+                run_at: "2026-06-18T00:00:00Z",
+            };
+            evaluate(&conn, &MaintainConfig::default(), &i).unwrap()
+        };
+        // Scope targets the converging loop → T (verified commit, scoped convergence).
+        let t = eval("chatbot-improving");
+        assert_eq!(t.status, "T", "{}", t.reason);
+        assert_eq!(t.converging, Some(true));
+        // Same ledger, scope the oscillating loop → D. Proves per-iteration scoping.
+        let d = eval("chatbot-oscillating");
+        assert_eq!(d.status, "D", "{}", d.reason);
+        assert_eq!(d.converging, Some(false));
+    }
+
+    #[test]
+    fn untrusted_commit_escalates() {
+        // A well-formed but non-existent sha → provenance untrusted → U, regardless of lenses.
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let loops = lens_fx("loops");
+        let (repo, _sha) = temp_git_repo();
+        let i = MaintainInputs {
+            hits_path: &hits,
+            corpus_dir: &corpus,
+            loops_dir: Some(&loops),
+            query_embeddings_dir: None,
+            iteration: Some(IterationScope {
+                loop_id: "chatbot-improving",
+                commit_sha: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                repo_dir: repo.path(),
+            }),
+            run_at: "2026-06-18T00:00:00Z",
+        };
+        let v = evaluate(&conn, &MaintainConfig::default(), &i).unwrap();
+        assert_eq!(v.status, "U", "{}", v.reason);
+        assert!(
+            v.reason.contains("provenance"),
+            "reason names the cause: {}",
+            v.reason
+        );
     }
 
     #[test]

--- a/docs/contracts/maintain-gate.contract.md
+++ b/docs/contracts/maintain-gate.contract.md
@@ -99,11 +99,14 @@ propose-merge, 1 → reject + revert, 2 → human escalate.
 When the gate is given an iteration scope (`loop_id` + `commit_sha` + the loop's repo):
 - **Convergence is scoped** to that `loop_id` (no longer whole-ledger).
 - **`commit_sha` is externally verified** against real git state — hex-validated, then
-  `git cat-file -e <sha>^{commit}` (exists) + `git status --porcelain` (clean). A
-  forged/absent sha or a dirty worktree fail-closes to **U** *before any lens verdict*
-  (an unverified key minted by the judged loop is as forgeable as a self-declared
-  metric). Surfaced as a `provenance` signal + an `iteration-commit:<loop_id>` evidence
-  entry (`hash: "git:<sha>"`).
+  `git cat-file -e <sha>^{commit}` (exists) + `git status --porcelain` (clean) — **and**
+  a recorded loop row must exist for the exact `(loop_id, commit_sha)` pair (verifying
+  the commit alone is not enough: a clean-but-unrelated commit for a loop with earlier
+  improving rows would otherwise be scored as that loop). A forged/absent sha, a dirty
+  worktree, **or no matching loop row** fail-closes to **U** *before any lens verdict*
+  (the key is minted by the judged loop, so it gets the same external-derivation
+  discipline as the metric). Surfaced as a `provenance` signal + an
+  `iteration-commit:<loop_id>` evidence entry (`hash: "git:<sha>"`).
 
 **Still whole-history (deferred):** drift scoping per-iteration awaits a query→loop tag
 in Contract B; until then drift stays corpus-level advisory. **Still Phase 3b:** the

--- a/docs/contracts/maintain-gate.contract.md
+++ b/docs/contracts/maintain-gate.contract.md
@@ -95,10 +95,20 @@ propose-merge, 1 → reject + revert, 2 → human escalate.
   v2; write-isolation of the ledgers from the proposing agent is a Phase-3 precondition
   for the gate going *authoritative*.
 
-## Known limitation (Phase 1 → fixed in Phase 3)
-The soft lenses (convergence, drift) aggregate over the **whole** ledger / embedding
-history, not just the iteration under evaluation. Scoping them needs the
-iteration-correlation key (`loop_id` / `commit_sha`, never wall-clock) — Phase 3.
+## Iteration correlation + provenance (Phase 3a)
+When the gate is given an iteration scope (`loop_id` + `commit_sha` + the loop's repo):
+- **Convergence is scoped** to that `loop_id` (no longer whole-ledger).
+- **`commit_sha` is externally verified** against real git state — hex-validated, then
+  `git cat-file -e <sha>^{commit}` (exists) + `git status --porcelain` (clean). A
+  forged/absent sha or a dirty worktree fail-closes to **U** *before any lens verdict*
+  (an unverified key minted by the judged loop is as forgeable as a self-declared
+  metric). Surfaced as a `provenance` signal + an `iteration-commit:<loop_id>` evidence
+  entry (`hash: "git:<sha>"`).
+
+**Still whole-history (deferred):** drift scoping per-iteration awaits a query→loop tag
+in Contract B; until then drift stays corpus-level advisory. **Still Phase 3b:** the
+verdict is *advisory* — write-isolation of the ledgers from the proposing agent (and
+therefore any authoritative auto-revert) is not yet enforced.
 
 ## Locked-field discipline
 Changing `status`/`decision` value sets or the exit-code mapping after Phase-4 freeze

--- a/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
+++ b/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
@@ -165,20 +165,20 @@ it validates the only genuinely new code (iteration-correlation) on synthetic sh
 write-isolation is the exact DGM failure mode the gate exists to prevent. Split into:
 
 #### Phase 3a — Make the pixel right: one real iteration + advisory consumption
+- [x] **ix-side iteration correlation + provenance** — `IterationScope`
+      (`loop_id`/`commit_sha`/`repo_dir`); `commit_sha` externally verified vs git
+      (hex-validate → `cat-file -e` exists + `status --porcelain` clean); forged/absent/
+      dirty → **U** before any lens verdict. `provenance` signal + `iteration-commit`
+      evidence. Tests: `scoped_convergence_with_verified_commit`, `untrusted_commit_escalates`.
+- [x] **Convergence scoped to the iteration's `loop_id`** (was whole-ledger). Drift
+      per-iteration scoping still deferred (needs a query→loop tag in Contract B).
 - [ ] **Drive ONE real, non-sentinel GA `/auto-optimize` iteration row** through the
-      live loop path (the gating prerequisite — *do this first*). Cross-repo / GA-side;
-      cannot be fabricated.
-- [ ] Extend the gate inputs with `loop_id` + `commit_sha`; **fail-closed on absent,
-      duplicate, dirty-worktree, stale, or non-matching keys**, and **verify
-      `commit_sha` ix-side against actual git state** (an unverified key minted by the
-      judged loop is as forgeable as the self-declared metric we already rejected).
-- [ ] Scope the soft lenses (convergence, drift) to that iteration via the key —
-      fixes the Phase-1 whole-history limitation, validated against the real row.
-- [ ] **Advisory consumption only:** GA loop calls the ix gate CLI *synchronously*
+      live loop path, then validate the gate consumes its exact `loop_id`/`commit_sha`
+      end-to-end. Cross-repo / GA-side; cannot be fabricated. *(the Go condition)*
+- [ ] **Advisory consumption wiring:** GA loop calls the ix gate CLI *synchronously*
       after writing the row + running the executable oracles; verdict → JSON-on-disk;
-      Demerzel reads it via its existing governance pipeline; **block unattended
-      promotion on U/D/F/C, but NO auto-revert.** (Q1 disk-first, Q2 loop-owned sync
-      call, Q3 advisory — all unanimous.)
+      Demerzel reads it; **block unattended promotion on U/D/F/C, but NO auto-revert.**
+      (Q1 disk-first, Q2 loop-owned sync call, Q3 advisory — all unanimous. Cross-repo.)
 
 #### Phase 3b — Authority (separate, gated on enforced write-isolation)
 - [ ] Real isolation boundary (harness-owned writer + read-only proposer view;

--- a/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
+++ b/docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md
@@ -155,15 +155,40 @@ This proves the anti-Goodhart conjunction before scaling.
 - Deferred to Phase 3 (with the first reader, per the chatbot-contract precedent):
   the `provenance{}`/freeze machinery + constitution checksum (v2).
 
-### Phase 3 — Wire consumers
-- [ ] Demerzel governance reads the verdict (existing governance-check path or a
-      new MCP tool — **open question**, see below).
-- [ ] Document the loop integration: an RSI loop calls `gate` after each iteration;
-      exit 1 → reject + revert, exit 2 → human escalate, exit 0 → propose-merge.
-- [ ] **Scope soft lenses to the current iteration** via the iteration-correlation
-      key (loop_id / commit_sha, never wall-clock). Phase 1 aggregates convergence +
-      drift over the *whole* history (known limitation, flagged in `maintain.rs`);
-      this is where it gets fixed, alongside the same key the panel required.
+### Phase 3 — Wire consumers  ⚠ RE-SCOPED (panel 2026-06-18, Codex + architecture-strategist, unanimous **No-Go as scoped**)
+
+The original single Phase 3 co-scoped write-isolation with authoritative auto-revert,
+over a loop that has **never produced a real iteration row**. Both reviewers
+independently rejected this: it's governance-over-nothing (`feedback_sentinels_void`),
+it validates the only genuinely new code (iteration-correlation) on synthetic shapes
+(`feedback_tests_must_use_real_data_shapes`), and shipping authority before enforced
+write-isolation is the exact DGM failure mode the gate exists to prevent. Split into:
+
+#### Phase 3a — Make the pixel right: one real iteration + advisory consumption
+- [ ] **Drive ONE real, non-sentinel GA `/auto-optimize` iteration row** through the
+      live loop path (the gating prerequisite — *do this first*). Cross-repo / GA-side;
+      cannot be fabricated.
+- [ ] Extend the gate inputs with `loop_id` + `commit_sha`; **fail-closed on absent,
+      duplicate, dirty-worktree, stale, or non-matching keys**, and **verify
+      `commit_sha` ix-side against actual git state** (an unverified key minted by the
+      judged loop is as forgeable as the self-declared metric we already rejected).
+- [ ] Scope the soft lenses (convergence, drift) to that iteration via the key —
+      fixes the Phase-1 whole-history limitation, validated against the real row.
+- [ ] **Advisory consumption only:** GA loop calls the ix gate CLI *synchronously*
+      after writing the row + running the executable oracles; verdict → JSON-on-disk;
+      Demerzel reads it via its existing governance pipeline; **block unattended
+      promotion on U/D/F/C, but NO auto-revert.** (Q1 disk-first, Q2 loop-owned sync
+      call, Q3 advisory — all unanimous.)
+
+#### Phase 3b — Authority (separate, gated on enforced write-isolation)
+- [ ] Real isolation boundary (harness-owned writer + read-only proposer view;
+      hash-chained / signed rows). Post-hoc hashing is audit evidence, **not**
+      isolation. This is the *primary deliverable*, not a checkbox.
+- [ ] Only then: authoritative behaviour (auto-revert on F/C). MCP tool only if a
+      second consumer demands it.
+
+**Go condition (flips No-Go → Go):** one genuine `/auto-optimize` iteration row exists
+and the ix gate has consumed that exact `loop_id`/`commit_sha` advisory end-to-end.
 
 ### Phase 4 — Freeze (one-way door)
 - [ ] Freeze contract schema + exit-code semantics only here. Log sign-off.


### PR DESCRIPTION
## Summary
The ix-side half of the **re-scoped** Phase 3 (panel 2026-06-18, Codex + architecture-strategist, unanimous "No-Go as scoped" → split into 3a advisory / 3b authority).

- **`IterationScope { loop_id, commit_sha, repo_dir }`** on `MaintainInputs`. When present, the gate **externally verifies `commit_sha` against real git** (hex-validate → `git cat-file -e <sha>^{commit}` exists + `git status --porcelain` clean). A forged/absent sha or a dirty worktree **fail-closes to U before any lens verdict** — the correlation key is minted by the loop being judged, so it gets the same external-derivation discipline as the metric (panel risk #2). Surfaced as a `provenance` signal + `iteration-commit` evidence.
- **Convergence scoped** to the iteration's `loop_id` (was whole-ledger). Drift per-iteration scoping stays deferred (needs a query→loop tag in Contract B).
- **Advisory only** — no authoritative behaviour; that's Phase 3b, gated on enforced write-isolation.
- `ix_maintain_gate` example takes optional `<loop_id> <commit_sha>`. Contract + plan updated.

## What this is NOT (deliberately deferred per panel)
- **Not** authoritative — no auto-revert (Phase 3b, needs write-isolation).
- **Not** yet validated against a real loop row — the GA `/auto-optimize` loop has never emitted one; driving that + the advisory consumption wiring (GA loop → ix CLI → Demerzel reads) is the remaining cross-repo 3a work and the Go condition.

## Testing
- 87 `--features duck` tests pass (+2: `scoped_convergence_with_verified_commit`, `untrusted_commit_escalates`); clippy (duck + default) + fmt clean.
- All behind the `duck` feature; default workspace build unaffected.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: opt-in `duck`-feature analyst tooling; advisory verdict only, no runtime/production authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)