### PR TITLE
docs(adr) + feat(ix-duck): IXQL↔DuckDB seam — ADR-0001 + maintain-gate --json

### DIFF
--- a/crates/ix-duck/examples/ix_maintain_gate.rs
+++ b/crates/ix-duck/examples/ix_maintain_gate.rs
@@ -4,7 +4,13 @@
 //! set the exit code (accept=0, reject=1, escalate=2).
 //!
 //!   cargo run -p ix-duck --features duck --example ix_maintain_gate -- <hits.jsonl> <corpus-dir>
-//!   cargo run -p ix-duck --features duck --example ix_maintain_gate           # defaults below
+//!   cargo run -p ix-duck --features duck --example ix_maintain_gate -- --json …   # machine-readable
+//!   cargo run -p ix-duck --features duck --example ix_maintain_gate              # defaults below
+//!
+//! `--json` (first arg) emits the `MaintainVerdict` as one JSON object to **stdout**
+//! and nothing else — the machine-readable *seam* an MCP wrapper or the IXQL executor
+//! (`mcp_tool_output → when verdict.status == "T"`) consumes. See
+//! `docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md`. Human-readable is the default.
 //!
 //! Defaults: metric ← `state/thinking-machine/hits.jsonl` (IX-local, harness-written);
 //! guardrail ← `../ga/state/quality/chatbot-qa`. Verdict appended to
