### PR TITLE
fix(ix-duck): sweep — crash-proof chatbot guardrail + loops net_delta absence≠0

### DIFF
--- a/crates/ix-duck/examples/ix_maintain_lens.rs
+++ b/crates/ix-duck/examples/ix_maintain_lens.rs
@@ -43,9 +43,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         println!("\n  per-loop convergence:");
         for s in loops::loop_summary(&conn)? {
+            let net = s
+                .net_delta
+                .map(|d| format!("{d:+.3}"))
+                .unwrap_or_else(|| "—".into());
             println!(
-                "    {:<22} {:<10} iters={:<3} net={:+.3}  {}",
-                s.loop_id, s.domain, s.iterations, s.net_delta, s.final_verdict
+                "    {:<22} {:<10} iters={:<3} net={net:>7}  {}",
+                s.loop_id, s.domain, s.iterations, s.final_verdict
             );
         }
         println!("\n  recurring worst-items (≥2):");

--- a/crates/ix-duck/src/chatbot.rs
+++ b/crates/ix-duck/src/chatbot.rs
@@ -166,18 +166,27 @@ pub fn build_traces(conn: &Connection, corpus_dir: &Path) -> Result<usize, Chatb
     }
     let list = sql_list(&files);
     conn.execute_batch(&format!(
+        // Read `response.*` via `json_extract(to_json(response), …)` rather than struct-field
+        // access: a subfield absent from EVERY trace file would otherwise be a bind-time
+        // error ("Could not find key"), since struct field access binds against the inferred
+        // type. This mirrors the `facts` handling below and hardens the guardrail lens
+        // against trace-schema evolution. A missing subfield → SQL NULL, never a crash.
         "CREATE OR REPLACE TABLE chatbot_traces AS
-         SELECT promptId                                AS prompt_id,
-                prompt,
-                category,
-                response.agentId                        AS agent_id,
-                TRY_CAST(response.confidence AS DOUBLE) AS routing_confidence,
-                response.routingMethod                  AS routing_method,
-                response.grounding IS NOT NULL          AS grounding_present,
-                length(response.naturalLanguageAnswer)  AS response_length,
-                TRY_CAST(response.elapsedMs AS BIGINT)  AS elapsed_ms,
-                recordedAt                              AS recorded_at
-         FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1);"
+         WITH raw AS (
+             SELECT promptId AS prompt_id, prompt, category, recordedAt AS recorded_at,
+                    to_json(response) AS rj
+             FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1)
+         )
+         SELECT prompt_id, prompt, category,
+                json_extract_string(rj, '$.agentId')                       AS agent_id,
+                TRY_CAST(json_extract(rj, '$.confidence') AS DOUBLE)       AS routing_confidence,
+                json_extract_string(rj, '$.routingMethod')                 AS routing_method,
+                (json_extract(rj, '$.grounding') IS NOT NULL
+                 AND json_extract(rj, '$.grounding')::VARCHAR <> 'null')   AS grounding_present,
+                length(json_extract_string(rj, '$.naturalLanguageAnswer')) AS response_length,
+                TRY_CAST(json_extract(rj, '$.elapsedMs') AS BIGINT)        AS elapsed_ms,
+                recorded_at
+         FROM raw;"
     ))?;
     let n: i64 = conn.query_row("SELECT count(*) FROM chatbot_traces", [], |r| r.get(0))?;
     Ok(n as usize)
@@ -287,7 +296,8 @@ pub fn build_grounding(conn: &Connection, corpus_dir: &Path) -> Result<usize, Ch
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_grounding AS
          WITH g AS (
-             SELECT promptId AS prompt_id, category, to_json(response.grounding) AS gj
+             SELECT promptId AS prompt_id, category,
+                    json_extract(to_json(response), '$.grounding') AS gj
              FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1)
          )
          SELECT prompt_id, category,
@@ -468,10 +478,11 @@ fn build_signatures(conn: &Connection, corpus_dir: &Path) -> Result<(), ChatbotE
     let list = sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_signatures AS
