### PR TITLE
refactor(ix-duck): artifact-source seam (deepen lens ingest, kill a defect class)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,19 @@ contracts (see `docs/contracts/`), not runtime coupling.
   (learnings), and the in-flight **business-value scorecard**.
 - **OPTIC-K** — the mmap voicing index schema (`ix-voicings`/`ix-optick`) consumed
   by `ga`. **Voicing** = a fingered chord shape (music-domain, lives in `ga`).
+- **Analyst's bench** — the in-process, in-memory DuckDB layer (`ix-duck`) over the
+  JSONL/Parquet IX and `ga` already emit. Not a production engine, not a source of
+  truth (see `docs/DUCKDB.md`).
+- **Lens** — a read-only analyst module on the bench (`ix_duck::{chatbot, routing,
+  loops, ood, maintain}`) that turns a GA artifact set into a queryable signal. A lens
+  owns *analytics*, not ingest.
+- **Artifact source** (`ix_duck::source`) — the deep module a **lens** reads through:
+  given a file selector + a flat **column spec**, it materializes a GA-emitted JSON
+  artifact set into a bench table, owning file selection, the `read_json_auto` flags,
+  the empty-fallback (typed schema, 0 rows), and the **safe projection**
+  (`json_extract(to_json(obj),'$.f')` / `TRY_CAST`, never struct-field access, never
+  `coalesce(...,0)`). The seam that makes the absence-as-zero / struct-bind-crash
+  defect class non-recurring (see `docs/solutions/.../2026-06-19-duckdb-absence-as-zero-and-struct-bind-crash.md`).
 
 ## Conventions
 

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -56,6 +56,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Artifact source — the deep module every lens reads through: safe materialization of
+/// a GA-emitted JSON artifact set into a bench table (file selection + read_json_auto
+/// flags + the json_extract projection + empty-fallback). See `CONTEXT.md` → "Artifact source".
+#[cfg(feature = "duck")]
+pub mod source;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/routing.rs
+++ b/crates/ix-duck/src/routing.rs
@@ -11,89 +11,65 @@
 //! intent keys (`skill.scaleinfo`) are extracted via JSON-Pointer paths
 //! (`/key/field`) — JSONPath's `$.` would mis-split the dot into nesting.
 
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
 
