### PR TITLE
refactor(ix-duck): migrate loops + ood lenses onto the artifact-source seam

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,19 @@ contracts (see `docs/contracts/`), not runtime coupling.
   (learnings), and the in-flight **business-value scorecard**.
 - **OPTIC-K** — the mmap voicing index schema (`ix-voicings`/`ix-optick`) consumed
   by `ga`. **Voicing** = a fingered chord shape (music-domain, lives in `ga`).
+- **Analyst's bench** — the in-process, in-memory DuckDB layer (`ix-duck`) over the
+  JSONL/Parquet IX and `ga` already emit. Not a production engine, not a source of
+  truth (see `docs/DUCKDB.md`).
+- **Lens** — a read-only analyst module on the bench (`ix_duck::{chatbot, routing,
+  loops, ood, maintain}`) that turns a GA artifact set into a queryable signal. A lens
+  owns *analytics*, not ingest.
+- **Artifact source** (`ix_duck::source`) — the deep module a **lens** reads through:
+  given a file selector + a flat **column spec**, it materializes a GA-emitted JSON
+  artifact set into a bench table, owning file selection, the `read_json_auto` flags,
+  the empty-fallback (typed schema, 0 rows), and the **safe projection**
+  (`json_extract(to_json(obj),'$.f')` / `TRY_CAST`, never struct-field access, never
+  `coalesce(...,0)`). The seam that makes the absence-as-zero / struct-bind-crash
+  defect class non-recurring (see `docs/solutions/.../2026-06-19-duckdb-absence-as-zero-and-struct-bind-crash.md`).
 
 ## Conventions
 

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -56,6 +56,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Artifact source — the deep module every lens reads through: safe materialization of
+/// a GA-emitted JSON artifact set into a bench table (file selection + read_json_auto
+/// flags + the json_extract projection + empty-fallback). See `CONTEXT.md` → "Artifact source".
+#[cfg(feature = "duck")]
+pub mod source;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/loops.rs
+++ b/crates/ix-duck/src/loops.rs
@@ -13,110 +13,50 @@
 //! analyses below exclude seed/test domains so a fresh checkout reads as "no signal"
 //! rather than a phantom. Absent directory → empty tables (never an error).
 
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use duckdb::Connection;
 
-/// Errors from the loop lens: directory I/O vs DuckDB.
-#[derive(Debug)]
-pub enum LoopError {
-    Io(std::io::Error),
-    Duck(duckdb::Error),
-}
-impl std::fmt::Display for LoopError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LoopError::Io(e) => write!(f, "loop-iterations I/O error: {e}"),
-            LoopError::Duck(e) => write!(f, "duckdb error: {e}"),
-        }
-    }
-}
-impl std::error::Error for LoopError {}
-impl From<std::io::Error> for LoopError {
-    fn from(e: std::io::Error) -> Self {
-        LoopError::Io(e)
-    }
-}
-impl From<duckdb::Error> for LoopError {
-    fn from(e: duckdb::Error) -> Self {
-        LoopError::Duck(e)
-    }
-}
+use crate::source::{self, Col, Files};
 
-/// `*.iterations.jsonl` files in `loops_dir` (sorted). Absent dir → empty (skip);
-/// any other read error on a present dir → surfaced.
-fn ledger_files(loops_dir: &Path) -> Result<Vec<PathBuf>, LoopError> {
-    let rd = match std::fs::read_dir(loops_dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.ends_with(".iterations.jsonl") {
-                out.push(p);
-            }
-        }
-    }
-    out.sort();
-    Ok(out)
-}
+/// Errors from the loop lens — the shared artifact-source error
+/// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
+pub type LoopError = source::SourceError;
 
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            format!(
-                "'{}'",
-                p.to_string_lossy().replace('\\', "/").replace('\'', "''")
-            )
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
-}
+/// `loop_iterations` column spec. Every field is top-level in GA's JSONL row, so each is a
+/// flat [`Col::direct`] projection (`TRY_CAST` for numerics/booleans → NULL, never an error,
+/// on a bad/absent value). The deep artifact-source path owns the safe read + empty-fallback.
+const LOOP_SPEC: &[Col] = &[
+    Col::direct("loop_id", "VARCHAR", "loop_id::VARCHAR"),
+    Col::direct("domain", "VARCHAR", "domain::VARCHAR"),
+    Col::direct("iteration", "BIGINT", "TRY_CAST(iteration AS BIGINT)"),
+    Col::direct("ts", "VARCHAR", "ts::VARCHAR"),
+    Col::direct("oracle_status", "VARCHAR", "oracle_status::VARCHAR"),
+    Col::direct("metric_name", "VARCHAR", "metric_name::VARCHAR"),
+    Col::direct("metric_before", "DOUBLE", "TRY_CAST(metric_before AS DOUBLE)"),
+    Col::direct("metric_after", "DOUBLE", "TRY_CAST(metric_after AS DOUBLE)"),
+    Col::direct("metric_delta", "DOUBLE", "TRY_CAST(metric_delta AS DOUBLE)"),
+    Col::direct("verdict", "VARCHAR", "verdict::VARCHAR"),
+    Col::direct("worst_item", "VARCHAR", "worst_item::VARCHAR"),
+    Col::direct("artifact_edited", "VARCHAR", "artifact_edited::VARCHAR"),
+    Col::direct("commit_sha", "VARCHAR", "commit_sha::VARCHAR"),
+    Col::direct("roundtrip_passed", "BOOLEAN", "TRY_CAST(roundtrip_passed AS BOOLEAN)"),
+];
 
