### PR TITLE
feat(ix-agent): ix_maintain_gate MCP tool (governance verdict), feature-gated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,9 @@ ix-embedding-diagnostics = { path = "crates/ix-embedding-diagnostics", version =
 ix-quality-trend = { path = "crates/ix-quality-trend", version = "0.1.0" }
 ix-invariant-coverage = { path = "crates/ix-invariant-coverage", version = "0.1.0" }
 ix-bracelet = { path = "crates/ix-bracelet", version = "0.1.0" }
+# ix-duck default-features = off: only consumers that opt into the `duck`/`udf` feature
+# pull DuckDB. The default workspace build never compiles it.
+ix-duck = { path = "crates/ix-duck", version = "0.1.0", default-features = false }
 ix-autoresearch = { path = "crates/ix-autoresearch", version = "0.1.0" }
 ix-blast-radius = { path = "crates/ix-blast-radius", version = "0.1.0" }
 ix-ai-annotations = { path = "crates/ix-ai-annotations", version = "0.1.0" }

--- a/crates/ix-agent/Cargo.toml
+++ b/crates/ix-agent/Cargo.toml
@@ -73,6 +73,16 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 reqwest = { version = "0.12", features = ["blocking", "json", "rustls-tls"], default-features = false }
 blake3 = "1.5"
+# Optional: the maintain-gate MCP tool wraps ix_duck::maintain::evaluate, which needs the
+# bundled-DuckDB (`duck`) feature. Heavy native (C++) dep, so it is OFF by default — the
+# default agent build and `--workspace` CI never compile DuckDB. See
+# docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md.
+ix-duck = { workspace = true, optional = true, features = ["duck"] }
+
+[features]
+# Exposes the `ix_maintain_gate` MCP tool (governance verdict as a callable). Opt-in:
+# `cargo build -p ix-agent --features maintain-gate`.
+maintain-gate = ["dep:ix-duck"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ix-agent/src/lib.rs
+++ b/crates/ix-agent/src/lib.rs
@@ -10,6 +10,10 @@ pub mod demo;
 pub mod eval;
 pub mod flywheel;
 pub mod handlers;
+/// `ix_maintain_gate` MCP tool (governance verdict via ix-duck). Feature-gated — pulls
+/// bundled DuckDB; off by default. See docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md.
+#[cfg(feature = "maintain-gate")]
+pub mod maintain_gate;
 pub mod ml_pipeline;
 pub mod projection;
 pub mod registry_bridge;

--- a/crates/ix-agent/src/maintain_gate.rs
+++ b/crates/ix-agent/src/maintain_gate.rs
@@ -1,0 +1,66 @@
+//! `ix_maintain_gate` MCP tool — the governance-verdict callable seam.
+//!
+//! Wraps [`ix_duck::maintain::evaluate`] (the hexavalent T/P/U/D/F/C RSI oracle) as an
+//! MCP tool so an agent — or an IXQL pipeline via `mcp_tool_output → when verdict.status
+//! == "T"` — can read the verdict in-process. **Feature-gated** (`maintain-gate`): it pulls
+//! the bundled-DuckDB `duck` build, which the default agent never compiles. See
+//! `docs/adr/0001-ixql-duckdb-integration-via-mcp-seam.md`.
+//!
+//! Read-only: it returns the verdict and does NOT append to the ledger (an ad-hoc MCP call
+//! must not pollute the tamper-evident `maintain-gate.jsonl`). The verdict is **advisory**
+//! until ledger write-isolation (Phase-3b) — it is not yet a binding governance gate.
+
+use std::path::Path;
+
+use ix_duck::maintain::{self, IterationScope, MaintainConfig, MaintainInputs};
+use serde_json::Value;
+
+fn str_arg<'a>(args: &'a Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(|v| v.as_str())
+}
+
+/// MCP handler: `ix_maintain_gate(hits_path, corpus_dir, [loops_dir, query_embeddings_dir,
+/// loop_id, commit_sha, repo_dir, run_at])` → the serialized `MaintainVerdict`.
+pub fn ix_maintain_gate(args: Value) -> Result<Value, String> {
+    let hits = str_arg(&args, "hits_path").ok_or("hits_path (string) is required")?;
+    let corpus = str_arg(&args, "corpus_dir").ok_or("corpus_dir (string) is required")?;
+    // Mirror the CLI guard: local paths only (no URLs / remote schemes).
+    for p in [hits, corpus] {
+        if p.contains("://") {
+            return Err(format!("refusing non-local path: {p}"));
+        }
+    }
+
+    let loops_dir = str_arg(&args, "loops_dir");
+    let emb_dir = str_arg(&args, "query_embeddings_dir");
+    let loop_id = str_arg(&args, "loop_id");
+    let commit_sha = str_arg(&args, "commit_sha");
+    let repo_dir = str_arg(&args, "repo_dir");
+    // Caller may pin run_at (RFC3339); default to now so the verdict carries a real stamp.
+    let run_at_owned = str_arg(&args, "run_at")
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+
+    // Iteration scope is all-or-nothing: a loop_id without a verifiable commit can't be scoped.
+    let iteration = match (loop_id, commit_sha, repo_dir) {
+        (Some(l), Some(c), Some(r)) => Some(IterationScope {
+            loop_id: l,
+            commit_sha: c,
+            repo_dir: Path::new(r),
+        }),
+        _ => None,
+    };
+
+    let conn = ix_duck::open_bench().map_err(|e| format!("open_bench: {e}"))?;
+    let inputs = MaintainInputs {
+        hits_path: Path::new(hits),
+        corpus_dir: Path::new(corpus),
+        loops_dir: loops_dir.map(Path::new),
+        query_embeddings_dir: emb_dir.map(Path::new),
+        iteration,
+        run_at: &run_at_owned,
+    };
+    let verdict = maintain::evaluate(&conn, &MaintainConfig::default(), &inputs)
+        .map_err(|e| format!("maintain-gate: {e}"))?;
+    serde_json::to_value(&verdict).map_err(|e| format!("serialize verdict: {e}"))
+}

--- a/crates/ix-agent/src/tools.rs
+++ b/crates/ix-agent/src/tools.rs
@@ -2465,6 +2465,34 @@ Example 2 — "cluster crates by complexity then classify":
             handler: crate::demo::ix_demo,
         });
 