-/// Errors from the routing lens: directory I/O vs DuckDB.
-#[derive(Debug)]
-pub enum RoutingError {
-    Io(std::io::Error),
-    Duck(duckdb::Error),
-}
-impl std::fmt::Display for RoutingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RoutingError::Io(e) => write!(f, "routing-eval I/O error: {e}"),
-            RoutingError::Duck(e) => write!(f, "duckdb error: {e}"),
-        }
-    }
-}
-impl std::error::Error for RoutingError {}
-impl From<std::io::Error> for RoutingError {
-    fn from(e: std::io::Error) -> Self {
-        RoutingError::Io(e)
-    }
-}
-impl From<duckdb::Error> for RoutingError {
-    fn from(e: duckdb::Error) -> Self {
-        RoutingError::Duck(e)
-    }
+use crate::source::{self, Col, Files};
+
+/// Errors from the routing lens — the shared artifact-source error
+/// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
+pub type RoutingError = source::SourceError;
+
+fn is_routing_eval(name: &str) -> bool {
+    name.starts_with("routing-eval-") && name.ends_with(".json")
 }
 
-/// `routing-eval-*.json` files in `quality_dir` (sorted). Absent dir → empty (skip);
-/// any other read error on a present dir → surfaced.
-fn eval_files(quality_dir: &Path) -> Result<Vec<PathBuf>, RoutingError> {
-    let rd = match std::fs::read_dir(quality_dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.starts_with("routing-eval-") && n.ends_with(".json") {
-                out.push(p);
-            }
-        }
-    }
-    out.sort();
-    Ok(out)
-}
-
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| format!("'{}'", p.to_string_lossy().replace('\\', "/").replace('\'', "''")))
-        .collect();
-    format!("[{}]", items.join(", "))
-}
+/// `routing_overall` column spec — the flat top-line metrics. The InScope/OOS/margin
+/// metrics were added 2026-05-30, so older eval files lack them; reading each via
+/// [`Col::extract`] (json_extract, not struct-field access) yields `NULL` on
+/// whole-corpus absence rather than a bind error or a fabricated zero.
+const OVERALL_SPEC: &[Col] = &[
+    Col::direct("generated_at", "VARCHAR", "generatedAt::VARCHAR"),
+    Col::direct("day", "VARCHAR", "(generatedAt::VARCHAR)[1:10]"),
+    Col::extract("accuracy", "DOUBLE", "overall", "$.Accuracy"),
+    Col::extract("in_scope_accuracy", "DOUBLE", "overall", "$.InScopeAccuracy"),
+    Col::extract("oos_decline_rate", "DOUBLE", "overall", "$.OosDeclineRate"),
+    Col::extract("mean_in_scope_margin", "DOUBLE", "overall", "$.MeanInScopeMargin"),
+];
 
 /// Build `routing_evals` (run × intent) and `routing_overall` (run). Returns the
 /// per-intent row count; 0 when the directory is absent/empty.
 // @ai:invariant build_routing_evals creates routing_evals with one row per (run, intent) parsed from each routing-eval-*.json perIntent map [T:test conf:0.9 src:ix_duck::routing::tests::evals_row_per_run_intent]
 pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usize, RoutingError> {
-    let intent_cols = "generated_at VARCHAR, day VARCHAR, intent VARCHAR, support BIGINT, \
-                       precision DOUBLE, recall DOUBLE, f1 DOUBLE, status VARCHAR";
-    let overall_cols = "generated_at VARCHAR, day VARCHAR, accuracy DOUBLE, \
-                        in_scope_accuracy DOUBLE, oos_decline_rate DOUBLE, mean_in_scope_margin DOUBLE";
-    let files = eval_files(quality_dir)?;
+    let files = source::select_files(Files { dir: quality_dir, matches: is_routing_eval })?;
+    // routing_overall is a flat projection → the deep artifact-source path owns the safe
+    // read + empty-fallback (it can't drift back into struct-access / coalesce-0).
+    source::materialize_files(conn, "routing_overall", &files, OVERALL_SPEC)?;
+    // routing_evals is a map-explode (one row per perIntent key) — not a flat spec — so it
+    // keeps a custom SELECT, but still reuses the shared file list + read flags.
+    build_routing_evals_table(conn, &files)?;
+    let n: i64 = conn.query_row("SELECT count(*) FROM routing_evals", [], |r| r.get(0))?;
+    Ok(n as usize)
+}
+
+/// The `perIntent` map-explode (custom shape — out of scope for the flat [`Col`] spec —
+/// but shares [`source::READ_FLAGS`] + [`source::sql_list`]). Dotted intent keys use
+/// JSON-Pointer (`/key/field`); JSONPath's `$.` would mis-split the dot into nesting.
+fn build_routing_evals_table(conn: &Connection, files: &[PathBuf]) -> Result<(), RoutingError> {
+    let cols = "generated_at VARCHAR, day VARCHAR, intent VARCHAR, support BIGINT, \
+                precision DOUBLE, recall DOUBLE, f1 DOUBLE, status VARCHAR";
     if files.is_empty() {
-        conn.execute_batch(&format!(
-            "CREATE OR REPLACE TABLE routing_evals ({intent_cols});
-             CREATE OR REPLACE TABLE routing_overall ({overall_cols});"
-        ))?;
-        return Ok(0);
+        conn.execute_batch(&format!("CREATE OR REPLACE TABLE routing_evals ({cols});"))?;
+        return Ok(());
     }
-    let list = sql_list(&files);
+    let list = source::sql_list(files);
+    let flags = source::READ_FLAGS;
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE routing_evals AS
          WITH raw AS (
              SELECT generatedAt::VARCHAR AS generated_at, to_json(perIntent) AS pi
-             FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1)
+             FROM read_json_auto({list}, {flags})
          ),
          keyed AS (SELECT generated_at, pi, unnest(json_keys(pi)) AS intent FROM raw)
          SELECT generated_at, generated_at[1:10] AS day, intent,