-const COLS: &str = "loop_id VARCHAR, domain VARCHAR, iteration BIGINT, ts VARCHAR, \
-                    oracle_status VARCHAR, metric_name VARCHAR, metric_before DOUBLE, \
-                    metric_after DOUBLE, metric_delta DOUBLE, verdict VARCHAR, \
-                    worst_item VARCHAR, artifact_edited VARCHAR, commit_sha VARCHAR, \
-                    roundtrip_passed BOOLEAN";
+fn is_iterations_jsonl(name: &str) -> bool {
+    name.ends_with(".iterations.jsonl")
+}
 
 /// Build `loop_iterations` (one row per loop × iteration). Returns the row count
 /// (including any seed/test rows); 0 when the directory is absent/empty.
 // @ai:invariant build_loop_iterations creates loop_iterations with one row per JSONL line across every *.iterations.jsonl in loops_dir [T:test conf:0.9 src:ix_duck::loops::tests::rows_one_per_iteration]
 pub fn build_loop_iterations(conn: &Connection, loops_dir: &Path) -> Result<usize, LoopError> {
-    let files = ledger_files(loops_dir)?;
-    if files.is_empty() {
-        conn.execute_batch(&format!(
-            "CREATE OR REPLACE TABLE loop_iterations ({COLS});"
-        ))?;
-        return Ok(0);
-    }
-    let list = sql_list(&files);
-    conn.execute_batch(&format!(
-        "CREATE OR REPLACE TABLE loop_iterations AS
-         SELECT loop_id::VARCHAR              AS loop_id,
-                domain::VARCHAR               AS domain,
-                TRY_CAST(iteration AS BIGINT) AS iteration,
-                ts::VARCHAR                   AS ts,
-                oracle_status::VARCHAR        AS oracle_status,
-                metric_name::VARCHAR          AS metric_name,
-                TRY_CAST(metric_before AS DOUBLE) AS metric_before,
-                TRY_CAST(metric_after  AS DOUBLE) AS metric_after,
-                TRY_CAST(metric_delta  AS DOUBLE) AS metric_delta,
-                verdict::VARCHAR              AS verdict,
-                worst_item::VARCHAR           AS worst_item,
-                artifact_edited::VARCHAR      AS artifact_edited,
-                commit_sha::VARCHAR           AS commit_sha,
-                TRY_CAST(roundtrip_passed AS BOOLEAN) AS roundtrip_passed
-         FROM read_json_auto({list}, union_by_name=true, sample_size=-1);"
-    ))?;
-    let n: i64 = conn.query_row("SELECT count(*) FROM loop_iterations", [], |r| r.get(0))?;
-    Ok(n as usize)
+    source::materialize(
+        conn,
+        "loop_iterations",
+        Files { dir: loops_dir, matches: is_iterations_jsonl },
+        LOOP_SPEC,
+    )
 }
 
 /// Real (non-seed, non-test) rows only — the predicate every analysis shares so a
@@ -223,6 +163,7 @@ pub fn loop_summary(conn: &Connection) -> duckdb::Result<Vec<LoopSummary>> {
 #[cfg(all(test, feature = "duck"))]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn fixtures() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/loops")

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -42,6 +42,7 @@ use duckdb::Connection;
 use serde::Serialize;
 
 use crate::chatbot;
+use crate::source;
 
 /// Errors from the maintain gate.
 #[derive(Debug)]
@@ -49,8 +50,10 @@ pub enum MaintainError {
     Io(std::io::Error),
     Duck(duckdb::Error),
     Chatbot(chatbot::ChatbotError),
-    Loops(crate::loops::LoopError),
-    Ood(crate::ood::OodError),
+    /// Any artifact-source lens error. The convergence (loops) and drift (ood) lenses now
+    /// share [`source::SourceError`], so they collapse into one variant — distinct
+    /// `From<source::SourceError>` impls per lens would be a conflicting-impl error.
+    Source(source::SourceError),
 }
 impl std::fmt::Display for MaintainError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -58,8 +61,7 @@ impl std::fmt::Display for MaintainError {
             MaintainError::Io(e) => write!(f, "maintain I/O error: {e}"),
             MaintainError::Duck(e) => write!(f, "duckdb error: {e}"),
             MaintainError::Chatbot(e) => write!(f, "guardrail lens error: {e}"),
-            MaintainError::Loops(e) => write!(f, "convergence lens error: {e}"),
-            MaintainError::Ood(e) => write!(f, "drift lens error: {e}"),
+            MaintainError::Source(e) => write!(f, "lens error: {e}"),
         }
     }
 }