+        // Governance verdict as a callable (ADR-0001). Feature-gated: pulls bundled DuckDB
+        // via ix-duck, so it is absent from the default agent surface (and the parity test).
+        #[cfg(feature = "maintain-gate")]
+        self.tools.push(Tool {
+            name: "ix_maintain_gate",
+            description: "Evaluate one self-improvement iteration against the maintain-gate \
+                          (the hexavalent T/P/U/D/F/C RSI oracle): fuse the externally-derived \
+                          yield metric, the chatbot guardrail, and the convergence/drift lenses \
+                          into one verdict. Returns the MaintainVerdict JSON (status, decision, \
+                          signals, evidence, reason). Read-only — does not append to the ledger. \
+                          Advisory until Phase-3b ledger write-isolation.",
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "hits_path": { "type": "string", "description": "Externally-derived hits.jsonl (the yield metric source)." },
+                    "corpus_dir": { "type": "string", "description": "Chatbot guardrail baseline dir (chatbot-qa)." },
+                    "loops_dir": { "type": "string", "description": "Optional loop-iteration ledger dir (convergence lens)." },
+                    "query_embeddings_dir": { "type": "string", "description": "Optional query-embeddings dir (drift lens)." },
+                    "loop_id": { "type": "string", "description": "Optional iteration scope: loop id (needs commit_sha + repo_dir)." },
+                    "commit_sha": { "type": "string", "description": "Optional iteration scope: commit to verify against git." },
+                    "repo_dir": { "type": "string", "description": "Optional iteration scope: repo to verify commit_sha in." },
+                    "run_at": { "type": "string", "description": "Optional RFC3339 timestamp; defaults to now." }
+                },
+                "required": ["hits_path", "corpus_dir"]
+            }),
+            handler: crate::maintain_gate::ix_maintain_gate,
+        });
+
         self.tools.push(Tool {
             name: "ix_explain_algorithm",
             description: "Recommend an ix algorithm for a described problem. Designed to \

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -113,6 +113,18 @@ const EXPECTED: &[&str] = &[
     "ix_voicings_payload",
 ];
 
+/// `EXPECTED` plus any feature-gated tools present in this build. The `maintain-gate`
+/// feature adds `ix_maintain_gate` (pulls bundled DuckDB; off in the default/CI build), so
+/// both the default surface (93) and the `--features maintain-gate` surface (94) stay green.
+fn expected() -> Vec<&'static str> {
+    // `mut` is only used when the feature adds a tool; allow the default-build no-op.
+    #[allow(unused_mut)]
+    let mut v = EXPECTED.to_vec();
+    #[cfg(feature = "maintain-gate")]
+    v.push("ix_maintain_gate");
+    v
+}
+
 fn exposed_names() -> HashSet<String> {
     let reg = ToolRegistry::new();
     let list = reg.list();
@@ -127,24 +139,25 @@ fn exposed_names() -> HashSet<String> {
 #[test]
 fn parity_all_64_tools_reachable() {
     let exposed = exposed_names();
-    let missing: Vec<&&str> = EXPECTED.iter().filter(|n| !exposed.contains(**n)).collect();
+    let exp = expected();
+    let missing: Vec<&&str> = exp.iter().filter(|n| !exposed.contains(**n)).collect();
     assert!(
         missing.is_empty(),
         "Tools vanished after migration: {:?}",
         missing
     );
-    // Stricter: the tool list should have EXACTLY the 43 expected names — not
-    // more (no duplicates from naming mismatches) and not fewer. If this drifts
-    // past 43, a migration is producing a name that doesn't match the original.
+    // Stricter: the tool list should have EXACTLY the expected names — not more (no
+    // duplicates from naming mismatches) and not fewer. `expected()` includes any
+    // feature-gated tools present in this build, so both surfaces stay exact.
     assert_eq!(
         exposed.len(),
-        EXPECTED.len(),
+        exp.len(),
         "expected exactly {} tools, got {} — names diverged from originals: extras={:?}",
-        EXPECTED.len(),
+        exp.len(),
         exposed.len(),
         exposed
             .iter()
-            .filter(|n| !EXPECTED.contains(&n.as_str()))
+            .filter(|n| !exp.contains(&n.as_str()))
             .collect::<Vec<_>>()
     );
 }
@@ -381,4 +394,30 @@ fn registry_backed_calls_dispatch_correctly() {
     let result = reg.call("ix_eigen", params).expect("ix_eigen via registry");
     let top = result["eigenvalues"][0].as_f64().expect("eigenvalues[0]");
     assert!((top - 3.0).abs() < 1e-9, "top eigenvalue ~3, got {top}");
+}
+
+/// End-to-end: the feature-gated `ix_maintain_gate` tool dispatches through the manual
+/// `handler` path and returns a verdict. Only the two hard lenses are exercised (no
+/// loops/embeddings dirs) so the gate is deterministic and avoids touching live ga state.
+#[cfg(feature = "maintain-gate")]
+#[test]
+fn maintain_gate_tool_returns_a_verdict() {
+    let here = env!("CARGO_MANIFEST_DIR");
+    let fx = format!("{here}/../ix-duck/tests/fixtures/maintain");
+    let reg = ToolRegistry::new();
+    let args = serde_json::json!({
+        "hits_path": format!("{fx}/hits_up.jsonl"),
+        "corpus_dir": format!("{fx}/corpus-pass"),
+        "run_at": "2026-06-20T00:00:00Z"
+    });
+    let v = reg
+        .call("ix_maintain_gate", args)
+        .expect("ix_maintain_gate should dispatch and run");
+    assert_eq!(
+        v["status"], "T",
+        "metric up + guardrail held → T; got {v:?}"
+    );
+    assert_eq!(v["decision"], "accept");
+    // A missing required arg is a clean error, not a panic.
+    assert!(reg.call("ix_maintain_gate", serde_json::json!({})).is_err());
 }


### PR DESCRIPTION
## Summary

**(c)** of the IXQL↔DuckDB opportunities — the in-agent counterpart to #134's `--json` CLI seam. Exposes the maintain-gate hexavalent verdict as an in-process MCP tool, so an agent (or an IXQL pipeline via `mcp_tool_output`) can call it directly.

Per **ADR-0001**, this pulls **bundled DuckDB into `ix-agent`** (ix-duck's `duck` feature), so it's **off by default** — behind the new `maintain-gate` cargo feature. The default agent build and `--workspace` CI never compile DuckDB.

- `crates/ix-agent/src/maintain_gate.rs` — handler `ix_maintain_gate(hits_path, corpus_dir, [loops_dir, query_embeddings_dir, loop_id, commit_sha, repo_dir, run_at])` → serialized `MaintainVerdict`. **Read-only** (does *not* append to the ledger — an ad-hoc call must not pollute the tamper-evident ledger). Local-path guard.
- `tools.rs` — feature-gated `Tool` descriptor; `lib.rs` — feature-gated module.
- Cargo — optional `ix-duck` dep (`duck` feature) + `maintain-gate` feature; added `ix-duck` to `[workspace.dependencies]` (`default-features = false` — it's the first consumer).
- `parity.rs` — `expected()` is **feature-aware**, so both surfaces stay exact (default **93**, `--features maintain-gate` **94**); a feature-gated end-to-end smoke test dispatches the tool and asserts `T`/`accept`.

## Testing (both builds)
- Default: `cargo test -p ix-agent --test parity` → 9 pass (93-tool surface unchanged).
- Feature: `cargo test -p ix-agent --features maintain-gate --test parity` → 10 pass (94 tools; smoke returns `T`/`accept`, missing-arg → clean error).
- `cargo clippy -p ix-agent --all-targets -D warnings` clean **and** `--features maintain-gate` clean (the gated handler is linted); rustfmt clean.

## Caveats / follow-ups
- **Advisory only** until Phase-3b ledger write-isolation (ADR-0001) — not yet a binding gate.
- **Default CI doesn't exercise the feature** (no `--all-features`), so the gated handler isn't lint/tested by the default pipeline. The `ix-duck-chatbot` duck-CI job should add a `--features maintain-gate` build to cover it. (I verified both builds locally.)

## Post-Deploy Monitoring & Validation
`No additional operational monitoring required: opt-in feature (off by default), read-only verdict tool; no default-build, schema, or service impact. If enabled in a deployment, watch that the agent binary size/build time increase is acceptable (bundled DuckDB).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
