### PR TITLE
feat(ix-duck): maintain_trend — convergence read side of the verdict trend table

### DIFF
--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -576,6 +576,81 @@ pub fn append_to_ledger(verdict: &MaintainVerdict, path: &Path) -> std::io::Resu
     writeln!(f, "{line}")
 }
 
+/// A convergence summary over the verdict ledger — the **read side** of the maintain-gate
+/// "trend table" (the same `state/thinking-machine/maintain-gate.jsonl` the gate appends to,
+/// schema `maintain-gate.contract.md`). `ix-duck` reads it via `read_json_auto`, so a
+/// Demerzel / IXQL convergence loop can ask "are we converging?" in one query rather than
+/// re-deriving it from raw verdicts.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TrendSummary {
+    pub total: i64,
+    pub accepts: i64,
+    pub rejects: i64,
+    pub escalates: i64,
+    /// `status == "C"`: metric improved while a held capability regressed (reward-hack).
+    pub reward_hacks: i64,
+    /// `(status, count)` descending — the hexavalent verdict distribution.
+    pub by_status: Vec<(String, i64)>,
+    /// The most recent verdict's status (by `run_at`), if any.
+    pub latest_status: Option<String>,
+}
+
+/// Aggregate the append-only verdict ledger into a [`TrendSummary`] (the convergence-trend
+/// read side of opportunity #3 in `docs/adr/0001-…`). An absent ledger → an empty summary
+/// (degrade, never error) — the convergence loop reads "no data yet".
+// @ai:invariant maintain_trend aggregates the verdict ledger by decision/status and reads an absent ledger as an empty summary rather than erroring [T:test conf:0.9 src:ix_duck::maintain::tests::maintain_trend_aggregates_the_ledger]
+pub fn maintain_trend(
+    conn: &Connection,
+    ledger_path: &Path,
+) -> Result<TrendSummary, MaintainError> {
+    if !ledger_path.exists() {
+        return Ok(TrendSummary::default());
+    }
+    let p = ledger_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace('\'', "''");
+    let src = format!("read_json_auto('{p}', union_by_name=true)");
+    let (total, accepts, rejects, escalates, reward_hacks): (i64, i64, i64, i64, i64) = conn
+        .query_row(
+            &format!(
+                "SELECT count(*),
+                        count(*) FILTER (WHERE decision = 'accept'),
+                        count(*) FILTER (WHERE decision = 'reject'),
+                        count(*) FILTER (WHERE decision = 'escalate'),
+                        count(*) FILTER (WHERE status = 'C')
+                 FROM {src}"
+            ),
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )?;
+    let by_status: Vec<(String, i64)> = {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT status, count(*) FROM {src} GROUP BY status ORDER BY count(*) DESC, status"
+        ))?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<duckdb::Result<_>>()?;
+        rows
+    };
+    let latest_status: Option<String> = conn
+        .query_row(
+            &format!("SELECT status FROM {src} ORDER BY run_at DESC LIMIT 1"),
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    Ok(TrendSummary {
+        total,
+        accepts,
+        rejects,
+        escalates,
+        reward_hacks,
+        by_status,
+        latest_status,
+    })
+}
+
 #[cfg(all(test, feature = "duck"))]
 mod tests {
     use super::*;
@@ -1058,5 +1133,48 @@ mod tests {
             2,
             "append-only: two writes = two lines"
         );
+    }
+
+    #[test]
+    fn maintain_trend_aggregates_the_ledger() {
+        let conn = crate::open_bench().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let ledger = dir.path().join("maintain-gate.jsonl");
+        let line = |run_at: &str, status: &str, decision: &str| {
+            format!(
+                "{{\"schema_version\":\"maintain-gate.v0.1\",\"run_at\":\"{run_at}\",\"status\":\"{status}\",\"decision\":\"{decision}\",\"signals\":[],\"evidence\":[],\"reason\":\"x\"}}\n"
+            )
+        };
+        let body = format!(
+            "{}{}{}{}{}",
+            line("2026-06-18T00:00:00Z", "T", "accept"),
+            line("2026-06-18T00:01:00Z", "T", "accept"),
+            line("2026-06-18T00:02:00Z", "C", "reject"),
+            line("2026-06-18T00:03:00Z", "F", "reject"),
+            line("2026-06-18T00:04:00Z", "U", "escalate"),
+        );
+        std::fs::write(&ledger, body).unwrap();
+
+        let t = maintain_trend(&conn, &ledger).unwrap();
+        assert_eq!(t.total, 5);
+        assert_eq!(t.accepts, 2);
+        assert_eq!(t.rejects, 2);
+        assert_eq!(t.escalates, 1);
+        assert_eq!(t.reward_hacks, 1, "one status=C reward-hack");
+        assert_eq!(t.latest_status.as_deref(), Some("U"), "latest by run_at");
+        assert_eq!(
+            t.by_status.iter().find(|(s, _)| s == "T").map(|(_, c)| *c),
+            Some(2),
+            "T appears twice"
+        );
+    }
+
+    #[test]
+    fn maintain_trend_absent_ledger_is_empty() {
+        let conn = crate::open_bench().unwrap();
+        let t = maintain_trend(&conn, Path::new("/no/such/ledger.jsonl")).unwrap();
+        assert_eq!(t.total, 0);
+        assert!(t.by_status.is_empty());
+        assert_eq!(t.latest_status, None);
     }
 }