@@ -79,14 +81,9 @@ impl From<chatbot::ChatbotError> for MaintainError {
         MaintainError::Chatbot(e)
     }
 }
-impl From<crate::loops::LoopError> for MaintainError {
-    fn from(e: crate::loops::LoopError) -> Self {
-        MaintainError::Loops(e)
-    }
-}
-impl From<crate::ood::OodError> for MaintainError {
-    fn from(e: crate::ood::OodError) -> Self {
-        MaintainError::Ood(e)
+impl From<source::SourceError> for MaintainError {
+    fn from(e: source::SourceError) -> Self {
+        MaintainError::Source(e)
     }
 }
 

--- a/crates/ix-duck/src/ood.rs
+++ b/crates/ix-duck/src/ood.rs
@@ -16,103 +16,47 @@
 //! Producer is default-on; first rows land when the chatbot routes a live query.
 //! Absent/empty directory → empty (never error).
 
-use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use duckdb::Connection;
 
-/// Errors from the OOD lens: directory I/O vs DuckDB.
-#[derive(Debug)]
-pub enum OodError {
-    Io(std::io::Error),
-    Duck(duckdb::Error),
-}
-impl std::fmt::Display for OodError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OodError::Io(e) => write!(f, "query-embeddings I/O error: {e}"),
-            OodError::Duck(e) => write!(f, "duckdb error: {e}"),
-        }
-    }
-}
-impl std::error::Error for OodError {}
-impl From<std::io::Error> for OodError {
-    fn from(e: std::io::Error) -> Self {
-        OodError::Io(e)
-    }
-}
-impl From<duckdb::Error> for OodError {
-    fn from(e: duckdb::Error) -> Self {
-        OodError::Duck(e)
-    }
-}
+use crate::source::{self, Col, Files};
 
-/// `*.jsonl` files in `dir` (sorted). Absent dir → empty (skip); other errors surfaced.
-fn embedding_files(dir: &Path) -> Result<Vec<PathBuf>, OodError> {
-    let rd = match std::fs::read_dir(dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.ends_with(".jsonl") {
-                out.push(p);
-            }
-        }
-    }
-    out.sort();
-    Ok(out)
-}
+/// Errors from the OOD lens — the shared artifact-source error
+/// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
+pub type OodError = source::SourceError;
 
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            format!(
-                "'{}'",
-                p.to_string_lossy().replace('\\', "/").replace('\'', "''")
-            )
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
-}
+/// `query_embeddings` column spec. Every field (including the `embedding DOUBLE[]` vector and
+/// the derived `day` slice) is a flat [`Col::direct`] projection; the deep artifact-source
+/// path owns the safe read + empty-fallback. `intent` is nullable per Contract B — the direct
+/// `intent::VARCHAR` cast yields NULL on a JSON null, not an error.
+const EMBEDDING_SPEC: &[Col] = &[
+    Col::direct("query_id", "VARCHAR", "query_id::VARCHAR"),
+    Col::direct("ts", "VARCHAR", "ts::VARCHAR"),
+    Col::direct("day", "VARCHAR", "(ts::VARCHAR)[1:10]"),
+    Col::direct("query_text", "VARCHAR", "query_text::VARCHAR"),
+    Col::direct("intent", "VARCHAR", "intent::VARCHAR"),
+    Col::direct("route_method", "VARCHAR", "route_method::VARCHAR"),
+    Col::direct("route_confidence", "DOUBLE", "TRY_CAST(route_confidence AS DOUBLE)"),
+    Col::direct("embedder", "VARCHAR", "embedder::VARCHAR"),
+    Col::direct("dim", "BIGINT", "TRY_CAST(dim AS BIGINT)"),
+    Col::direct("embedding", "DOUBLE[]", "embedding::DOUBLE[]"),
+];
 