-         SELECT t.promptId AS prompt_id, step.agentId AS expected_agent
+         SELECT t.promptId AS prompt_id,
+                json_extract_string(to_json(step), '$.agentId') AS expected_agent
          FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1) t,
               UNNEST(t.steps) AS u(step)
-         WHERE step.name = 'orchestration.answer';"
+         WHERE json_extract_string(to_json(step), '$.name') = 'orchestration.answer';"
     ))?;
     Ok(())
 }
@@ -652,6 +663,36 @@ mod tests {
         let files = run_files(&fixtures()).unwrap().len();
         assert!(files >= 3, "need a real multi-prompt fixture corpus, found {files}");
         assert_eq!(n, files, "one chatbot_traces row per run file");
+    }
+
+    /// A trace whose `response` object lacks subfields (trace-schema drift) must BUILD.
+    /// With struct-field access this bind-errored ("Could not find key …"); via
+    /// `json_extract(to_json(response), …)` the missing fields read as NULL. Guards the
+    /// guardrail lens against GA renaming/removing a `response` subfield.
+    #[test]
+    fn response_missing_subfields_builds_as_null() {
+        let dir = tempfile::tempdir().unwrap();
+        let run = dir.path().join("golden-traces/q1/run-1.json");
+        fs::create_dir_all(run.parent().unwrap()).unwrap();
+        // `response` carries only agentId — no confidence/routingMethod/grounding/answer/elapsedMs.
+        fs::write(
+            &run,
+            r#"{"promptId":"q1","prompt":"p","category":"c",
+                "response":{"agentId":"skill.x"},"recordedAt":"2026-06-19T00:00:00Z"}"#,
+        )
+        .unwrap();
+        let conn = crate::open_bench().unwrap();
+        let n = build_traces(&conn, dir.path()).unwrap(); // struct-field access would Err here
+        assert_eq!(n, 1, "the trace builds despite the sparse response");
+        let (agent, conf): (String, Option<f64>) = conn
+            .query_row(
+                "SELECT agent_id, routing_confidence FROM chatbot_traces",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(agent, "skill.x");
+        assert_eq!(conf, None, "absent confidence reads as NULL, not a crash or 0");
     }
 
     #[test]

--- a/crates/ix-duck/src/loops.rs
+++ b/crates/ix-duck/src/loops.rs
@@ -182,8 +182,11 @@ pub struct LoopSummary {
     pub loop_id: String,
     pub domain: String,
     pub iterations: i64,
-    /// Sum of per-iteration metric deltas (net movement over the run).
-    pub net_delta: f64,
+    /// Sum of per-iteration metric deltas (net movement over the run). `None` when no
+    /// iteration recorded a delta (all unmeasured, e.g. oracle couldn't run) — distinct
+    /// from a *measured* net of `0.0`. (Absence is not zero — the defect class swept out
+    /// of `routing`/`chatbot`.)
+    pub net_delta: Option<f64>,
     pub final_verdict: String,
 }
 