--- a/docs/contracts/maintain-gate.contract.md
+++ b/docs/contracts/maintain-gate.contract.md
@@ -5,7 +5,8 @@
 schema + exit-code semantics **freeze only at the named Phase-4 milestone**
 (`docs/plans/2026-06-16-002-feat-maintain-gate-rsi-oracle-plan.md`).
 **Producer:** `ix-duck` — `ix_duck::maintain::evaluate` (CLI: `ix_maintain_gate`).
-**Consumer:** none yet (intended: Demerzel governance + the bounded-RSI loop, read-only).
+**Consumer:** `ix_duck::maintain::maintain_trend` (convergence-trend read side, below);
+intended further: Demerzel governance + the bounded-RSI loop, read-only.
 **Location:** `state/thinking-machine/maintain-gate.jsonl` (**ix-side**, append-only,
 gitignored / regenerable). One verdict per line. Never written into a sibling tree.
 
@@ -118,6 +119,20 @@ When the gate is given an iteration scope (`loop_id` + `commit_sha` + the loop's
 in Contract B; until then drift stays corpus-level advisory. **Still Phase 3b:** the
 verdict is *advisory* — write-isolation of the ledgers from the proposing agent (and
 therefore any authoritative auto-revert) is not yet enforced.
+
+## Convergence trend (read side — the "trend table")
+
+The append-only ledger doubles as the governance **trend table**: the same JSONL is read
+back by `ix-duck` (`ix_duck::maintain::maintain_trend`, via `read_json_auto`) to summarise
+convergence — `total`, `accepts`/`rejects`/`escalates`, `reward_hacks` (`status == "C"`),
+the hexavalent `by_status` distribution, and the `latest_status` (by `run_at`). An absent
+ledger reads as an empty summary (degrade, never error).
+
+This is the read side of the IXQL↔DuckDB convergence loop
+(`docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md`): a Demerzel/IXQL pipeline appends
+verdicts here; `ix-duck` aggregates them so the loop can ask "are we converging?" in one
+query. No new schema — the trend table **is** this verdict ledger, so the locked-field
+discipline below covers both the per-verdict and the trend consumers.
 
 ## Locked-field discipline
 Changing `status`/`decision` value sets or the exit-code mapping after Phase-4 freeze


### PR DESCRIPTION
## Summary

**Opportunity #3** of the IXQL↔DuckDB integration (ADR-0001), made real on the read side. The maintain-gate's append-only verdict ledger (`state/thinking-machine/maintain-gate.jsonl`) **is** the governance "trend table" — this adds the `ix-duck` reader so a Demerzel/IXQL convergence loop can ask "are we converging?" in one query instead of re-deriving it from raw verdicts.

- **`maintain_trend(conn, ledger_path) -> TrendSummary`** reads the ledger via `read_json_auto` and aggregates: `total`, `accepts`/`rejects`/`escalates`, `reward_hacks` (`status == "C"`), the hexavalent `by_status` distribution, and `latest_status` (by `run_at`).
- Absent ledger → empty summary (degrade, never error).
- **Contract doc** gains a "Convergence trend (read side)" section: **no new schema** — the trend table *is* the existing verdict ledger, so the locked-field discipline covers both per-verdict and trend consumers. Consumer line updated.

## Testing
- `maintain_trend_aggregates_the_ledger`: a 5-verdict ledger → total=5, accepts=2, rejects=2, escalates=1, reward_hacks=1, latest=`U`, `by_status[T]`=2.
- `maintain_trend_absent_ledger_is_empty`: missing ledger → empty.
- `cargo clippy -p ix-duck --features duck --all-targets -D warnings` clean; rustfmt clean.

## Relationship to the other opportunity PRs
- ADR-0001 + `--json` seam (opportunity #2): **#134**.
- Drift-lens mixed-dim fix: **#135**.
- This (opportunity #3): the trend read side.

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: feature-gated (duck) read-only aggregator + a draft-contract doc addition; no schema change (reuses the existing verdict ledger), no service impact.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