-const COLS: &str = "query_id VARCHAR, ts VARCHAR, day VARCHAR, query_text VARCHAR, \
-                    intent VARCHAR, route_method VARCHAR, route_confidence DOUBLE, \
-                    embedder VARCHAR, dim BIGINT, embedding DOUBLE[]";
+fn is_jsonl(name: &str) -> bool {
+    name.ends_with(".jsonl")
+}
 
 /// Build `query_embeddings` (one row per routed query). Returns the row count;
 /// 0 when the directory is absent/empty.
 // @ai:invariant build_query_embeddings creates query_embeddings with one row per JSONL line, embedding as DOUBLE[] [T:test conf:0.9 src:ix_duck::ood::tests::rows_one_per_query]
 pub fn build_query_embeddings(conn: &Connection, dir: &Path) -> Result<usize, OodError> {
-    let files = embedding_files(dir)?;
-    if files.is_empty() {
-        conn.execute_batch(&format!(
-            "CREATE OR REPLACE TABLE query_embeddings ({COLS});"
-        ))?;
-        return Ok(0);
-    }
-    let list = sql_list(&files);
-    conn.execute_batch(&format!(
-        "CREATE OR REPLACE TABLE query_embeddings AS
-         SELECT query_id::VARCHAR        AS query_id,
-                ts::VARCHAR              AS ts,
-                (ts::VARCHAR)[1:10]      AS day,
-                query_text::VARCHAR      AS query_text,
-                intent::VARCHAR          AS intent,
-                route_method::VARCHAR    AS route_method,
-                TRY_CAST(route_confidence AS DOUBLE) AS route_confidence,
-                embedder::VARCHAR        AS embedder,
-                TRY_CAST(dim AS BIGINT)  AS dim,
-                embedding::DOUBLE[]      AS embedding
-         FROM read_json_auto({list}, union_by_name=true, sample_size=-1);"
-    ))?;
-    let n: i64 = conn.query_row("SELECT count(*) FROM query_embeddings", [], |r| r.get(0))?;
-    Ok(n as usize)
+    source::materialize(
+        conn,
+        "query_embeddings",
+        Files { dir, matches: is_jsonl },
+        EMBEDDING_SPEC,
+    )
 }
 
 /// Mean top-`k` cosine to nearest neighbours, per **distinct** query embedding