@@ -194,7 +197,7 @@ pub fn loop_summary(conn: &Connection) -> duckdb::Result<Vec<LoopSummary>> {
     let mut stmt = conn.prepare(&format!(
         "WITH agg AS (
              SELECT loop_id, any_value(domain) AS domain, count(*) AS iterations,
-                    coalesce(sum(metric_delta), 0) AS net_delta, max(iteration) AS last_iter
+                    sum(metric_delta) AS net_delta, max(iteration) AS last_iter
              FROM loop_iterations WHERE {REAL}
              GROUP BY loop_id
          )
@@ -272,10 +275,33 @@ mod tests {
             "one row per iteration, not multiplied"
         );
         assert!(
-            (improving.net_delta - 0.06).abs() < 1e-9,
-            "net delta = 0.02+0.03+0.01, got {}",
+            (improving.net_delta.unwrap() - 0.06).abs() < 1e-9,
+            "net delta = 0.02+0.03+0.01, got {:?}",
             improving.net_delta
         );
+    }
+
+    #[test]
+    fn net_delta_none_when_all_deltas_unmeasured() {
+        // A loop whose iterations all recorded a null metric_delta (oracle couldn't run)
+        // has net_delta = None — "unmeasured", not a measured net of 0.0.
+        let dir = tempfile::tempdir().unwrap();
+        let row = |it: i32| {
+            format!(
+                "{{\"loop_id\":\"l-x\",\"domain\":\"chatbot\",\"iteration\":{it},\"ts\":\"2026-06-18T00:0{it}:00Z\",\"oracle_status\":\"couldnt_run\",\"metric_name\":\"p\",\"metric_before\":null,\"metric_after\":null,\"metric_delta\":null,\"verdict\":\"couldnt_run\",\"worst_item\":\"x\",\"artifact_edited\":\"a\",\"commit_sha\":\"c\",\"roundtrip_passed\":false}}\n"
+            )
+        };
+        std::fs::write(
+            dir.path().join("x.iterations.jsonl"),
+            format!("{}{}", row(1), row(2)),
+        )
+        .unwrap();
+        let conn = crate::open_bench().unwrap();
+        build_loop_iterations(&conn, dir.path()).unwrap();
+        let sum = loop_summary(&conn).unwrap();
+        assert_eq!(sum.len(), 1);
+        assert_eq!(sum[0].iterations, 2);
+        assert_eq!(sum[0].net_delta, None, "all-null deltas → None, not 0.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Completes the **defect-signature sweep** (absence-as-zero / struct-field-access over `read_json_auto`) the course surfaced. Two lenses, two commits.

### 1. Chatbot guardrail — `json_extract` instead of struct-field access
The guardrail lens read nested fields by **struct access**: `response.{agentId,confidence,routingMethod,grounding,naturalLanguageAnswer,elapsedMs}` (build), `to_json(response.grounding)` (grounding), `step.{agentId,name}` (signature). Struct access binds against the *inferred* type, so a subfield absent from **every** trace file hard-errors (`Binder Error: Could not find key`) — the same class that bit `routing` (#126), in the lens that feeds both the maintain gate **and** the `chatbot-gate` CI check.

Masked today only by `union_by_name` keeping every field present (verified: 45 golden traces, **1 uniform schema**), but a GA trace-schema rename/removal would crash the gate. **Fix:** `json_extract(to_json(response|step), '$.field')` → missing subfield = SQL NULL, never a bind error (mirrors the lens's own `facts` handling).

**Validated behaviour-preserving on real data:** `ix_chatbot_lens` output is **byte-identical** before/after (45 traces, 33/45 ungrounded, same routing split, latency top-5, 1/45 grounded).

### 2. Loops `net_delta` — `Option`, not coalesced-to-0
`loop_summary` did `coalesce(sum(metric_delta), 0)`, so a loop whose iterations all recorded a null delta (oracle couldn't run) reported `net_delta = 0.0` — indistinguishable from a real net of zero. Now `Option<f64>`; all-null → `None`. Loops with any measured delta unchanged. Low ripple (maintain.rs reads only `loop_id`).

## Why this was shipped despite "untriggered today"
Both are latent on current data (operator call: *fix all*). The chatbot fix is the high-value one — it's the guardrail, and I could **validate it on real traces** (identical output). Verified-safe defensive hardening of the gate against future GA schema drift.

## Testing
- `response_missing_subfields_builds_as_null` — sparse-response trace builds (struct access would Err); absent fields → NULL.
- `net_delta_none_when_all_deltas_unmeasured` — all-null deltas → None, not 0.0.
- **94 duck tests pass**; existing chatbot/loops tests unchanged; `cargo clippy -p ix-duck --features duck --all-targets` clean.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: behind the `duck` feature (not in default/CI build); the chatbot change is verified byte-identical on real data; pure analyst lenses, no persisted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)