### PR TITLE
fix(ix-duck): ood lens — dedup by embedding (restores signal + ~49× faster)

### DIFF
--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -79,5 +79,9 @@ required-features = ["duck"]
 name = "ix_voicing_lens"
 required-features = ["duck"]
 
+[[example]]
+name = "ix_ood_lens"
+required-features = ["duck"]
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ix-duck/examples/ix_ood_lens.rs
+++ b/crates/ix-duck/examples/ix_ood_lens.rs
@@ -1,0 +1,93 @@
+//! `ix_ood_lens` — out-of-domain query lens over GA's `query-embeddings/*.jsonl`
+//! (Contract B). Thin shell over `ix_duck::ood`: build the query-embedding table, score
+//! each query by mean top-k cosine to its nearest neighbours (leave-one-out), and surface
+//! the most out-of-domain queries. Also **times the O(n²) all-pairs scoring** so we can
+//! decide empirically (not by guessing) whether brute force is a problem at real scale.
+//!
+//!   cargo run -p ix-duck --features duck --example ix_ood_lens            # live ../ga
+//!   cargo run -p ix-duck --features duck --example ix_ood_lens -- <dir>   # explicit query-embeddings dir
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Instant;
+
+use ix_duck::ood;
+
+fn default_dir() -> PathBuf {
+    if let Ok(root) = std::env::var("GA_ROOT") {
+        return PathBuf::from(root).join("state/quality/query-embeddings");
+    }
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let ix_root = cwd.canonicalize().unwrap_or(cwd);
+    ix_root
+        .parent()
+        .map(|p| p.join("ga/state/quality/query-embeddings"))
+        .unwrap_or_else(|| PathBuf::from("../ga/state/quality/query-embeddings"))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = std::env::args().nth(1).map(PathBuf::from).unwrap_or_else(default_dir);
+    if dir.to_string_lossy().contains("://") {
+        eprintln!("refusing non-local path: {}", dir.display());
+        std::process::exit(2);
+    }
+
+    let conn = ix_duck::open_bench()?;
+    println!("query-embeddings dir: {}\n", dir.display());
+
+    let n = ood::build_query_embeddings(&conn, &dir)?;
+    if n < 2 {
+        println!("(only {n} query row(s) — need ≥2 to score against neighbours)");
+        return Ok(());
+    }
+
+    // query_id → query_text, for readable output.
+    let mut text: HashMap<String, String> = HashMap::new();
+    {
+        let mut stmt = conn.prepare("SELECT query_id, query_text FROM query_embeddings")?;
+        let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?;
+        for row in rows {
+            let (id, t) = row?;
+            text.insert(id, t);
+        }
+    }
+
+    // Time the exact all-pairs cosine scoring on the REAL corpus. `ood_scores` dedups by
+    // embedding first, so the work is over DISTINCT embeddings (= scores.len()), not raw n.
+    let k = 3;
+    let t0 = Instant::now();
+    let scores = ood::ood_scores(&conn, k)?;
+    let elapsed = t0.elapsed();
+
+    let distinct = scores.len();
+    let pairs = distinct.saturating_mul(distinct.saturating_sub(1));
+    println!(
+        "rows = {n} raw  |  {distinct} distinct embeddings ({:.1}× replay)  |  dim 1024, k = {k}",
+        n as f64 / distinct.max(1) as f64
+    );
+    println!(
+        "exact all-pairs cosine over the distinct set: {pairs} pairs in {:.1} ms\n",
+        elapsed.as_secs_f64() * 1e3
+    );
+
+    println!("most out-of-domain (lowest mean top-{k} cosine):");
+    println!("  {:>6}  {:<26}  query", "score", "intent");
+    for (id, intent, score) in scores.iter().take(15) {
+        let q = text.get(id).map(|s| s.as_str()).unwrap_or("");
+        let q = if q.chars().count() > 60 {
+            format!("{}…", q.chars().take(59).collect::<String>())
+        } else {
+            q.to_string()
+        };
+        println!("  {score:>6.3}  {intent:<26}  {q}");
+    }
+
+    for thr in [0.3_f64, 0.5] {
+        let flagged = ood::flag_ood(&conn, k, thr)?;
+        println!(
+            "\nflagged OOD at threshold {thr}: {} / {distinct} distinct",
+            flagged.len()
+        );
+    }
+    Ok(())
+}