@@ -169,6 +113,7 @@ pub fn flag_ood(
 #[cfg(all(test, feature = "duck"))]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     fn fixtures() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/query-embeddings")

--- a/crates/ix-duck/src/routing.rs
+++ b/crates/ix-duck/src/routing.rs
@@ -11,89 +11,65 @@
 //! intent keys (`skill.scaleinfo`) are extracted via JSON-Pointer paths
 //! (`/key/field`) — JSONPath's `$.` would mis-split the dot into nesting.
 
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
 
-/// Errors from the routing lens: directory I/O vs DuckDB.
-#[derive(Debug)]
-pub enum RoutingError {
-    Io(std::io::Error),
-    Duck(duckdb::Error),
-}
-impl std::fmt::Display for RoutingError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            RoutingError::Io(e) => write!(f, "routing-eval I/O error: {e}"),
-            RoutingError::Duck(e) => write!(f, "duckdb error: {e}"),
-        }
-    }
-}
-impl std::error::Error for RoutingError {}
-impl From<std::io::Error> for RoutingError {
-    fn from(e: std::io::Error) -> Self {
-        RoutingError::Io(e)
-    }
-}
-impl From<duckdb::Error> for RoutingError {
-    fn from(e: duckdb::Error) -> Self {
-        RoutingError::Duck(e)
-    }
+use crate::source::{self, Col, Files};
+
+/// Errors from the routing lens — the shared artifact-source error
+/// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
+pub type RoutingError = source::SourceError;
+
+fn is_routing_eval(name: &str) -> bool {
+    name.starts_with("routing-eval-") && name.ends_with(".json")
 }
 
-/// `routing-eval-*.json` files in `quality_dir` (sorted). Absent dir → empty (skip);
-/// any other read error on a present dir → surfaced.
-fn eval_files(quality_dir: &Path) -> Result<Vec<PathBuf>, RoutingError> {
-    let rd = match std::fs::read_dir(quality_dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.starts_with("routing-eval-") && n.ends_with(".json") {
-                out.push(p);
-            }
-        }
-    }
-    out.sort();
-    Ok(out)
-}
-
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| format!("'{}'", p.to_string_lossy().replace('\\', "/").replace('\'', "''")))
-        .collect();
-    format!("[{}]", items.join(", "))
-}
+/// `routing_overall` column spec — the flat top-line metrics. The InScope/OOS/margin
+/// metrics were added 2026-05-30, so older eval files lack them; reading each via
+/// [`Col::extract`] (json_extract, not struct-field access) yields `NULL` on
+/// whole-corpus absence rather than a bind error or a fabricated zero.
+const OVERALL_SPEC: &[Col] = &[
+    Col::direct("generated_at", "VARCHAR", "generatedAt::VARCHAR"),
+    Col::direct("day", "VARCHAR", "(generatedAt::VARCHAR)[1:10]"),
+    Col::extract("accuracy", "DOUBLE", "overall", "$.Accuracy"),
+    Col::extract("in_scope_accuracy", "DOUBLE", "overall", "$.InScopeAccuracy"),
+    Col::extract("oos_decline_rate", "DOUBLE", "overall", "$.OosDeclineRate"),
+    Col::extract("mean_in_scope_margin", "DOUBLE", "overall", "$.MeanInScopeMargin"),
+];
 
 /// Build `routing_evals` (run × intent) and `routing_overall` (run). Returns the
 /// per-intent row count; 0 when the directory is absent/empty.
 // @ai:invariant build_routing_evals creates routing_evals with one row per (run, intent) parsed from each routing-eval-*.json perIntent map [T:test conf:0.9 src:ix_duck::routing::tests::evals_row_per_run_intent]
 pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usize, RoutingError> {
-    let intent_cols = "generated_at VARCHAR, day VARCHAR, intent VARCHAR, support BIGINT, \
-                       precision DOUBLE, recall DOUBLE, f1 DOUBLE, status VARCHAR";
-    let overall_cols = "generated_at VARCHAR, day VARCHAR, accuracy DOUBLE, \
-                        in_scope_accuracy DOUBLE, oos_decline_rate DOUBLE, mean_in_scope_margin DOUBLE";
-    let files = eval_files(quality_dir)?;
+    let files = source::select_files(Files { dir: quality_dir, matches: is_routing_eval })?;
+    // routing_overall is a flat projection → the deep artifact-source path owns the safe
+    // read + empty-fallback (it can't drift back into struct-access / coalesce-0).
+    source::materialize_files(conn, "routing_overall", &files, OVERALL_SPEC)?;
+    // routing_evals is a map-explode (one row per perIntent key) — not a flat spec — so it
+    // keeps a custom SELECT, but still reuses the shared file list + read flags.
+    build_routing_evals_table(conn, &files)?;
+    let n: i64 = conn.query_row("SELECT count(*) FROM routing_evals", [], |r| r.get(0))?;
+    Ok(n as usize)
+}
+
+/// The `perIntent` map-explode (custom shape — out of scope for the flat [`Col`] spec —
+/// but shares [`source::READ_FLAGS`] + [`source::sql_list`]). Dotted intent keys use
+/// JSON-Pointer (`/key/field`); JSONPath's `$.` would mis-split the dot into nesting.
+fn build_routing_evals_table(conn: &Connection, files: &[PathBuf]) -> Result<(), RoutingError> {
+    let cols = "generated_at VARCHAR, day VARCHAR, intent VARCHAR, support BIGINT, \
+                precision DOUBLE, recall DOUBLE, f1 DOUBLE, status VARCHAR";
     if files.is_empty() {
-        conn.execute_batch(&format!(
-            "CREATE OR REPLACE TABLE routing_evals ({intent_cols});
-             CREATE OR REPLACE TABLE routing_overall ({overall_cols});"
-        ))?;
-        return Ok(0);
+        conn.execute_batch(&format!("CREATE OR REPLACE TABLE routing_evals ({cols});"))?;
+        return Ok(());
     }
-    let list = sql_list(&files);
+    let list = source::sql_list(files);
+    let flags = source::READ_FLAGS;
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE routing_evals AS
          WITH raw AS (
              SELECT generatedAt::VARCHAR AS generated_at, to_json(perIntent) AS pi
-             FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1)
+             FROM read_json_auto({list}, {flags})
          ),
          keyed AS (SELECT generated_at, pi, unnest(json_keys(pi)) AS intent FROM raw)
          SELECT generated_at, generated_at[1:10] AS day, intent,
@@ -102,17 +78,9 @@ pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usiz
                 json_extract(pi, '/' || intent || '/Recall')::DOUBLE    AS recall,
                 json_extract(pi, '/' || intent || '/F1')::DOUBLE        AS f1,
                 json_extract_string(pi, '/' || intent || '/Status')     AS status
-         FROM keyed;
-         CREATE OR REPLACE TABLE routing_overall AS
-         SELECT generatedAt::VARCHAR AS generated_at, (generatedAt::VARCHAR)[1:10] AS day,
-                TRY_CAST(json_extract(to_json(overall), '$.Accuracy') AS DOUBLE)          AS accuracy,
-                TRY_CAST(json_extract(to_json(overall), '$.InScopeAccuracy') AS DOUBLE)   AS in_scope_accuracy,
-                TRY_CAST(json_extract(to_json(overall), '$.OosDeclineRate') AS DOUBLE)    AS oos_decline_rate,
-                TRY_CAST(json_extract(to_json(overall), '$.MeanInScopeMargin') AS DOUBLE) AS mean_in_scope_margin
-         FROM read_json_auto({list}, filename=true, union_by_name=true, sample_size=-1);"
+         FROM keyed;"
     ))?;
