### PR TITLE
fix(ix-duck): ix_cosine/ix_euclidean honor SQL NULL (course adoption seed #1)

### DIFF
--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -215,4 +215,38 @@ mod tests {
             .unwrap();
         assert!(z.abs() < 1e-12, "equal vectors → 0.0, got {z}");
     }
+
+    #[test]
+    fn ix_cosine_passes_null_through() {
+        let conn = open_bench().unwrap();
+        // A NULL list argument yields SQL NULL, not a spurious number.
+        let n: Option<f64> = conn
+            .query_row(
+                "SELECT ix_cosine(NULL::DOUBLE[], [1.0,2.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, None, "NULL arg → SQL NULL");
+
+        // In a mixed chunk, non-NULL rows still compute while the NULL row stays NULL.
+        let mut stmt = conn
+            .prepare(
+                "SELECT ix_cosine(a, b) FROM (VALUES \
+                   (1, [1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[]), \
+                   (2, NULL::DOUBLE[],          [1.0,2.0,3.0]::DOUBLE[]), \
+                   (3, [1.0,0.0]::DOUBLE[],     [0.0,1.0]::DOUBLE[]) \
+                 ) t(i,a,b) ORDER BY i",
+            )
+            .unwrap();
+        let rows: Vec<Option<f64>> = stmt
+            .query_map([], |r| r.get::<_, Option<f64>>(0))
+            .unwrap()
+            .map(|x| x.unwrap())
+            .collect();
+        assert_eq!(rows.len(), 3);
+        assert!((rows[0].unwrap() - 1.0).abs() < 1e-12, "identical → 1.0");
+        assert_eq!(rows[1], None, "NULL row stays NULL in a mixed chunk");
+        assert!(rows[2].unwrap().abs() < 1e-12, "orthogonal → 0.0");
+    }
 }

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -27,7 +27,10 @@ fn list_double() -> LogicalTypeHandle {
 /// buffer so the child slice and the entry lookups never alias the same vector.
 /// `cap` is `max(offset + length)`, so every `all[o..o + l]` slice is in bounds
 /// by construction — a malformed entry cannot index past the child buffer.
-// @ai:assumption list inputs are non-NULL; a NULL list row is read as its raw (offset,length) and yields a numeric result rather than SQL NULL. True for IX embedding telemetry. Proper NULL->NULL passthrough (validity mask + null output) is the Phase-4 follow-up. [U:uncertain conf:0.6 src:docs/plans/2026-06-14-001-feat-ix-duck-duckdb-udfs-plan.md]
+// Reads the raw (offset,length) slice for EVERY row, including NULL list rows (whose
+// entry is typically (0,0) → an empty Vec). NULL handling is the caller's job: the
+// scalar UDFs read per-row validity separately and emit SQL NULL (see `invoke_pairwise`),
+// so a NULL row's harmless raw read is overridden downstream.
 pub(crate) fn read_list_col(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<Vec<f64>> {
     let lv = input.list_vector(col);
     let entries: Vec<(usize, usize)> = (0..n).map(|i| lv.get_entry(i)).collect();
@@ -43,6 +46,7 @@ pub(crate) fn read_list_col(input: &mut DataChunkHandle, col: usize, n: usize) -
 /// Shared row-wise driver: read two `LIST<DOUBLE>` columns, apply `metric`
 /// pairwise, write a `DOUBLE` per row. A metric error (e.g. dimension mismatch)
 /// becomes a DuckDB SQL error rather than a panic.
+// @ai:invariant a NULL list argument (either side) yields SQL NULL, never a spurious number: per-row validity is read via FlatVector::row_is_null and the output row flagged via FlatVector::set_null [T:test conf:0.9 src:ix_duck::tests::ix_cosine_passes_null_through]
 fn invoke_pairwise(
     input: &mut DataChunkHandle,
     output: &mut dyn WritableVector,
@@ -50,16 +54,40 @@ fn invoke_pairwise(
     metric: impl Fn(&Array1<f64>, &Array1<f64>) -> Result<f64, MathError>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let n = input.len();
+    // SQL NULL passthrough: capture each argument column's per-row validity *before*
+    // borrowing it as a list. A list vector's NULL mask lives on the vector itself, so a
+    // `FlatVector` view of the same column pointer reads list-row nullity correctly.
+    let a_null = null_mask(input, 0, n);
+    let b_null = null_mask(input, 1, n);
     let a = read_list_col(input, 0, n);
     let b = read_list_col(input, 1, n);
     let mut out = output.flat_vector();
-    let out_slice = unsafe { out.as_mut_slice_with_len::<f64>(n) };
-    for i in 0..n {
-        let av = Array1::from_vec(a[i].clone());
-        let bv = Array1::from_vec(b[i].clone());
-        out_slice[i] = metric(&av, &bv).map_err(|e| format!("{name}: {e}"))?;
+    {
+        let out_slice = unsafe { out.as_mut_slice_with_len::<f64>(n) };
+        for i in 0..n {
+            if a_null[i] || b_null[i] {
+                out_slice[i] = 0.0; // placeholder; the row is flagged NULL below
+                continue;
+            }
+            let av = Array1::from_vec(a[i].clone());
+            let bv = Array1::from_vec(b[i].clone());
+            out_slice[i] = metric(&av, &bv).map_err(|e| format!("{name}: {e}"))?;
+        }
+    }
+    // Flag NULL rows after the value slice is dropped (set_null re-borrows the vector).
+    for (i, (&an, &bn)) in a_null.iter().zip(&b_null).enumerate() {
+        if an || bn {
+            out.set_null(i);
+        }
     }
     Ok(())
+}
+
+/// Per-row NULL mask of a `LIST` column. A list vector's validity mask is on the
+/// vector itself, so a `FlatVector` view of the same column pointer reads it.
+fn null_mask(input: &DataChunkHandle, col: usize, n: usize) -> Vec<bool> {
+    let v = input.flat_vector(col);
+    (0..n).map(|i| v.row_is_null(i as u64)).collect()
 }
 
 /// `ix_cosine(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — cosine similarity in [-1, 1].


### PR DESCRIPTION
## Summary
First *implemented* outcome of the DuckDB⨯IX course (`/teach`): the "power left on the table" pass on `udf.rs` found three adoption seeds; this lands the one that's both real and non-speculative.

`ix_cosine`/`ix_euclidean` assumed non-NULL `LIST<DOUBLE>` inputs — an explicit `@ai:assumption [U:uncertain]` (`udf.rs:30`). A NULL list argument was read by its raw `(offset,length)` and returned a **spurious number** instead of SQL `NULL`. Fine for IX's own non-NULL embedding telemetry; a latent footgun for any external corpus (the cross-repo direction).

### Fix
`invoke_pairwise` now reads each argument column's per-row validity (`FlatVector::row_is_null` over the same column pointer — a list vector's NULL mask lives on the vector itself) and flags the output via `FlatVector::set_null`. A NULL argument (either side) → SQL `NULL`; non-NULL rows unchanged. The `[U:uncertain]` assumption becomes a tested `[T:test]` invariant.

### Scope (feasibility-checked against pinned `duckdb-rs =1.10503.1`)
- ✅ **#1 NULL passthrough** — this PR.
- ⚠ **#2 aggregate UDFs** — *no safe wrapper; feasible via raw FFI* (corrected from an earlier "infeasible"): the safe `duckdb` crate has no `VAggregate`, but `libduckdb-sys` exposes the full custom-aggregate C API (`duckdb_create_aggregate_function` + init/update/combine/finalize typedefs). Buildable via unsafe FFI or an upstreamed `VAggregate`; demand-gated (YAGNI) until a `GROUP BY centroid` consumer exists — not impossible.
- ⏸ **#3 FLOAT[]/ARRAY overloads** — deferred: no FLOAT[] consumer today; the ARRAY overload belongs with the `vss`/HNSW adoption (it gains a real driver there).
- The analogous `LIST<BIGINT>` reader in `sketch.rs` is a separate follow-up (one module per PR).

## Testing
- `+ix_cosine_passes_null_through`: scalar NULL arg → `None`; a mixed 3-row chunk → the NULL row stays NULL while its neighbours compute (1.0 and 0.0). Exercises the vectorized chunk path, not just a 1-row scalar.
- Existing `ix_cosine_matches_ix_math` / `ix_euclidean_matches_ix_math` unchanged.
- **90 duck tests pass**; `cargo clippy -p ix-duck --features duck --all-targets` clean; `udf.rs`/`lib.rs` fmt-clean.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: behind the `duck` feature (not in the default/CI build), pure in-process UDF behavior, fully covered by the unit test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