--- a/crates/ix-duck/src/ood.rs
+++ b/crates/ix-duck/src/ood.rs
@@ -115,16 +115,30 @@ pub fn build_query_embeddings(conn: &Connection, dir: &Path) -> Result<usize, Oo
     Ok(n as usize)
 }
 
-/// Mean top-`k` cosine to nearest neighbours, per query (leave-one-out).
-/// `(query_id, intent, score)` ascending — most out-of-domain first. Needs ≥2 rows
-/// (a query is scored against the others); fewer → empty. Uses the registered
-/// `ix_cosine` UDF, so dimensions must be uniform (mismatch surfaces as a SQL error).
+/// Mean top-`k` cosine to nearest neighbours, per **distinct** query embedding
+/// (leave-one-out). `(query_id, intent, score)` ascending — most out-of-domain first.
+///
+/// **Deduplicated by embedding first** (verified on real Contract-B data: a 263-row day
+/// held only 51 distinct queries — 5.2× replay). A query repeated more than `k` times is
+/// otherwise its *own* nearest neighbours at cosine 1.0 → scores ~1.0 and **never flags**,
+/// even when genuinely out-of-domain. Scoring over distinct embeddings makes the score
+/// "distance to the distinct corpus" — the correct OOD question — and collapses the O(n²)
+/// pair join to the distinct set (≈26× fewer pairs on that day). Each distinct embedding
+/// keeps a representative `query_id`/`intent`.
+///
+/// Needs ≥2 **distinct** embeddings; fewer → empty. Uses the registered `ix_cosine` UDF,
+/// so dimensions must be uniform (mismatch surfaces as a SQL error).
+// @ai:invariant ood_scores dedups by embedding before scoring, so a query repeated >k times is not masked by its own copies — a duplicated out-of-domain query is still flagged [T:test conf:0.9 src:ix_duck::ood::tests::duplicates_dont_mask_ood]
 pub fn ood_scores(conn: &Connection, k: i64) -> duckdb::Result<Vec<(String, String, f64)>> {
     let mut stmt = conn.prepare(
-        "WITH pairs AS (
+        "WITH distinct_q AS (
+             SELECT any_value(query_id) AS query_id, any_value(intent) AS intent, embedding
+             FROM query_embeddings GROUP BY embedding
+         ),
+         pairs AS (
              SELECT a.query_id, a.intent,
                     ix_cosine(a.embedding, b.embedding) AS sim
-             FROM query_embeddings a JOIN query_embeddings b ON a.query_id <> b.query_id
+             FROM distinct_q a JOIN distinct_q b ON a.query_id <> b.query_id
          ),
          ranked AS (
              SELECT query_id, intent, sim,
@@ -236,6 +250,50 @@ mod tests {
         assert_eq!(
             declined.1, "(declined)",
             "null intent surfaces as a label, not an error"
+        );
+    }
+
+    /// A genuinely OOD query repeated more than `k` times would, without dedup, be its own
+    /// nearest neighbours at cosine 1.0 and score ~1.0 — never flagging. Dedup-by-embedding
+    /// fixes that: it is scored against the *distinct* corpus and flagged.
+    #[test]
+    fn duplicates_dont_mask_ood() {
+        let dir = tempfile::tempdir().unwrap();
+        let row = |id: &str, e: &str| {
+            format!(
+                "{{\"query_id\":\"{id}\",\"ts\":\"2026-06-16T00:00:00Z\",\"query_text\":\"{id}\",\"intent\":\"i\",\"route_method\":\"embedding\",\"route_confidence\":0.9,\"embedder\":\"x\",\"dim\":3,\"embedding\":{e}}}\n"
+            )
+        };
+        let mut s = String::new();
+        // 4 distinct in-domain queries, tightly clustered near [1,0,0].
+        s.push_str(&row("a0", "[1.0,0.0,0.0]"));
+        s.push_str(&row("a1", "[0.99,0.1,0.0]"));
+        s.push_str(&row("a2", "[0.98,0.0,0.1]"));
+        s.push_str(&row("a3", "[0.97,0.1,0.1]"));
+        // One OOD query (orthogonal) repeated 4× — would self-mask without dedup.
+        for i in 0..4 {
+            s.push_str(&row(&format!("b{i}"), "[0.0,0.0,1.0]"));
+        }
+        std::fs::write(dir.path().join("2026-06-16.jsonl"), s).unwrap();
+
+        let conn = crate::open_bench().unwrap();
+        let total = build_query_embeddings(&conn, dir.path()).unwrap();
+        assert_eq!(total, 8, "8 raw rows loaded");
+
+        let scores = ood_scores(&conn, 3).unwrap();
+        assert_eq!(
+            scores.len(),
+            5,
+            "scored over 5 DISTINCT embeddings, not 8 raw rows"
+        );
+
+        // The duplicated OOD query is flagged despite its 4 identical copies.
+        let flagged = flag_ood(&conn, 3, 0.5).unwrap();
+        assert_eq!(flagged.len(), 1, "duplicated OOD query no longer masked");
+        assert!(
+            flagged[0].0.starts_with('b'),
+            "the flagged query is the orthogonal one, got {}",
+            flagged[0].0
         );
     }
 }


### PR DESCRIPTION
## Summary
Running the OOD lens against **real Contract-B data** (via the new `ix_ood_lens` example) exposed two problems the brute-force self-join hid — and the fix addresses both, exactly.

The empirical run (`../ga/state/quality/query-embeddings/2026-06-19.jsonl`):
- **Signal dead:** 263 rows held only **51 distinct queries (5.2× replay** — eval traffic). A query repeated more than `k` times is its *own* k nearest neighbours at cosine 1.0 → scores ~1.0 → **never flags**, even if genuinely OOD. Every query scored 1.000; **0 flagged** at any threshold.
- **Slow now (not at 10⁴):** the `O(n²)` `ix_cosine` self-join took **2656 ms** for just 263 rows.

## Fix: dedup by embedding before the pair join
One `DISTINCT`-by-embedding CTE (keeping a representative `query_id`/`intent`), then score over the distinct set. This makes the score *"distance to the distinct corpus"* — the correct OOD question — and collapses the join to distinct points. **Exact** (no HNSW/approximation), so the ROC-sweep-tuned operating point is untouched.

### Real-data result (same corpus, after)
- **2656 ms → 49 ms (~49×)**
- scores now spread **0.52–0.68+** (meaningful: the most-OOD are exotic scales — *Hijaz, Hungarian minor, altered scale*)
- **0 flagged is now a TRUE negative** (homogeneous in-domain corpus, lowest 0.524 > 0.5 threshold) — not a masked dead signal

## Also
- Adds the **`ix_ood_lens`** example (how this was found; the first example for the OOD lens — every other lens had one).
- Test **`duplicates_dont_mask_ood`**: a 4×-duplicated OOD query is flagged, not self-masked.

## Follow-ups (noted, not in scope)
- A separate, larger win exists for genuinely large corpora (normalize-once + GEMM table function, or vss/HNSW if approximate is acceptable) — deferred until distinct-corpus size warrants it.
- The data itself is *eval-replay* traffic, not organic queries — a Contract-B data-quality observation worth feeding back to GA.

## Testing
**92 duck tests pass** (+`duplicates_dont_mask_ood`); existing ood tests unchanged; `cargo clippy -p ix-duck --features duck --all-targets` clean.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: behind the `duck` feature (not in the default/CI build), advisory analyst-lens, no persisted state. Behaviour covered by unit tests + reproducible via `cargo run -p ix-duck --features duck --example ix_ood_lens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)