-    let n: i64 = conn.query_row("SELECT count(*) FROM routing_evals", [], |r| r.get(0))?;
-    Ok(n as usize)
+    Ok(())
 }
 
 /// Weakest intents in the **latest** run: `(intent, f1, support)` with `f1 < threshold`.

--- a/crates/ix-duck/src/source.rs
+++ b/crates/ix-duck/src/source.rs
@@ -1,0 +1,284 @@
+//! Artifact source — the deep module a [`lens`](crate) reads through.
+//!
+//! Every lens used to re-implement the same three things by hand: an `Io | Duck`
+//! error enum, file enumeration + a DuckDB list literal, and the
+//! `CREATE OR REPLACE TABLE … AS SELECT … FROM read_json_auto(…)` materialization.
+//! That last one carries a load-bearing invariant — the *safe projection* — and
+//! re-applying it by hand is exactly how the absence-as-zero / struct-field
+//! bind-crash defect class kept recurring (routing #126, chatbot/loops #127). See
+//! `docs/solutions/feature-implementations/2026-06-19-duckdb-absence-as-zero-and-struct-bind-crash.md`.
+//!
+//! This module concentrates all three behind one seam. A lens declares *which files*
+//! ([`Files`]) and *which columns* (a flat [`Col`] spec); [`materialize`] owns the
+//! rest and guarantees the invariant:
+//!
+//! - **Optional / nested fields go through `json_extract(to_json(root), path)`**, never
+//!   struct-field access — so a field absent from *every* file yields `NULL`, not a
+//!   bind-time "Could not find key" error.
+//! - **Absence is `NULL`, never `coalesce(…, 0)`** — a missing metric can't masquerade
+//!   as a real zero and fake a trend.
+//! - **An absent/empty directory yields an empty table _with the declared schema_**, so
+//!   downstream lens queries still bind (graceful degrade, never an error).
+//!
+//! Lenses whose shape isn't a flat projection (e.g. routing's `perIntent` map-explode)
+//! keep a custom `SELECT` but still reuse [`select_files`], [`sql_list`], [`READ_FLAGS`]
+//! and [`SourceError`] — so only the genuinely-different projection stays bespoke.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use duckdb::Connection;
+
+/// `read_json_auto` flags every artifact read uses: per-file `filename`, schema union
+/// across ragged files, and type inference over *all* rows (`sample_size=-1`).
+pub const READ_FLAGS: &str = "filename=true, union_by_name=true, sample_size=-1";
+
+/// Error from an artifact source: directory I/O vs DuckDB. Shared by every lens
+/// (replaces the per-lens `RoutingError`/`ChatbotError`/… copies).
+#[derive(Debug)]
+pub enum SourceError {
+    Io(std::io::Error),
+    Duck(duckdb::Error),
+}
+impl std::fmt::Display for SourceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SourceError::Io(e) => write!(f, "artifact source I/O error: {e}"),
+            SourceError::Duck(e) => write!(f, "duckdb error: {e}"),
+        }
+    }
+}
+impl std::error::Error for SourceError {}
+impl From<std::io::Error> for SourceError {
+    fn from(e: std::io::Error) -> Self {
+        SourceError::Io(e)
+    }
+}
+impl From<duckdb::Error> for SourceError {
+    fn from(e: duckdb::Error) -> Self {
+        SourceError::Duck(e)
+    }
+}
+
+/// A file selector: a directory and a filename predicate. The predicate is a plain
+/// `fn` (lens patterns capture nothing — prefix/suffix/extension matches).
+#[derive(Clone, Copy)]
+pub struct Files<'a> {
+    pub dir: &'a Path,
+    pub matches: fn(&str) -> bool,
+}
+
+/// How one output column is produced from the parsed JSON.
+#[derive(Clone, Copy)]
+pub enum ColSource {
+    /// A top-level field/expression `read_json_auto` infers; emitted as-is. `union_by_name`
+    /// NULL-fills it across ragged files, so direct access is safe. e.g. `"generatedAt::VARCHAR"`.
+    Direct(&'static str),
+    /// An optional / nested field: `json_extract(to_json(root), path)` cast to the column
+    /// type. NULL on whole-corpus absence (never a bind error), never coalesced to zero.
+    /// `path` is a JSONPath (`"$.Accuracy"`) or JSON-Pointer (`"/key/F1"`).
+    Extract {
+        root: &'static str,
+        path: &'static str,
+    },
+}
+
+/// One output column of an artifact source: its name, SQL type (used for the
+/// empty-table schema and the cast), and how it's projected.
+#[derive(Clone, Copy)]
+pub struct Col {
+    pub name: &'static str,
+    pub ty: &'static str,
+    pub source: ColSource,
+}
+impl Col {
+    /// A top-level field/expression, emitted directly.
+    pub const fn direct(name: &'static str, ty: &'static str, expr: &'static str) -> Self {
+        Col { name, ty, source: ColSource::Direct(expr) }
+    }
+    /// An optional/nested field read safely via `json_extract` (NULL on absence).
+    pub const fn extract(name: &'static str, ty: &'static str, root: &'static str, path: &'static str) -> Self {
+        Col { name, ty, source: ColSource::Extract { root, path } }
+    }
+
+    /// `name ty` for the empty-table schema.
+    fn schema_decl(&self) -> String {
+        format!("{} {}", self.name, self.ty)
+    }
+
+    /// The SELECT projection for a populated table — this is where the safe-read
+    /// invariant lives.
+    fn projection(&self) -> String {
+        match self.source {
+            ColSource::Direct(expr) => format!("{expr} AS {}", self.name),
+            // VARCHAR comes back JSON-quoted from json_extract, so use json_extract_string;
+            // everything else round-trips through TRY_CAST (NULL, never an error, on a bad/absent value).
+            ColSource::Extract { root, path } if self.ty.eq_ignore_ascii_case("VARCHAR") => {
+                format!("json_extract_string(to_json({root}), '{path}') AS {}", self.name)
+            }
+            ColSource::Extract { root, path } => {
+                format!("TRY_CAST(json_extract(to_json({root}), '{path}') AS {}) AS {}", self.ty, self.name)
+            }
+        }
+    }
+}
+
+/// Files in `sel.dir` matching `sel.matches`, sorted. An **absent** directory →
+/// empty (the lens degrades to "no data"); any other read error on a present dir is
+/// surfaced.
+pub fn select_files(sel: Files) -> Result<Vec<PathBuf>, SourceError> {
+    let rd = match std::fs::read_dir(sel.dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut out = Vec::new();
+    for entry in rd {
+        let p = entry?.path();
+        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
+            if (sel.matches)(n) {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// A DuckDB list literal of POSIX-slashed, quote-escaped paths.
+pub fn sql_list(paths: &[PathBuf]) -> String {
+    let items: Vec<String> = paths
+        .iter()
+        .map(|p| format!("'{}'", p.to_string_lossy().replace('\\', "/").replace('\'', "''")))
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+/// Materialize `table` from a precomputed file list using the flat column `spec`.
+/// Empty list → an empty table with the declared schema. Returns the row count.
+pub fn materialize_files(
+    conn: &Connection,
+    table: &str,
+    files: &[PathBuf],
+    spec: &[Col],
+) -> Result<usize, SourceError> {
+    if files.is_empty() {
+        let decls: Vec<String> = spec.iter().map(Col::schema_decl).collect();
+        conn.execute_batch(&format!("CREATE OR REPLACE TABLE {table} ({});", decls.join(", ")))?;
+        return Ok(0);
+    }
+    let proj: Vec<String> = spec.iter().map(Col::projection).collect();
+    let list = sql_list(files);
+    conn.execute_batch(&format!(
+        "CREATE OR REPLACE TABLE {table} AS SELECT {} FROM read_json_auto({list}, {READ_FLAGS});",
+        proj.join(", ")
+    ))?;
+    let n: i64 = conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |r| r.get(0))?;
+    Ok(n as usize)
+}
+
+/// Select files and materialize `table` in one step — the common lens path.
+pub fn materialize(
+    conn: &Connection,
+    table: &str,
+    sel: Files,
+    spec: &[Col],
+) -> Result<usize, SourceError> {
+    let files = select_files(sel)?;
+    materialize_files(conn, table, &files, spec)
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // A spec mirroring routing_overall: two Direct columns + four optional Extract metrics.
+    const SPEC: &[Col] = &[
+        Col::direct("generated_at", "VARCHAR", "generatedAt::VARCHAR"),
+        Col::direct("day", "VARCHAR", "(generatedAt::VARCHAR)[1:10]"),
+        Col::extract("accuracy", "DOUBLE", "overall", "$.Accuracy"),
+        Col::extract("oos_decline_rate", "DOUBLE", "overall", "$.OosDeclineRate"),
+        Col::extract("label", "VARCHAR", "overall", "$.Label"),
+    ];
+
+    fn matches_eval(n: &str) -> bool {
+        n.starts_with("eval-") && n.ends_with(".json")
+    }
+
+    fn write(dir: &Path, name: &str, body: &str) {
+        let mut f = std::fs::File::create(dir.join(name)).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn absent_dir_yields_empty_table_with_schema() {
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(
+            &conn,
+            "t",
+            Files { dir: Path::new("/no/such/dir"), matches: matches_eval },
+            SPEC,
+        )
+        .unwrap();
+        assert_eq!(n, 0);
+        // Downstream queries must still bind against the declared schema.
+        let rows: i64 = conn
+            .query_row("SELECT count(*) FROM (SELECT accuracy, label, oos_decline_rate FROM t)", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(rows, 0);
+    }
+
+    #[test]
+    fn optional_field_absent_corpuswide_is_null_not_crash() {
+        // Every file predates the OosDeclineRate / Label fields → both absent from the
+        // whole corpus. Struct-field access would fail at bind time; json_extract yields
+        // NULL. This is the defect-class guard, now in ONE place for all lenses.
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "eval-2026-05-11.json", r#"{"generatedAt":"2026-05-11T00:00:00Z","overall":{"Accuracy":0.875}}"#);
+        write(dir.path(), "eval-2026-05-12.json", r#"{"generatedAt":"2026-05-12T00:00:00Z","overall":{"Accuracy":0.9}}"#);
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        assert_eq!(n, 2);
+        let (acc, oos, label): (Option<f64>, Option<f64>, Option<String>) = conn
+            .query_row(
+                "SELECT accuracy, oos_decline_rate, label FROM t ORDER BY generated_at LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(acc, Some(0.875), "present field reads its value");
+        assert_eq!(oos, None, "absent numeric field is NULL, not 0.0");
+        assert_eq!(label, None, "absent string field is NULL");
+    }
+
+    #[test]
+    fn present_fields_read_through_including_string_and_derived() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "eval-2026-06-02.json",
+            r#"{"generatedAt":"2026-06-02T12:00:00Z","overall":{"Accuracy":0.95,"OosDeclineRate":0.5,"Label":"green"}}"#,
+        );
+        let conn = crate::open_bench().unwrap();
+        materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        let (day, oos, label): (String, Option<f64>, Option<String>) = conn
+            .query_row("SELECT day, oos_decline_rate, label FROM t", [], |r| {
+                Ok((r.get(0)?, r.get(1)?, r.get(2)?))
+            })
+            .unwrap();
+        assert_eq!(day, "2026-06-02", "Direct derived expr (slice) works");
+        assert_eq!(oos, Some(0.5));
+        assert_eq!(label.as_deref(), Some("green"), "VARCHAR extract is unquoted via json_extract_string");
+    }
+
+    #[test]
+    fn non_matching_files_are_ignored() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "eval-2026-06-02.json", r#"{"generatedAt":"2026-06-02T00:00:00Z","overall":{"Accuracy":0.9}}"#);
+        write(dir.path(), "README.md", "not an eval");
+        let conn = crate::open_bench().unwrap();
+        let n = materialize(&conn, "t", Files { dir: dir.path(), matches: matches_eval }, SPEC).unwrap();
+        assert_eq!(n, 1, "only eval-*.json is read");
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #129. Folds the `loops` and `ood` lenses onto the `source.rs` artifact-source seam #129 introduced (`routing` was the reference port). Each lens dropped its hand-rolled `Io|Duck` error enum, file enumeration, `sql_list`, and `read_json_auto` materialization — all of which carried the absence-as-zero / struct-bind-crash invariant that kept recurring when re-implemented by hand.

- **loops** — `LOOP_SPEC` (14× `Col::direct`) → `source::materialize`; `LoopError` aliases `source::SourceError`.
- **ood** — `EMBEDDING_SPEC` (10× `Col::direct`, including the `DOUBLE[]` vector and derived `day` slice) → `source::materialize`; `OodError` aliases `source::SourceError`.
- **maintain** — collapses the `Loops` + `Ood` error variants into one `Source` variant. Aliasing both lens errors to `source::SourceError` makes per-lens `From<source::SourceError>` impls conflict (E0119); a single `Source` variant + one `From` impl resolves it. `chatbot` deliberately stays a distinct error (not migrated — its `golden-traces/<id>/` walk is two-level and it has non-flat `UNNEST`/CTE tables).

Net **−117 lines**, zero behaviour change.

## Testing
- `cargo test -p ix-duck --features duck` → **99 passed** (every `loops::`, `ood::`, `maintain::`, `source::` case).
- `cargo clippy -p ix-duck --features duck --all-targets -- -D warnings` → clean.

## Stack / merge order
Base is the **#129 branch**, not `main`. Merge #129 first, then **retarget this PR to `main`** before merging (a squash-merge of #129 with `--delete-branch` would otherwise auto-close this child).

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: feature-gated (`duck`/`udf`) analyst-bench refactor, never built by default/CI runtime; behaviour-preserving (test-verified), no schema or artifact-format change.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