@@ -102,17 +78,9 @@ pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usiz
                 json_extract(pi, '/' || intent || '/Recall')::DOUBLE    AS recall,
                 json_extract(pi, '/' || intent || '/F1')::DOUBLE        AS f1,
                 json_extract_string(pi, '/' || intent || '/Status')     AS status
-         FROM keyed;
-         CREATE OR REPLACE TABLE routing_overall AS
-         SELECT generatedAt::VARCHAR AS generated_at, (generatedAt::VARCHAR)[1:10] AS day,
-                TRY_CAST(json_extract(to_json(overall), '$.Accuracy') AS DOUBLE)          AS accuracy,
-                TRY_CAST(json_extract(to_json(overall), '$.InScopeAccuracy') AS DOUBLE)   AS in_scope_accuracy,
-                TRY_CAST(json_extract(to_json(overall), '$.OosDeclineRate') AS DOUBLE)    AS oos_decline_rate,
-                TRY_CAST(json_extract(to_json(overall), '$.MeanInScopeMargin') AS DOUBLE) AS mean_in_scope_margin
-         FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1);"
+         FROM keyed;"
     ))?;
-    let n: i64 = conn.query_row("SELECT count(*) FROM routing_evals", [], |r| r.get(0))?;
-    Ok(n as usize)
+    Ok(())
 }
 
 /// Weakest intents in the **latest** run: `(intent, f1, support)` with `f1 < threshold`.