@@ -35,7 +41,13 @@ fn default_corpus() -> PathBuf {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = std::env::args().skip(1);
+    let mut argv: Vec<String> = std::env::args().skip(1).collect();
+    // `--json` (first token) → emit ONLY the verdict JSON to stdout (the callable seam).
+    let json = argv.first().map(|s| s == "--json").unwrap_or(false);
+    if json {
+        argv.remove(0);
+    }
+    let mut args = argv.into_iter();
     let hits = args.next().map(PathBuf::from).unwrap_or_else(default_hits);
     let corpus = args
         .next()
@@ -80,35 +92,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let verdict = maintain::evaluate(&conn, &MaintainConfig::default(), &inputs)?;
 
-    println!(
-        "maintain-gate verdict: {} ({})",
-        verdict.status, verdict.decision
-    );
-    println!("  reason: {}", verdict.reason);
-    println!("  metric: {}", hits.display());
-    println!("  guardrail: {}", corpus.display());
-    println!("\n  signals:");
-    for s in &verdict.signals {
-        let mark = match s.ok {
-            Some(true) => "ok ",
-            Some(false) => "BAD",
-            None => " ? ",
-        };
-        println!("    [{mark}] {:<10} {}", s.lens, s.detail);
-    }
-    println!("\n  evidence:");
-    for e in &verdict.evidence {
-        println!("    {:<18} {}  ({})", e.kind, e.hash, e.source);
+    if json {
+        // The seam: one verdict object on stdout, nothing else (pipe-friendly).
+        println!("{}", serde_json::to_string(&verdict)?);
+    } else {
+        println!(
+            "maintain-gate verdict: {} ({})",
+            verdict.status, verdict.decision
+        );
+        println!("  reason: {}", verdict.reason);
+        println!("  metric: {}", hits.display());
+        println!("  guardrail: {}", corpus.display());
+        println!("\n  signals:");
+        for s in &verdict.signals {
+            let mark = match s.ok {
+                Some(true) => "ok ",
+                Some(false) => "BAD",
+                None => " ? ",
+            };
+            println!("    [{mark}] {:<10} {}", s.lens, s.detail);
+        }
+        println!("\n  evidence:");
+        for e in &verdict.evidence {
+            println!("    {:<18} {}  ({})", e.kind, e.hash, e.source);
+        }
     }
 
     let ledger = PathBuf::from("state/thinking-machine/maintain-gate.jsonl");
-    if let Err(e) = maintain::append_to_ledger(&verdict, &ledger) {
-        eprintln!(
+    match maintain::append_to_ledger(&verdict, &ledger) {
+        // In --json mode stdout stays pure verdict JSON; the ledger note goes to stderr.
+        Ok(()) if json => eprintln!("appended to {}", ledger.display()),
+        Ok(()) => println!("\n  → appended to {}", ledger.display()),
+        Err(e) => eprintln!(
             "warning: could not append to ledger {}: {e}",
             ledger.display()
-        );
-    } else {
-        println!("\n  → appended to {}", ledger.display());
+        ),
     }
 
     std::process::exit(maintain::exit_code(&verdict.status));

--- a/docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md
+++ b/docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md
@@ -1,0 +1,51 @@
+# IXQL ↔ DuckDB+IX integration goes through the MCP seam, not new IXQL grammar nodes
+
+Status: accepted (2026-06-20)
+
+## Decision
+
+IXQL (Demerzel's governance pipeline-spec DSL) and DuckDB+IX (`ix-duck`, the analyst bench)
+are **complementary layers** — specification vs. analysis — joined only by a JSON-on-disk
+format contract, by design (`docs/DUCKDB.md`). When we want them to interoperate, we connect
+through **the MCP tool seam and the shared file format**, *not* by adding DuckDB/Parquet
+source or sink nodes to the IXQL grammar — until the IXQL executor ships **and** a grammar
+change gets explicit Galactic-Protocol sign-off.
+
+Concretely, the three integration opportunities resolve to:
+1. **DuckDB as an IXQL data source** → expose an ix-duck query as an MCP tool; IXQL reaches it
+   via its existing `mcp_tool_output("…")` / `database("…")` productions. No grammar change.
+2. **Governance verdict as a callable** → expose the already-built `maintain-gate`
+   (`ix-duck::maintain`, the hexavalent T/P/U/D/F/C RSI oracle — *already* "DuckDB as referee")
+   as an MCP tool; IXQL gates on it with `→ when verdict == "T"` once the executor lands.
+3. **IXQL → trend table** → IXQL writes JSONL with `ix.io.write()` (works today); `ix-duck`
+   reads it with `read_json_auto`. Formalize the schema; no grammar change.
+
+## Why (the trade-off)
+
+- **The IXQL executor is spec-only.** `ix-cli` (#103) and the tars CE are both "Draft" and
+  absent from the workspace; only the tree-sitter grammar + a Node validator exist. A new
+  grammar source/sink node would be syntax **nothing can execute** — premature.
+- **The grammar is a governed artifact.** Galactic-Protocol/grammar changes require explicit
+  sign-off (CLAUDE.md "one-way doors"); the MCP seam and the file-format contract do not.
+- **The MCP seam is runnable today and forward-compatible.** MCP tools are useful to agents
+  immediately and become the IXQL integration point for free when the executor ships — IXQL's
+  `mcp_tool_output` already targets them. The shared substrate even exists already: IXQL data
+  sources already `read_json_auto()` the same `ix/state/**/*.jsonl` files `ix-duck` reads.
+
+## Consequences
+
+- Exposing the maintain-gate as an MCP tool (`ix_maintain_gate`) makes `ix-agent` depend on
+  `ix-duck`'s **bundled-DuckDB (`duck`) feature** — a heavy native (C++) dependency. It is
+  therefore **feature-gated** (off by default) so the default agent build and `--workspace`
+  CI never compile DuckDB. The duck-feature CI job (`ix-duck-chatbot.yml`) is where it should
+  be exercised.
+- The maintain-gate's verdict is **advisory until its ledger write-isolation (Phase-3b) lands**
+  (`docs/contracts/maintain-gate.contract.md`): the proposing agent must not be able to write
+  the ledger it is judged against. Until then the MCP tool reports a verdict but it is not a
+  *binding* governance gate.
+
+## Revisit trigger
+
+When the IXQL executor (`ix-cli` #103) actually ships — at that point a first-class
+`duckdb(…)` source / `write_parquet(…)` sink may be worth the grammar change (with sign-off),
+because it would then be runnable and could validate schemas at pipeline-author time.


### PR DESCRIPTION
## Summary

Explores the IXQL ↔ DuckDB+IX integration opportunities and lands the decision + the runnable first slice.

**ADR-0001** (`docs/adr/0001-…`) records: IXQL (Demerzel's governance pipeline-spec DSL) and DuckDB+IX (the analyst bench) are **complementary layers** joined by a JSON-on-disk contract. Integrate via **the MCP seam + the shared file format, not new IXQL grammar nodes** — because the IXQL executor is **spec-only** (new grammar source/sink nodes would be unrunnable) and the grammar is a sign-off-gated governed artifact. Two one-way doors logged:
- an in-agent `ix_maintain_gate` MCP tool would pull **bundled DuckDB into `ix-agent`** → kept feature-gated/deferred;
- the maintain-gate verdict is **advisory until ledger write-isolation (Phase-3b)**.

**The runnable first slice** — the governance-verdict *callable seam* — is a **`--json` mode** on the maintain-gate CLI (`ix-duck` `ix_maintain_gate`). It emits the `MaintainVerdict` as one JSON object on stdout (nothing else) — exactly what an MCP wrapper or IXQL's `mcp_tool_output → when verdict.status == "T"` consumes. Human-readable output stays the default. No DuckDB-in-agent, no grammar change.

## Why this shape (vs. the in-agent MCP tool I'd offered)
Confirming the dep tradeoff in practice: the in-agent MCP tool forces bundled DuckDB into `ix-agent` **and** a feature-conditional rewrite of the strict 93-tool parity oracle, all for an **advisory-only** verdict. The `--json` seam delivers the same callable-verdict capability (it's what any MCP/IXQL caller actually invokes) with none of that — the MCP wrapper becomes a thin follow-up if/when there's demand + Phase-3b.

## Testing
- `--json` → one valid `MaintainVerdict` (status=T, decision=accept, metric_up/guardrail_held=true, 4 signals) on the pass fixtures; exit code preserved (T→0).
- Human mode unchanged (`maintain-gate verdict: T (accept)`).
- `cargo clippy -p ix-duck --features duck --example ix_maintain_gate -- -D warnings` clean.

Pre-existing observation (orthogonal, not fixed here): the drift lens errors when pointed at a live `ga/query-embeddings` dir holding **mixed-dimension** embeddings (`ix_cosine: expected 4, got 1024`) instead of degrading to advisory — worth a follow-up to make mixed-dim embeddings read as "no signal".

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: a docs ADR + an additive --json output mode on a feature-gated (duck) example CLI; no default-build, runtime, or schema impact.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
