### PR TITLE
feat(ix-duck): twelve-tone serialism DuckDB UDFs (exposes #131 in SQL)

### DIFF
--- a/crates/ix-bracelet/src/lib.rs
+++ b/crates/ix-bracelet/src/lib.rs
@@ -16,6 +16,7 @@ pub mod neo_riemannian;
 pub mod orbit;
 pub mod pc_set;
 pub mod prime_form;
+pub mod serial;
 
 pub use action::Action;
 pub use dihedral::{DihedralElement, Group};
@@ -27,3 +28,4 @@ pub use neo_riemannian::{classify_triad, h, l, n, p, r, s, TriadKind};
 pub use orbit::{all_prime_forms, orbit, orbit_unique};
 pub use pc_set::PcSet;
 pub use prime_form::{bracelet_prime_form, necklace_prime_form};
+pub use serial::{RowForm, SerialError, ToneRow};

--- a/crates/ix-bracelet/src/pc_set.rs
+++ b/crates/ix-bracelet/src/pc_set.rs
@@ -68,6 +68,20 @@ impl PcSet {
         let mask = self.0;
         (0u8..12).filter(move |k| (mask >> k) & 1 == 1)
     }
+
+    /// The `Z/12` complement: every pitch class **not** in `self`. A hexachord and its
+    /// complement are the two halves of the aggregate (the basis of combinatoriality).
+    #[inline]
+    pub const fn complement(self) -> Self {
+        Self((!self.0) & MASK12)
+    }
+
+    /// Multiplicative transform `Mₘ`: maps each pitch class `x ↦ (m · x) mod 12`. `M5` is
+    /// the circle-of-fourths transform, `M7` the circle-of-fifths, `M11 = I₀` (inversion).
+    /// For `m` coprime to 12 (1, 5, 7, 11) this is a bijection; otherwise the image collapses.
+    pub fn multiply(self, m: u8) -> Self {
+        Self::from_pcs(self.iter_pcs().map(|x| (x * (m % 12)) % 12))
+    }
 }
 
 impl fmt::Display for PcSet {
@@ -128,6 +142,37 @@ mod tests {
 
         let pcs: Vec<u8> = PcSet::from_pcs([7, 0, 4]).iter_pcs().collect();
         assert_eq!(pcs, vec![0, 4, 7]);
+    }
+
+    #[test]
+    fn complement_is_z12_negation() {
+        let s = PcSet::from_pcs([0, 4, 7]);
+        let c = s.complement();
+        assert_eq!(c, PcSet::from_pcs([1, 2, 3, 5, 6, 8, 9, 10, 11]));
+        // Involution; complement of complement is the original.
+        assert_eq!(c.complement(), s);
+        // A set and its complement partition the aggregate.
+        assert_eq!(s.cardinality() + c.cardinality(), 12);
+        assert_eq!(PcSet::empty().complement(), PcSet::chromatic());
+    }
+
+    #[test]
+    fn multiply_m5_m7_m11() {
+        // M7 (circle of fifths) on {0,1,2} -> {0,7,2}.
+        assert_eq!(
+            PcSet::from_pcs([0, 1, 2]).multiply(7),
+            PcSet::from_pcs([0, 7, 2])
+        );
+        // M5 (circle of fourths) on {0,1,2} -> {0,5,10}.
+        assert_eq!(
+            PcSet::from_pcs([0, 1, 2]).multiply(5),
+            PcSet::from_pcs([0, 5, 10])
+        );
+        // M11 == inversion about 0: {0,1,2} -> {0,11,10}.
+        assert_eq!(
+            PcSet::from_pcs([0, 1, 2]).multiply(11),
+            PcSet::from_pcs([0, 11, 10])
+        );
     }
 
     #[test]

--- a/crates/ix-bracelet/src/serial.rs
+++ b/crates/ix-bracelet/src/serial.rs
@@ -1,0 +1,408 @@
+//! Twelve-tone serialism: **ordered** rows over `Z/12` and their transformations.
+//!
+//! The rest of this crate works with *unordered* pitch-class sets ([`PcSet`]) — the
+//! atonal set-theory world (orbits, prime forms, Forte numbers). Serialism is the
+//! complementary *ordered* world: a [`ToneRow`] is a permutation of all 12 pitch
+//! classes, and the four classical transformations act on that ordering:
+//!
+//! - **Prime (P)** — the row, transposed: `Tₙ(row)[k] = (row[k] + n) mod 12`.
+//! - **Inversion (I)** — intervals mirrored: `I₀(row)[k] = (12 − row[k]) mod 12`
+//!   (the same `Iₙ(x) = (n − x) mod 12` convention [`crate::dihedral`] uses), then transposed.
+//! - **Retrograde (R)** — the row reversed.
+//! - **Retrograde-Inversion (RI)** — the inversion, reversed.
+//!
+//! [`ToneRow::matrix`] builds the classic 12×12 row matrix; [`ToneRow::all_forms`]
+//! enumerates the 48 forms (4 transformations × 12 transpositions). Hexachordal
+//! combinatoriality — the property Schoenberg exploited so a row and one of its
+//! transforms jointly complete the aggregate without overlap — is decided by
+//! [`ToneRow::combinatorial_prime_levels`] / [`ToneRow::combinatorial_inversion_levels`].
+
+use core::fmt;
+
+use crate::pc_set::PcSet;
+
+/// Why a tone-row / multiplicative operation was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SerialError {
+    /// The input was not a permutation of all 12 pitch classes (duplicate, gap, or out of range).
+    NotARow,
+    /// The input slice did not have exactly 12 elements.
+    WrongLength(usize),
+    /// A multiplicative factor not coprime to 12 (only 1, 5, 7, 11 are bijections on `Z/12`).
+    NotCoprime(u8),
+}
+
+impl fmt::Display for SerialError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SerialError::NotARow => {
+                f.write_str("not a tone row: must be a permutation of the 12 pitch classes")
+            }
+            SerialError::WrongLength(n) => write!(f, "a tone row needs 12 pitch classes, got {n}"),
+            SerialError::NotCoprime(m) => {
+                write!(
+                    f,
+                    "multiplicative factor {m} is not coprime to 12 (use 1, 5, 7, or 11)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for SerialError {}
+
+/// The four classical row transformations, each carrying a transposition level `0..12`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowForm {
+    /// Prime — the row transposed by `n`.
+    Prime(u8),
+    /// Inversion — the row inverted then transposed by `n`.
+    Inversion(u8),
+    /// Retrograde — `Prime(n)` reversed.
+    Retrograde(u8),
+    /// Retrograde-inversion — `Inversion(n)` reversed.
+    RetrogradeInversion(u8),
+}
+
+impl fmt::Display for RowForm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RowForm::Prime(n) => write!(f, "P{n}"),
+            RowForm::Inversion(n) => write!(f, "I{n}"),
+            RowForm::Retrograde(n) => write!(f, "R{n}"),
+            RowForm::RetrogradeInversion(n) => write!(f, "RI{n}"),
+        }
+    }
+}
+
+/// An ordered twelve-tone row: a permutation of the 12 pitch classes of `Z/12`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ToneRow([u8; 12]);
+
+impl ToneRow {
+    /// Build from 12 pitch classes, validating that they form a permutation of `0..12`
+    /// (each pitch class exactly once). Values are taken as-is (must already be `< 12`).
+    pub fn new(pcs: [u8; 12]) -> Result<Self, SerialError> {
+        let mut seen = 0u16;
+        for &p in &pcs {
+            if p >= 12 {
+                return Err(SerialError::NotARow);
+            }
+            let bit = 1u16 << p;
+            if seen & bit != 0 {
+                return Err(SerialError::NotARow);
+            }
+            seen |= bit;
+        }
+        // A 12-element array with no duplicates and all values < 12 is necessarily a permutation.
+        Ok(Self(pcs))
+    }
+
+    /// Build from a slice; errors if it isn't exactly 12 elements or isn't a permutation.
+    pub fn from_slice(pcs: &[u8]) -> Result<Self, SerialError> {
+        let arr: [u8; 12] = pcs
+            .try_into()
+            .map_err(|_| SerialError::WrongLength(pcs.len()))?;
+        Self::new(arr)
+    }
+
+    /// The 12 pitch classes in row order.
+    #[inline]
+    pub fn pcs(&self) -> &[u8; 12] {
+        &self.0
+    }
+
+    /// Transpose: `Tₙ(row)[k] = (row[k] + n) mod 12`. (A bijection, so the result is a row.)
+    pub fn transpose(&self, n: u8) -> ToneRow {
+        let n = n % 12;
+        let mut out = [0u8; 12];
+        for (o, &p) in out.iter_mut().zip(self.0.iter()) {
+            *o = (p + n) % 12;
+        }
+        ToneRow(out)
+    }
+
+    /// Invert about pitch class 0: `I₀(row)[k] = (12 − row[k]) mod 12`
+    /// (the `Iₙ(x) = (n − x) mod 12` convention with `n = 0`). A bijection ⇒ still a row.
+    pub fn invert(&self) -> ToneRow {
+        let mut out = [0u8; 12];
+        for (o, &p) in out.iter_mut().zip(self.0.iter()) {
+            *o = (12 - p) % 12;
+        }
+        ToneRow(out)
+    }
+
+    /// Reverse the row order (the Retrograde of the prime).
+    pub fn retrograde(&self) -> ToneRow {
+        let mut out = self.0;
+        out.reverse();
+        ToneRow(out)
+    }
+
+    /// Realise one of the 48 [`RowForm`]s as a concrete row.
+    ///
+    /// Forms are defined relative to this row as `P₀`:
+    /// `Pₙ = Tₙ(row)`, `Iₙ = Tₙ(I₀(row))`, `Rₙ = retrograde(Pₙ)`, `RIₙ = retrograde(Iₙ)`.
+    pub fn form(&self, form: RowForm) -> ToneRow {
+        match form {
+            RowForm::Prime(n) => self.transpose(n),
+            RowForm::Inversion(n) => self.invert().transpose(n),
+            RowForm::Retrograde(n) => self.transpose(n).retrograde(),
+            RowForm::RetrogradeInversion(n) => self.invert().transpose(n).retrograde(),
+        }
+    }
+
+    /// All 48 forms (P/I/R/RI × 12 transpositions), each paired with its label.
+    /// For symmetric rows some forms coincide as *rows* though their labels differ.
+    pub fn all_forms(&self) -> Vec<(RowForm, ToneRow)> {
+        let mut out = Vec::with_capacity(48);
+        for n in 0..12u8 {
+            for f in [
+                RowForm::Prime(n),
+                RowForm::Inversion(n),
+                RowForm::Retrograde(n),
+                RowForm::RetrogradeInversion(n),
+            ] {
+                out.push((f, self.form(f)));
+            }
+        }
+        out
+    }
+
+    /// The classic 12×12 row matrix. `M[i][j] = (row[j] + row[0] − row[i]) mod 12`.
+    ///
+    /// Reading conventions: row `i` left→right is a Prime form, right→left a Retrograde;
+    /// column `j` top→bottom is an Inversion, bottom→top a Retrograde-Inversion. The first
+    /// row is the row itself, the first column is its inversion about the first pitch, and
+    /// the main diagonal is constant (= `row[0]`).
+    pub fn matrix(&self) -> [[u8; 12]; 12] {
+        let r0 = self.0[0];
+        let mut m = [[0u8; 12]; 12];
+        for (i, mi) in m.iter_mut().enumerate() {
+            for (j, cell) in mi.iter_mut().enumerate() {
+                // + 24 keeps the intermediate non-negative before the mod.
+                *cell = ((self.0[j] as u16 + r0 as u16 + 24 - self.0[i] as u16) % 12) as u8;
+            }
+        }
+        m
+    }
+
+    /// Multiplicative transform `Mₘ(row)[k] = (m · row[k]) mod 12`. Only `m ∈ {1,5,7,11}`
+    /// (coprime to 12) are bijections on `Z/12`; others are rejected. `M5` is the
+    /// "circle-of-fourths" transform, `M7` the circle-of-fifths; `M11 = I₀`.
+    pub fn multiply(&self, m: u8) -> Result<ToneRow, SerialError> {
+        if !matches!(m % 12, 1 | 5 | 7 | 11) {
+            return Err(SerialError::NotCoprime(m));
+        }
+        let mut out = [0u8; 12];
+        for (o, &p) in out.iter_mut().zip(self.0.iter()) {
+            *o = ((m as u16 * p as u16) % 12) as u8;
+        }
+        Ok(ToneRow(out))
+    }
+
+    /// The row's two hexachords as unordered sets: the first six and last six pitch classes.
+    /// They always partition the aggregate (the row is a permutation), so the second is the
+    /// [`PcSet::complement`] of the first.
+    pub fn hexachords(&self) -> (PcSet, PcSet) {
+        let h1 = PcSet::from_pcs(self.0[..6].iter().copied());
+        let h2 = PcSet::from_pcs(self.0[6..].iter().copied());
+        (h1, h2)
+    }
+
+    /// Transposition levels `n ∈ 1..12` at which the row is **prime-combinatorial**: the
+    /// first hexachord `H₁` maps onto the second `H₂` under `Tₙ` (so `H₁ ∪ Tₙ(H₁)` completes
+    /// the aggregate). `n = 6` is the classic semi-combinatorial case.
+    pub fn combinatorial_prime_levels(&self) -> Vec<u8> {
+        let (h1, h2) = self.hexachords();
+        (1..12u8).filter(|&n| transpose_set(h1, n) == h2).collect()
+    }
+
+    /// Transposition levels `n ∈ 0..12` at which the row is **inversion-combinatorial**:
+    /// the first hexachord `H₁` maps onto the second `H₂` under `Iₙ` (`x ↦ (n − x) mod 12`).
+    pub fn combinatorial_inversion_levels(&self) -> Vec<u8> {
+        let (h1, h2) = self.hexachords();
+        (0..12u8).filter(|&n| invert_set(h1, n) == h2).collect()
+    }
+}
+
+/// `Tₙ` on a pitch-class set: `{(x + n) mod 12}`.
+fn transpose_set(s: PcSet, n: u8) -> PcSet {
+    PcSet::from_pcs(s.iter_pcs().map(|x| (x + n) % 12))
+}
+
+/// `Iₙ` on a pitch-class set: `{(n − x) mod 12}`.
+fn invert_set(s: PcSet, n: u8) -> PcSet {
+    PcSet::from_pcs(s.iter_pcs().map(|x| (n + 12 - x) % 12))
+}
+
+impl fmt::Display for ToneRow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        for (i, p) in self.0.iter().enumerate() {
+            if i > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{p}")?;
+        }
+        f.write_str("]")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The chromatic row 0,1,…,11 — a clean reference whose transforms are exactly computable.
+    fn chromatic() -> ToneRow {
+        ToneRow::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).unwrap()
+    }
+
+    #[test]
+    fn new_validates_permutation() {
+        assert!(ToneRow::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).is_ok());
+        // Duplicate (two 0s, no 11).
+        assert_eq!(
+            ToneRow::new([0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1]),
+            Err(SerialError::NotARow)
+        );
+        // Out of range.
+        assert_eq!(
+            ToneRow::new([12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            Err(SerialError::NotARow)
+        );
+    }
+
+    #[test]
+    fn from_slice_checks_length() {
+        assert_eq!(
+            ToneRow::from_slice(&[0, 1, 2]),
+            Err(SerialError::WrongLength(3))
+        );
+        assert!(ToneRow::from_slice(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).is_ok());
+    }
+
+    #[test]
+    fn transpose_wraps_mod_12() {
+        let t = chromatic().transpose(3);
+        assert_eq!(t.pcs(), &[3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2]);
+    }
+
+    #[test]
+    fn invert_about_zero() {
+        // I0 of 0,1,2,…,11 = 0,11,10,…,1.
+        let i = chromatic().invert();
+        assert_eq!(i.pcs(), &[0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn retrograde_reverses() {
+        let r = chromatic().retrograde();
+        assert_eq!(r.pcs(), &[11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+    }
+
+    #[test]
+    fn ri_is_retrograde_of_inversion() {
+        let row = ToneRow::new([0, 11, 7, 4, 2, 9, 3, 8, 10, 1, 5, 6]).unwrap();
+        for n in 0..12u8 {
+            let ri = row.form(RowForm::RetrogradeInversion(n));
+            let expected = row.invert().transpose(n).retrograde();
+            assert_eq!(ri, expected, "RI{n} must equal retrograde of I{n}");
+        }
+    }
+
+    #[test]
+    fn every_form_is_a_valid_row() {
+        // All 48 transforms of a row are themselves rows (permutations).
+        let row = ToneRow::new([0, 11, 7, 4, 2, 9, 3, 8, 10, 1, 5, 6]).unwrap();
+        let forms = row.all_forms();
+        assert_eq!(forms.len(), 48);
+        for (label, r) in forms {
+            assert!(
+                ToneRow::new(*r.pcs()).is_ok(),
+                "{label} is not a valid permutation: {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn matrix_structural_invariants() {
+        let row = ToneRow::new([0, 11, 7, 4, 2, 9, 3, 8, 10, 1, 5, 6]).unwrap();
+        let m = row.matrix();
+        // First row is the row itself.
+        assert_eq!(m[0], *row.pcs());
+        // Main diagonal is constant = row[0].
+        for (i, mi) in m.iter().enumerate() {
+            assert_eq!(mi[i], row.pcs()[0], "diagonal cell ({i},{i})");
+        }
+        // First column read top→bottom is an inversion sharing the first pitch.
+        let first_col: Vec<u8> = m.iter().map(|r| r[0]).collect();
+        assert_eq!(first_col[0], row.pcs()[0]);
+        // Every row and every column is a permutation of 0..12.
+        for mi in &m {
+            assert!(ToneRow::new(*mi).is_ok(), "matrix row not a permutation");
+        }
+        let cols: Vec<[u8; 12]> = (0..12).map(|j| std::array::from_fn(|i| m[i][j])).collect();
+        for (j, col) in cols.iter().enumerate() {
+            assert!(
+                ToneRow::new(*col).is_ok(),
+                "matrix column {j} not a permutation"
+            );
+        }
+    }
+
+    #[test]
+    fn matrix_chromatic_is_difference_table() {
+        // For the chromatic row (row[0]=0), M[i][j] = (j - i) mod 12.
+        let m = chromatic().matrix();
+        for (i, mi) in m.iter().enumerate() {
+            for (j, &cell) in mi.iter().enumerate() {
+                assert_eq!(cell, ((j as i32 - i as i32).rem_euclid(12)) as u8);
+            }
+        }
+    }
+
+    #[test]
+    fn multiply_m7_is_bijection_m11_is_inversion() {
+        // M7 of the chromatic row = 0,7,2,9,4,11,6,1,8,3,10,5 (×7 mod 12).
+        let m7 = chromatic().multiply(7).unwrap();
+        assert_eq!(m7.pcs(), &[0, 7, 2, 9, 4, 11, 6, 1, 8, 3, 10, 5]);
+        // M11 == I0.
+        assert_eq!(chromatic().multiply(11).unwrap(), chromatic().invert());
+        // Non-coprime factor is rejected.
+        assert_eq!(chromatic().multiply(2), Err(SerialError::NotCoprime(2)));
+        assert_eq!(chromatic().multiply(6), Err(SerialError::NotCoprime(6)));
+    }
+
+    #[test]
+    fn hexachords_partition_the_aggregate() {
+        let row = ToneRow::new([0, 11, 7, 4, 2, 9, 3, 8, 10, 1, 5, 6]).unwrap();
+        let (h1, h2) = row.hexachords();
+        assert_eq!(h1.cardinality(), 6);
+        assert_eq!(h2.cardinality(), 6);
+        // The two hexachords are complements.
+        assert_eq!(h2, h1.complement());
+    }
+
+    #[test]
+    fn chromatic_row_is_prime_combinatorial_at_six() {
+        // H1 = {0..5}, H2 = {6..11} = T6(H1).
+        let levels = chromatic().combinatorial_prime_levels();
+        assert!(
+            levels.contains(&6),
+            "chromatic row is T6-combinatorial, got {levels:?}"
+        );
+    }
+
+    #[test]
+    fn inversion_combinatoriality_detects_a_known_case() {
+        // A row whose first hexachord {0,2,4,6,8,10} (whole-tone) maps to {1,3,5,7,9,11}
+        // under I1: (1 - x) mod 12 sends 0→1,2→11,4→9,… = {1,11,9,7,5,3} = H2. So I1 holds.
+        let row = ToneRow::new([0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11]).unwrap();
+        let levels = row.combinatorial_inversion_levels();
+        assert!(
+            levels.contains(&1),
+            "expected I1-combinatorial, got {levels:?}"
+        );
+    }
+}

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -34,6 +34,12 @@ mod tablefn;
 #[cfg(feature = "udf")]
 mod bracelet;
 
+/// Twelve-tone serialism scalar UDFs over ordered rows (ix_row_retrograde,
+/// ix_row_invert, ix_row_transpose, ix_row_matrix, ix_row_combinatoriality),
+/// registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod serial;
+
 /// Graph (ix_pagerank, ix_shortest_path) + signal (ix_rfft, ix_autocorrelation)
 /// table functions over JSON edge-lists / series, registered by [`udf::register_all`].
 #[cfg(feature = "udf")]

--- a/crates/ix-duck/src/serial.rs
+++ b/crates/ix-duck/src/serial.rs
@@ -1,0 +1,228 @@
+//! Twelve-tone serialism scalar UDFs over **ordered** rows (`ix-bracelet::serial`).
+//!
+//! Each takes a `BIGINT[]` of 12 pitch values (MIDI notes or pitch classes — reduced
+//! mod 12) **in row order** and returns a VARCHAR. Unlike the [`crate::bracelet`] UDFs,
+//! which read the input as an unordered pitch-class *set*, these preserve order: the
+//! input must be a valid tone row (a permutation of all 12 pitch classes) or the result
+//! is SQL NULL.
+//!
+//! - `ix_row_retrograde(notes)`      → the row reversed, e.g. `"[11,10,…,0]"`.
+//! - `ix_row_invert(notes)`          → the I₀ inversion, e.g. `"[0,11,10,…]"`.
+//! - `ix_row_matrix(notes)`          → the 12×12 row matrix, rows `;`-joined.
+//! - `ix_row_combinatoriality(notes)`→ combinatorial levels, e.g. `"P:[6] I:[]"`.
+//!
+//! Pure wraps of `ix_bracelet::serial` — no theory here. Use to analyse serial-music
+//! corpora in SQL the way [`crate::bracelet`] analyses set-class corpora.
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_bracelet::serial::ToneRow;
+use std::ffi::CString;
+
+fn list_bigint() -> LogicalTypeHandle {
+    LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Bigint))
+}
+
+fn varchar_sig() -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![list_bigint()],
+        LogicalTypeHandle::from(LogicalTypeId::Varchar),
+    )]
+}
+
+/// Read a `LIST<BIGINT>` column into one ordered pitch-class vector per row (values
+/// reduced mod 12, order preserved). Mirrors `bracelet::read_pcsets` but keeps order so
+/// the values can form a [`ToneRow`]. Reads entries before borrowing the child buffer.
+fn read_rows(input: &mut DataChunkHandle, n: usize) -> Vec<Vec<u8>> {
+    let lv = input.list_vector(0);
+    let entries: Vec<(usize, usize)> = (0..n).map(|i| lv.get_entry(i)).collect();
+    let cap = entries.iter().map(|(o, l)| o + l).max().unwrap_or(0);
+    let child = lv.child(cap);
+    let all = unsafe { child.as_slice_with_len::<i64>(cap) };
+    entries
+        .iter()
+        .map(|&(o, l)| all[o..o + l].iter().map(|&v| v.rem_euclid(12) as u8).collect())
+        .collect()
+}
+
+/// Shared driver: parse each row's values into a [`ToneRow`] and map through `f`.
+/// A non-row input (wrong length or not a permutation) → SQL NULL.
+fn invoke_row_str(
+    input: &mut DataChunkHandle,
+    output: &mut dyn WritableVector,
+    f: impl Fn(ToneRow) -> Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let n = input.len();
+    let rows = read_rows(input, n);
+    let mut out = output.flat_vector();
+    for (i, r) in rows.iter().enumerate() {
+        match ToneRow::from_slice(r).ok().and_then(&f) {
+            Some(v) => out.insert(i, CString::new(v)?),
+            None => out.set_null(i),
+        }
+    }
+    Ok(())
+}
+
+/// `[0,1,2,…]` rendering of a row (no spaces, matching the `bracelet` UDFs' style).
+fn fmt_row(row: &ToneRow) -> String {
+    let pcs: Vec<String> = row.pcs().iter().map(|p| p.to_string()).collect();
+    format!("[{}]", pcs.join(","))
+}
+
+struct IxRowRetrograde;
+impl VScalar for IxRowRetrograde {
+    type State = ();
+    // @ai:invariant ix_row_retrograde reverses a valid 12-tone row via ix_bracelet serial retrograde; [0,1,..,11] -> "[11,10,..,0]", non-row -> SQL NULL [T:test conf:0.9 src:ix_duck::serial::tests::retrograde_chromatic]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_row_str(input, output, |r| Some(fmt_row(&r.retrograde())))
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxRowInvert;
+impl VScalar for IxRowInvert {
+    type State = ();
+    // @ai:invariant ix_row_invert applies ix_bracelet serial invert (I0) to a valid 12-tone row; [0,1,..,11] -> "[0,11,10,..,1]", non-row -> SQL NULL [T:test conf:0.9 src:ix_duck::serial::tests::invert_chromatic]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_row_str(input, output, |r| Some(fmt_row(&r.invert())))
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxRowMatrix;
+impl VScalar for IxRowMatrix {
+    type State = ();
+    // @ai:invariant ix_row_matrix renders ix_bracelet serial 12x12 matrix of a valid row as 12 bracketed rows joined by ';'; the first row equals the input row [T:test conf:0.9 src:ix_duck::serial::tests::matrix_first_row_is_input]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_row_str(input, output, |r| {
+            let rows: Vec<String> = r
+                .matrix()
+                .iter()
+                .map(|mr| {
+                    let cells: Vec<String> = mr.iter().map(|c| c.to_string()).collect();
+                    format!("[{}]", cells.join(","))
+                })
+                .collect();
+            Some(rows.join(";"))
+        })
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+struct IxRowCombinatoriality;
+impl VScalar for IxRowCombinatoriality {
+    type State = ();
+    // @ai:invariant ix_row_combinatoriality renders ix_bracelet serial prime+inversion combinatorial levels as "P:[..] I:[..]"; the chromatic row [0..11] is T6-combinatorial so P contains 6 [T:test conf:0.9 src:ix_duck::serial::tests::combinatoriality_chromatic_has_p6]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_row_str(input, output, |r| {
+            let p: Vec<String> = r
+                .combinatorial_prime_levels()
+                .iter()
+                .map(|n| n.to_string())
+                .collect();
+            let inv: Vec<String> = r
+                .combinatorial_inversion_levels()
+                .iter()
+                .map(|n| n.to_string())
+                .collect();
+            Some(format!("P:[{}] I:[{}]", p.join(","), inv.join(",")))
+        })
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        varchar_sig()
+    }
+}
+
+/// Register the twelve-tone serialism scalar UDFs.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxRowRetrograde>("ix_row_retrograde")?;
+    conn.register_scalar_function::<IxRowInvert>("ix_row_invert")?;
+    conn.register_scalar_function::<IxRowMatrix>("ix_row_matrix")?;
+    conn.register_scalar_function::<IxRowCombinatoriality>("ix_row_combinatoriality")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    // The chromatic row 0..11 — exact, recognisable transforms.
+    const CHROMATIC: &str = "[0,1,2,3,4,5,6,7,8,9,10,11]";
+
+    fn scalar(sql: &str) -> Option<String> {
+        let conn = open_bench().unwrap();
+        conn.query_row(sql, [], |r| r.get::<_, Option<String>>(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn retrograde_chromatic() {
+        assert_eq!(
+            scalar(&format!("SELECT ix_row_retrograde({CHROMATIC})")).as_deref(),
+            Some("[11,10,9,8,7,6,5,4,3,2,1,0]")
+        );
+    }
+
+    #[test]
+    fn invert_chromatic() {
+        assert_eq!(
+            scalar(&format!("SELECT ix_row_invert({CHROMATIC})")).as_deref(),
+            Some("[0,11,10,9,8,7,6,5,4,3,2,1]")
+        );
+    }
+
+    #[test]
+    fn matrix_first_row_is_input() {
+        let m = scalar(&format!("SELECT ix_row_matrix({CHROMATIC})")).unwrap();
+        // 12 rows joined by ';' → 11 separators.
+        assert_eq!(m.matches(';').count(), 11);
+        assert!(
+            m.starts_with("[0,1,2,3,4,5,6,7,8,9,10,11];"),
+            "matrix first row must be the input row, got {m}"
+        );
+    }
+
+    #[test]
+    fn combinatoriality_chromatic_has_p6() {
+        // Chromatic hexachord {0..5} maps to {6..11} under T6 → P-combinatorial at 6.
+        let c = scalar(&format!("SELECT ix_row_combinatoriality({CHROMATIC})")).unwrap();
+        assert!(c.starts_with("P:["), "got {c}");
+        assert!(c.contains('6'), "chromatic row is T6-combinatorial, got {c}");
+    }
+
+    #[test]
+    fn non_row_input_is_null() {
+        // Too short, and not a permutation → SQL NULL (not an error).
+        assert_eq!(scalar("SELECT ix_row_retrograde([0,1,2])"), None);
+        // 12 values but with a duplicate (two 0s, no 11) → not a row → NULL.
+        assert_eq!(
+            scalar("SELECT ix_row_invert([0,0,2,3,4,5,6,7,8,9,10,1])"),
+            None
+        );
+    }
+}

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -144,6 +144,7 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxEuclidean>("ix_euclidean")?;
     crate::tablefn::register(conn)?;
     crate::bracelet::register(conn)?;
+    crate::serial::register(conn)?;
     crate::graphsig::register(conn)?;
     crate::eval::register(conn)?;
     crate::sketch::register(conn)?;


### PR DESCRIPTION
## Summary

**Stacked on #131.** Exposes the new `ix-bracelet::serial` row algebra as DuckDB scalar UDFs — the "DuckDB UDFs" half of the transform-exposure work (workstream **B**). Mirrors the `bracelet.rs` pattern: `LIST<BIGINT>` **in row order** → VARCHAR; a non-row input (wrong length or not a permutation) returns SQL `NULL`.

- `ix_row_retrograde(notes)` → the row reversed
- `ix_row_invert(notes)` → the I₀ inversion
- `ix_row_matrix(notes)` → the 12×12 row matrix, rows `;`-joined
- `ix_row_combinatoriality(notes)` → `"P:[..] I:[..]"` combinatorial levels

Lets serial-music corpora be analysed in SQL the way `bracelet.rs` analyses set-class corpora. Pure wraps of `ix_bracelet::serial`.

## Scope notes
- **VARCHAR output** (the proven on-branch pattern). BIGINT[]-returning row UDFs can follow once the list-output VScalar pattern (#128's grothendieck UDFs) lands on main.
- **MCP tools deferred** — they bump `ix-agent/tests/parity.rs` (the count oracle) and can't parallel-merge. The SQL surface is the high-value half; MCP can be one combined PR later with the spectral UDFs.
- **Spectral-feature UDFs** (mel/MFCC/chroma) need `ix-duck` to gain an `ix-acoustic-tune` dep + #132's chroma/CQT — a separate follow-up.

## Testing
- `cargo test -p ix-duck --features duck serial::` → **5 pass** (retrograde/invert exact on the chromatic row; matrix first-row == input + 11 separators; chromatic row's combinatoriality contains T₆; non-row input → NULL).
- `cargo clippy -p ix-duck --features duck --all-targets -D warnings` clean.
- `serial.rs` kept in the crate's CI-matching terse rustfmt style (local rustfmt over-wraps ix-duck — the same skew `bracelet.rs` carries; verified it shows the identical `--check` profile).

## ⚠️ Merge order
Base is **#131's branch**. Merge **#131 first**, then **retarget this PR to `main`** before merging — a squash-merge of #131 with `--delete-branch` would otherwise auto-close this child (the known stacked-PR hazard).

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: feature-gated (udf/duck) analyst-bench UDFs, never built by default/CI runtime; pure library wraps, fully unit-tested, no schema/service impact.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