--- a/crates/ix-duck/src/source.rs
+++ b/crates/ix-duck/src/source.rs
@@ -1,0 +1,284 @@
+//! Artifact source — the deep module a [`lens`](crate) reads through.
+//!
+//! Every lens used to re-implement the same three things by hand: an `Io | Duck`
+//! error enum, file enumeration + a DuckDB list literal, and the
+//! `CREATE OR REPLACE TABLE … AS SELECT … FROM read_json_auto(…)` materialization.
+//! That last one carries a load-bearing invariant — the *safe projection* — and
+//! re-applying it by hand is exactly how the absence-as-zero / struct-field
+//! bind-crash defect class kept recurring (routing #126, chatbot/loops #127). See
+//! `docs/solutions/feature-implementations/2026-06-19-duckdb-absence-as-zero-and-struct-bind-crash.md`.
+//!
+//! This module concentrates all three behind one seam. A lens declares *which files*
+//! ([`Files`]) and *which columns* (a flat [`Col`] spec); [`materialize`] owns the
+//! rest and guarantees the invariant:
+//!
+//! - **Optional / nested fields go through `json_extract(to_json(root), path)`**, never
+//!   struct-field access — so a field absent from *every* file yields `NULL`, not a
+//!   bind-time "Could not find key" error.
+//! - **Absence is `NULL`, never `coalesce(…, 0)`** — a missing metric can't masquerade
+//!   as a real zero and fake a trend.
+//! - **An absent/empty directory yields an empty table _with the declared schema_**, so
+//!   downstream lens queries still bind (graceful degrade, never an error).
+//!
+//! Lenses whose shape isn't a flat projection (e.g. routing's `perIntent` map-explode)
+//! keep a custom `SELECT` but still reuse [`select_files`], [`sql_list`], [`READ_FLAGS`]
+//! and [`SourceError`] — so only the genuinely-different projection stays bespoke.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use duckdb::Connection;
+
+/// `read_json_auto` flags every artifact read uses: per-file `filename`, schema union
+/// across ragged files, and type inference over *all* rows (`sample_size=-1`).
+pub const READ_FLAGS: &str = "filename=true, union_by_name=true, sample_size=-1";
+
+/// Error from an artifact source: directory I/O vs DuckDB. Shared by every lens
+/// (replaces the per-lens `RoutingError`/`ChatbotError`/… copies).
+#[derive(Debug)]
+pub enum SourceError {
+    Io(std::io::Error),
+    Duck(duckdb::Error),
+}
+impl std::fmt::Display for SourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceError::Io(e) => write!(f, "artifact source I/O error: {e}"),
+            SourceError::Duck(e) => write!(f, "duckdb error: {e}"),
+        }
+    }
+}
+impl std::error::Error for SourceError {}
+impl From<std::io::Error> for SourceError {
+    fn from(e: std::io::Error) -> Self {
+        SourceError::Io(e)
+    }
+}
+impl From<duckdb::Error> for SourceError {
+    fn from(e: duckdb::Error) -> Self {
+        SourceError::Duck(e)
+    }
+}
+
+/// A file selector: a directory and a filename predicate. The predicate is a plain
+/// `fn` (lens patterns capture nothing — prefix/suffix/extension matches).
+#[derive(Clone, Copy)]
+pub struct Files<'a> {
+    pub dir: &'a Path,
+    pub matches: fn(&str) -> bool,
+}
+
+/// How one output column is produced from the parsed JSON.
+#[derive(Clone, Copy)]
+pub enum ColSource {
+    /// A top-level field/expression `read_json_auto` infers; emitted as-is. `union_by_name`
+    /// NULL-fills it across ragged files, so direct access is safe. e.g. `"generatedAt::VARCHAR"`.
+    Direct(&'static str),
+    /// An optional / nested field: `json_extract(to_json(root), path)` cast to the column
+    /// type. NULL on whole-corpus absence (never a bind error), never coalesced to zero.
+    /// `path` is a JSONPath (`"$.Accuracy"`) or JSON-Pointer (`"/key/F1"`).
+    Extract {
+        root: &'static str,
+        path: &'static str,
+    },
+}
+
+/// One output column of an artifact source: its name, SQL type (used for the
+/// empty-table schema and the cast), and how it's projected.
+#[derive(Clone, Copy)]
+pub struct Col {
+    pub name: &'static str,
+    pub ty: &'static str,
+    pub source: ColSource,
+}
+impl Col {
+    /// A top-level field/expression, emitted directly.
+    pub const fn direct(name: &'static str, ty: &'static str, expr: &'static str) -> Self {
+        Col { name, ty, source: ColSource::Direct(expr) }
+    }
+    /// An optional/nested field read safely via `json_extract` (NULL on absence).
+    pub const fn extract(name: &'static str, ty: &'static str, root: &'static str, path: &'static str) -> Self {
+        Col { name, ty, source: ColSource::Extract { root, path } }
+    }
+
+    /// `name ty` for the empty-table schema.
+    fn schema_decl(&self) -> String {
+        format!("{} {}", self.name, self.ty)
+    }
+
+    /// The SELECT projection for a populated table — this is where the safe-read
+    /// invariant lives.
+    fn projection(&self) -> String {
+        match self.source {
+            ColSource::Direct(expr) => format!("{expr} AS {}", self.name),
+            // VARCHAR comes back JSON-quoted from json_extract, so use json_extract_string;
+            // everything else round-trips through TRY_CAST (NULL, never an error, on a bad/absent value).
+            ColSource::Extract { root, path } if self.ty.eq_ignore_ascii_case("VARCHAR") => {
+                format!("json_extract_string(to_json({root}), '{path}') AS {}", self.name)
+            }
+            ColSource::Extract { root, path } => {
+                format!("TRY_CAST(json_extract(to_json({root}), '{path}') AS {}) AS {}", self.ty, self.name)
+            }
+        }
+    }
+}
+
+/// Files in `sel.dir` matching `sel.matches`, sorted. An **absent** directory →
+/// empty (the lens degrades to "no data"); any other read error on a present dir is
+/// surfaced.
+pub fn select_files(sel: Files) -> Result<Vec<PathBuf>, SourceError> {
+    let rd = match std::fs::read_dir(sel.dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut out = Vec::new();
+    for entry in rd {
+        let p = entry?.path();
+        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
+            if (sel.matches)(n) {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// A DuckDB list literal of POSIX-slashed, quote-escaped paths.
+pub fn sql_list(paths: &[PathBuf]) -> String {
+    let items: Vec<String> = paths
+        .iter()
+        .map(|p| format!("'{}'", p.to_string_lossy().replace('\\', "/").replace('\'', "''")))
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+/// Materialize `table` from a precomputed file list using the flat column `spec`.
+/// Empty list → an empty table with the declared schema. Returns the row count.
+pub fn materialize_files(
+    conn: &Connection,
+    table: &str,
+    files: &[PathBuf],
+    spec: &[Col],
+) -> Result<usize, SourceError> {
+    if files.is_empty() {
+        let decls: Vec<String> = spec.iter().map(Col::schema_decl).collect();
+        conn.execute_batch(&format!("CREATE OR REPLACE TABLE {table} ({});", decls.join(", ")))?;
+        return Ok(0);
+    }
+    let proj: Vec<String> = spec.iter().map(Col::projection).collect();
+    let list = sql_list(files);
+    conn.execute_batch(&format!(
+        "CREATE OR REPLACE TABLE {table} AS SELECT {} FROM read_json_auto({list}, {READ_FLAGS});",
+        proj.join(", ")
+    ))?;
+    let n: i64 = conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |r| r.get(0))?;
+    Ok(n as usize)
+}
+
+/// Select files and materialize `table` in one step — the common lens path.
+pub fn materialize(
+    conn: &Connection,
+    table: &str,
+    sel: Files,
+    spec: &[Col],
+) -> Result<usize, SourceError> {
+    let files = select_files(sel)?;
+    materialize_files(conn, table, &files, spec)
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // A spec mirroring routing_overall: two Direct columns + four optional Extract metrics.
+    const SPEC: &[Col] = &[
+        Col::direct("generated_at", "VARCHAR", "generatedAt::VARCHAR"),
+        Col::direct("day", "VARCHAR", "(generatedAt::VARCHAR)[1:10]"),
+        Col::extract("accuracy", "DOUBLE", "overall", "$.Accuracy"),
+        Col::extract("oos_decline_rate", "DOUBLE", "overall", "$.OosDeclineRate"),
+        Col::extract("label", "VARCHAR", "overall", "$.Label"),
+    ];
+
+    fn matches_eval(n: &str) -> bool {
+        n.starts_with("eval-") && n.ends_with(".json")
+    }
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        let mut f = std::fs::File::create(dir.join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn absent_dir_yields_empty_table_with_schema() {
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(
+            &conn,
+            "t",
+            Files { dir: Path::new("/no/such/dir"), matches: matches_eval },
+            SPEC,
+        )
+        .unwrap();
+        assert_eq!(n, 0);
+        // Downstream queries must still bind against the declared schema.
+        let rows: i64 = conn
+            .query_row("SELECT count(*) FROM (SELECT accuracy, label, oos_decline_rate FROM t)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+
+    #[test]
+    fn optional_field_absent_corpuswide_is_null_not_crash() {
+        // Every file predates the OosDeclineRate / Label fields → both absent from the
+        // whole corpus. Struct-field access would fail at bind time; json_extract yields
+        // NULL. This is the defect-class guard, now in ONE place for all lenses.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "eval-2026-05-11.json", r#"{"generatedAt":"2026-05-11T00:00:00Z","overall":{"Accuracy":0.875}}"#);
+        write(dir.path(), "eval-2026-05-12.json", r#"{"generatedAt":"2026-05-12T00:00:00Z","overall":{"Accuracy":0.9}}"#);
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        assert_eq!(n, 2);
+        let (acc, oos, label): (Option<f64>, Option<f64>, Option<String>) = conn
+            .query_row(
+                "SELECT accuracy, oos_decline_rate, label FROM t ORDER BY generated_at LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(acc, Some(0.875), "present field reads its value");
+        assert_eq!(oos, None, "absent numeric field is NULL, not 0.0");
+        assert_eq!(label, None, "absent string field is NULL");
+    }
+
+    #[test]
+    fn present_fields_read_through_including_string_and_derived() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "eval-2026-06-02.json",
+            r#"{"generatedAt":"2026-06-02T12:00:00Z","overall":{"Accuracy":0.95,"OosDeclineRate":0.5,"Label":"green"}}"#,
+        );
+        let conn = crate::open_bench().unwrap();
+        materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        let (day, oos, label): (String, Option<f64>, Option<String>) = conn
+            .query_row("SELECT day, oos_decline_rate, label FROM t", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(day, "2026-06-02", "Direct derived expr (slice) works");
+        assert_eq!(oos, Some(0.5));
+        assert_eq!(label.as_deref(), Some("green"), "VARCHAR extract is unquoted via json_extract_string");
+    }
+
+    #[test]
+    fn non_matching_files_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "eval-2026-06-02.json", r#"{"generatedAt":"2026-06-02T00:00:00Z","overall":{"Accuracy":0.9}}"#);
+        write(dir.path(), "README.md", "not an eval");
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        assert_eq!(n, 1, "only eval-*.json is read");
+    }
+}


### PR DESCRIPTION
## Summary

From `/improve-codebase-architecture` (candidate #3). Introduces **`ix_duck::source`** — the deep module every **lens** reads through — and migrates the `routing` lens onto it as the tracer-bullet.

Each lens used to re-implement the same three things:
- an `Io | Duck` error enum (`RoutingError`/`ChatbotError`/`LoopError`/`OodError`/`MaintainError`),
- file selection + the DuckDB list literal,
- the `CREATE OR REPLACE TABLE … AS SELECT … FROM read_json_auto(…)` materialization.

That last one carries a load-bearing invariant — the **safe projection** — and re-applying it by hand is exactly how the **absence-as-zero / struct-field bind-crash** defect class kept recurring (routing #126, chatbot/loops #127).

## The seam
```rust
pub fn materialize(conn, table, Files, &[Col]) -> Result<usize, SourceError>
pub enum ColSource { Direct(&str), Extract { root, path } }   // flat column spec
pub const READ_FLAGS; pub fn select_files(Files); pub fn sql_list(&[PathBuf]);
```
`materialize` guarantees: optional/nested fields go through `json_extract(to_json(root),path)` (NULL on whole-corpus absence, never a bind error, never `coalesce(…,0)`); an absent dir yields an **empty table with the declared schema** (graceful degrade). The class **cannot re-enter via a new lens.**

## Migration (routing)
- `routing_overall` (flat) → `source::materialize_files(OVERALL_SPEC)`.
- `routing_evals` (perIntent **map-explode**, out of scope for a flat spec) → keeps its custom `SELECT` but reuses `select_files`/`sql_list`/`READ_FLAGS`/`SourceError`, so only the genuinely-different projection is bespoke.
- `RoutingError` is now an alias to `source::SourceError` (public name preserved).

## Tests
- The per-lens ingest crash tests collapse into **4 `source::` tests** over ragged / old-corpus / missing-dir fixtures (the defect-class guard, now central).
- `ix-duck --features duck`: **99 pass** (`source` 4, `routing` 6 unchanged — behaviour preserved); clippy clean.
- `CONTEXT.md` gains *Analyst's bench*, *Lens*, *Artifact source*.

## Follow-up
Migrate `chatbot`/`loops`/`ood`/`maintain` onto the seam — each then needs **zero** ingest tests. (Not in this PR; routing is the tracer-bullet.)

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required:` `duck` feature is opt-in, never built by default/CI; this is a behaviour-preserving internal refactor. Validate via `cargo test -p ix-duck --features duck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)