### PR TITLE
refactor(ix-duck): extract a telemetry ingestion seam shared by the lenses

### DIFF
--- a/crates/ix-duck/src/chatbot.rs
+++ b/crates/ix-duck/src/chatbot.rs
@@ -613,7 +613,7 @@ mod tests {
     use std::fs;
 
     fn fixtures() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/chatbot-qa")
+        crate::telemetry::fixture("chatbot-qa")
     }
 
     /// Copy the fixtures corpus into a tempdir so a test can mutate it.

--- a/crates/ix-duck/src/chatbot.rs
+++ b/crates/ix-duck/src/chatbot.rs
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 use duckdb::Connection;
 use serde::Serialize;
 
+use crate::telemetry;
+
 /// Errors from the flight recorder: corpus I/O (fail-closed) vs DuckDB.
 #[derive(Debug)]
 pub enum ChatbotError {
@@ -135,19 +137,6 @@ fn signature_files(corpus_dir: &Path) -> Result<Vec<PathBuf>, ChatbotError> {
     collect(corpus_dir, |n| n == "_signature.json")
 }
 
-/// Render a slice of paths as a DuckDB list literal `['p1', 'p2', …]`, POSIX-slashed
-/// and single-quote-escaped (paths never contain `://`, validated by the caller).
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            let s = p.to_string_lossy().replace('\\', "/").replace('\'', "''");
-            format!("'{s}'")
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
-}
-
 // ---- Slice A: trace warehouse ---------------------------------------------
 
 /// Build the `chatbot_traces` table (one row per `run-*.json`). Returns the row
@@ -164,7 +153,7 @@ pub fn build_traces(conn: &Connection, corpus_dir: &Path) -> Result<usize, Chatb
         )?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         // Read `response.*` via `json_extract(to_json(response), …)` rather than struct-field
         // access: a subfield absent from EVERY trace file would otherwise be a bind-time
@@ -292,7 +281,7 @@ pub fn build_grounding(conn: &Connection, corpus_dir: &Path) -> Result<usize, Ch
         conn.execute_batch(&format!("CREATE OR REPLACE TABLE chatbot_grounding ({cols});"))?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_grounding AS
          WITH g AS (
@@ -475,7 +464,7 @@ fn build_signatures(conn: &Connection, corpus_dir: &Path) -> Result<(), ChatbotE
         )?;
         return Ok(());
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_signatures AS
          SELECT t.promptId AS prompt_id,
@@ -586,14 +575,16 @@ fn baseline_hash(conn: &Connection) -> duckdb::Result<String> {
     let pairs = stmt
         .query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)))?
         .collect::<duckdb::Result<Vec<_>>>()?;
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for (k, v) in pairs {
-        for b in k.bytes().chain(b"=".iter().copied()).chain(v.bytes()).chain(b";".iter().copied()) {
-            h ^= b as u64;
-            h = h.wrapping_mul(0x0000_0100_0000_01b3);
-        }
-    }
-    Ok(format!("fnv1a64:{h:016x}"))
+    // Flatten the sorted (key, value) baseline into `k=v;` bytes and hash once via the
+    // shared evidence primitive — byte-comparable with `maintain`'s file hash.
+    let bytes = pairs.into_iter().flat_map(|(k, v)| {
+        k.into_bytes()
+            .into_iter()
+            .chain(std::iter::once(b'='))
+            .chain(v.into_bytes())
+            .chain(std::iter::once(b';'))
+    });
+    Ok(telemetry::fnv1a64(bytes))
 }
 
 /// Map a gate status to a process exit code: `regression` → 1, all else → 0.

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -56,6 +56,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Shared telemetry-ingestion plumbing for the lenses — the one graceful-degrade
+/// scanner (`collect_dir`), `sql_list`, and the `fnv1a64` evidence hash. Private:
+/// each lens keeps its own public `*Error`. See `docs/adr/0002-defer-lens-trait-in-ix-duck.md`.
+#[cfg(feature = "duck")]
+mod telemetry;
+
 /// Chatbot flight recorder — GA golden-trace warehouse (Slice A) + canonical-diff
 /// regression gate (Slice B). See `docs/plans/2026-06-14-004-…-flight-recorder-plan.md`.
 #[cfg(feature = "duck")]

--- a/crates/ix-duck/src/loops.rs
+++ b/crates/ix-duck/src/loops.rs
@@ -34,11 +34,8 @@ impl std::fmt::Display for LoopError {
     }
 }
 impl std::error::Error for LoopError {}
-impl From<std::io::Error> for LoopError {
-    fn from(e: std::io::Error) -> Self {
-        LoopError::Io(e)
-    }
-}
+// The `Io` variant is populated via `From<LensError>` (telemetry::collect_dir owns all
+// file I/O); there is no bare `io::Error` producer in this module, so no `From<io::Error>`.
 impl From<duckdb::Error> for LoopError {
     fn from(e: duckdb::Error) -> Self {
         LoopError::Duck(e)
@@ -206,7 +203,7 @@ mod tests {
     use super::*;
 
     fn fixtures() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/loops")
+        crate::telemetry::fixture("loops")
     }
 
     #[test]

--- a/crates/ix-duck/src/loops.rs
+++ b/crates/ix-duck/src/loops.rs
@@ -13,10 +13,11 @@
 //! analyses below exclude seed/test domains so a fresh checkout reads as "no signal"
 //! rather than a phantom. Absent directory → empty tables (never an error).
 
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
+
+use crate::telemetry::{self, LensError};
 
 /// Errors from the loop lens: directory I/O vs DuckDB.
 #[derive(Debug)]
@@ -43,40 +44,20 @@ impl From<duckdb::Error> for LoopError {
         LoopError::Duck(e)
     }
 }
-
-/// `*.iterations.jsonl` files in `loops_dir` (sorted). Absent dir → empty (skip);
-/// any other read error on a present dir → surfaced.
-fn ledger_files(loops_dir: &Path) -> Result<Vec<PathBuf>, LoopError> {
-    let rd = match std::fs::read_dir(loops_dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.ends_with(".iterations.jsonl") {
-                out.push(p);
-            }
+impl From<LensError> for LoopError {
+    fn from(e: LensError) -> Self {
+        match e {
+            LensError::Io(e) => LoopError::Io(e),
+            LensError::Duck(e) => LoopError::Duck(e),
         }
     }
-    out.sort();
-    Ok(out)
 }
 
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            format!(
-                "'{}'",
-                p.to_string_lossy().replace('\\', "/").replace('\'', "''")
-            )
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
+/// `*.iterations.jsonl` files in `loops_dir` (sorted). Absent dir → empty (skip);
+/// any other read error on a present dir → surfaced — the graceful-degrade contract
+/// lives in [`telemetry::collect_dir`].
+fn ledger_files(loops_dir: &Path) -> Result<Vec<PathBuf>, LoopError> {
+    telemetry::collect_dir(loops_dir, |n| n.ends_with(".iterations.jsonl")).map_err(Into::into)
 }
 
 const COLS: &str = "loop_id VARCHAR, domain VARCHAR, iteration BIGINT, ts VARCHAR, \
@@ -96,7 +77,7 @@ pub fn build_loop_iterations(conn: &Connection, loops_dir: &Path) -> Result<usiz
         ))?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE loop_iterations AS
          SELECT loop_id::VARCHAR              AS loop_id,

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -266,14 +266,10 @@ pub struct MaintainVerdict {
 }
 
 /// FNV-1a 64-bit hash of a file's bytes — stable across platforms; `None` if absent.
+/// Shares the [`crate::telemetry::fnv1a64`] primitive with `chatbot`'s baseline hash
+/// so the maintain-gate's evidence hashes stay byte-comparable.
 fn fnv1a64_file(path: &Path) -> Option<String> {
-    let bytes = std::fs::read(path).ok()?;
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in bytes {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    Some(format!("fnv1a64:{h:016x}"))
+    Some(crate::telemetry::fnv1a64(std::fs::read(path).ok()?))
 }
 
 /// Yield delta from an externally-derived `hits.jsonl`: mean `coverage_max` over

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -578,9 +578,7 @@ mod tests {
     use std::path::PathBuf;
 
     fn fx(rel: &str) -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/maintain")
-            .join(rel)
+        crate::telemetry::fixture("maintain").join(rel)
     }
 
     fn inputs<'a>(hits: &'a Path, corpus: &'a Path) -> MaintainInputs<'a> {
@@ -596,9 +594,7 @@ mod tests {
 
     /// Path to a sibling lens fixture dir (loops / query-embeddings live one level up).
     fn lens_fx(rel: &str) -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures")
-            .join(rel)
+        crate::telemetry::fixture(rel)
     }
 
     #[test]

--- a/crates/ix-duck/src/ood.rs
+++ b/crates/ix-duck/src/ood.rs
@@ -16,10 +16,11 @@
 //! Producer is default-on; first rows land when the chatbot routes a live query.
 //! Absent/empty directory → empty (never error).
 
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
+
+use crate::telemetry::{self, LensError};
 
 /// Errors from the OOD lens: directory I/O vs DuckDB.
 #[derive(Debug)]
@@ -46,39 +47,19 @@ impl From<duckdb::Error> for OodError {
         OodError::Duck(e)
     }
 }
-
-/// `*.jsonl` files in `dir` (sorted). Absent dir → empty (skip); other errors surfaced.
-fn embedding_files(dir: &Path) -> Result<Vec<PathBuf>, OodError> {
-    let rd = match std::fs::read_dir(dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.ends_with(".jsonl") {
-                out.push(p);
-            }
+impl From<LensError> for OodError {
+    fn from(e: LensError) -> Self {
+        match e {
+            LensError::Io(e) => OodError::Io(e),
+            LensError::Duck(e) => OodError::Duck(e),
         }
     }
-    out.sort();
-    Ok(out)
 }
 
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            format!(
-                "'{}'",
-                p.to_string_lossy().replace('\\', "/").replace('\'', "''")
-            )
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
+/// `*.jsonl` files in `dir` (sorted). Absent dir → empty (skip); other errors
+/// surfaced — the graceful-degrade contract lives in [`telemetry::collect_dir`].
+fn embedding_files(dir: &Path) -> Result<Vec<PathBuf>, OodError> {
+    telemetry::collect_dir(dir, |n| n.ends_with(".jsonl")).map_err(Into::into)
 }
 
 const COLS: &str = "query_id VARCHAR, ts VARCHAR, day VARCHAR, query_text VARCHAR, \
@@ -96,7 +77,7 @@ pub fn build_query_embeddings(conn: &Connection, dir: &Path) -> Result<usize, Oo
         ))?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE query_embeddings AS
          SELECT query_id::VARCHAR        AS query_id,

--- a/crates/ix-duck/src/ood.rs
+++ b/crates/ix-duck/src/ood.rs
@@ -37,11 +37,8 @@ impl std::fmt::Display for OodError {
     }
 }
 impl std::error::Error for OodError {}
-impl From<std::io::Error> for OodError {
-    fn from(e: std::io::Error) -> Self {
-        OodError::Io(e)
-    }
-}
+// The `Io` variant is populated via `From<LensError>` (telemetry::collect_dir owns all
+// file I/O); there is no bare `io::Error` producer in this module, so no `From<io::Error>`.
 impl From<duckdb::Error> for OodError {
     fn from(e: duckdb::Error) -> Self {
         OodError::Duck(e)
@@ -152,7 +149,7 @@ mod tests {
     use super::*;
 
     fn fixtures() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/query-embeddings")
+        crate::telemetry::fixture("query-embeddings")
     }
 
     #[test]

--- a/crates/ix-duck/src/routing.rs
+++ b/crates/ix-duck/src/routing.rs
@@ -11,10 +11,11 @@
 //! intent keys (`skill.scaleinfo`) are extracted via JSON-Pointer paths
 //! (`/key/field`) — JSONPath's `$.` would mis-split the dot into nesting.
 
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use duckdb::Connection;
+
+use crate::telemetry::{self, LensError};
 
 /// Errors from the routing lens: directory I/O vs DuckDB.
 #[derive(Debug)]
@@ -41,35 +42,23 @@ impl From<duckdb::Error> for RoutingError {
         RoutingError::Duck(e)
     }
 }
-
-/// `routing-eval-*.json` files in `quality_dir` (sorted). Absent dir → empty (skip);
-/// any other read error on a present dir → surfaced.
-fn eval_files(quality_dir: &Path) -> Result<Vec<PathBuf>, RoutingError> {
-    let rd = match std::fs::read_dir(quality_dir) {
-        Ok(r) => r,
-        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(e) => return Err(e.into()),
-    };
-    let mut out = Vec::new();
-    for entry in rd {
-        let p = entry?.path();
-        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
-            if n.starts_with("routing-eval-") && n.ends_with(".json") {
-                out.push(p);
-            }
+impl From<LensError> for RoutingError {
+    fn from(e: LensError) -> Self {
+        match e {
+            LensError::Io(e) => RoutingError::Io(e),
+            LensError::Duck(e) => RoutingError::Duck(e),
         }
     }
-    out.sort();
-    Ok(out)
 }
 
-/// DuckDB list literal of POSIX-slashed, quote-escaped paths.
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| format!("'{}'", p.to_string_lossy().replace('\\', "/").replace('\'', "''")))
-        .collect();
-    format!("[{}]", items.join(", "))
+/// `routing-eval-*.json` files in `quality_dir` (sorted). Absent dir → empty (skip);
+/// any other read error on a present dir → surfaced — the graceful-degrade contract
+/// lives in [`telemetry::collect_dir`].
+fn eval_files(quality_dir: &Path) -> Result<Vec<PathBuf>, RoutingError> {
+    telemetry::collect_dir(quality_dir, |n| {
+        n.starts_with("routing-eval-") && n.ends_with(".json")
+    })
+    .map_err(Into::into)
 }
 
 /// Build `routing_evals` (run × intent) and `routing_overall` (run). Returns the
@@ -88,7 +77,7 @@ pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usiz
         ))?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = telemetry::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE routing_evals AS
          WITH raw AS (

--- a/crates/ix-duck/src/routing.rs
+++ b/crates/ix-duck/src/routing.rs
@@ -32,11 +32,8 @@ impl std::fmt::Display for RoutingError {
     }
 }
 impl std::error::Error for RoutingError {}
-impl From<std::io::Error> for RoutingError {
-    fn from(e: std::io::Error) -> Self {
-        RoutingError::Io(e)
-    }
-}
+// The `Io` variant is populated via `From<LensError>` (telemetry::collect_dir owns all
+// file I/O); there is no bare `io::Error` producer in this module, so no `From<io::Error>`.
 impl From<duckdb::Error> for RoutingError {
     fn from(e: duckdb::Error) -> Self {
         RoutingError::Duck(e)
@@ -167,7 +164,7 @@ mod tests {
     use super::*;
 
     fn fixtures() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/routing")
+        crate::telemetry::fixture("routing")
     }
 
     #[test]

--- a/crates/ix-duck/src/telemetry.rs
+++ b/crates/ix-duck/src/telemetry.rs
@@ -1,0 +1,148 @@
+//! Shared telemetry-ingestion plumbing for the analyst **lenses** (routing, loops,
+//! ood, chatbot, maintain).
+//!
+//! Every lens reads JSON/JSONL telemetry off disk before it gets to its real work,
+//! and they all owe the same contract: **an absent directory degrades to "no signal"
+//! (skip), but a present-but-unreadable directory fails closed** (a broken mount or a
+//! permissions error must never be silently read as "no telemetry"). That invariant —
+//! which `maintain::evaluate` trusts when it fuses the lenses — used to live in four
+//! byte-identical copies (`routing::eval_files`, `loops::ledger_files`,
+//! `ood::embedding_files`, plus the flat half of `chatbot::collect`). Here it lives
+//! once, with one test.
+//!
+//! Each lens keeps its own public `*Error` type (the deepest lens, `maintain`,
+//! distinguishes *which* lens failed — guardrail vs convergence vs drift — via
+//! distinct `From` impls), so [`LensError`] is `pub(crate)` and converts into each.
+
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+/// Ingestion error: directory I/O vs DuckDB. `pub(crate)` — each lens's public
+/// `*Error` adds `From<LensError>`, so a lens `?`-propagates this into its own type
+/// and `maintain` still sees per-lens error context.
+#[derive(Debug)]
+pub(crate) enum LensError {
+    Io(std::io::Error),
+    Duck(duckdb::Error),
+}
+
+impl std::fmt::Display for LensError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LensError::Io(e) => write!(f, "telemetry I/O error: {e}"),
+            LensError::Duck(e) => write!(f, "duckdb error: {e}"),
+        }
+    }
+}
+impl std::error::Error for LensError {}
+impl From<std::io::Error> for LensError {
+    fn from(e: std::io::Error) -> Self {
+        LensError::Io(e)
+    }
+}
+impl From<duckdb::Error> for LensError {
+    fn from(e: duckdb::Error) -> Self {
+        LensError::Duck(e)
+    }
+}
+
+/// Files in `dir` whose file name satisfies `keep`, sorted. **Absent dir → empty
+/// (skip); any other read error on a present dir → surfaced (fail-closed).**
+///
+/// This is the flat, one-level scan shared by the routing/loops/ood lenses.
+/// (`chatbot` walks a two-level `golden-traces/*/leaf` corpus and keeps its own
+/// nested enumerator; it shares only [`sql_list`] and [`fnv1a64`].)
+pub(crate) fn collect_dir(
+    dir: &Path,
+    keep: impl Fn(&str) -> bool,
+) -> Result<Vec<PathBuf>, LensError> {
+    let rd = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e.into()),
+    };
+    let mut out = Vec::new();
+    for entry in rd {
+        let p = entry?.path();
+        if let Some(n) = p.file_name().and_then(|n| n.to_str()) {
+            if keep(n) {
+                out.push(p);
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Render paths as a DuckDB list literal `['p1', 'p2', …]`, POSIX-slashed and
+/// single-quote-escaped. Paths never contain `://` (validated by the caller).
+pub(crate) fn sql_list(paths: &[PathBuf]) -> String {
+    let items: Vec<String> = paths
+        .iter()
+        .map(|p| {
+            let s = p.to_string_lossy().replace('\\', "/").replace('\'', "''");
+            format!("'{s}'")
+        })
+        .collect();
+    format!("[{}]", items.join(", "))
+}
+
+/// FNV-1a (64-bit) over a byte stream, formatted as `fnv1a64:{:016x}`. The one
+/// content-hash used for the maintain-gate's evidence: `chatbot::baseline_hash`
+/// feeds it the joined `k=v;` baseline pairs, `maintain` feeds it file bytes — both
+/// must stay byte-comparable, so they share this definition.
+pub(crate) fn fnv1a64(bytes: impl IntoIterator<Item = u8>) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("fnv1a64:{h:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn absent_dir_degrades_to_empty() {
+        let missing = Path::new("definitely/not/a/real/dir/xyzzy");
+        let got = collect_dir(missing, |_| true).unwrap();
+        assert!(got.is_empty(), "absent dir must skip, not error");
+    }
+
+    #[test]
+    fn collect_dir_filters_and_sorts() {
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["b.jsonl", "a.jsonl", "skip.txt"] {
+            std::fs::File::create(dir.path().join(name)).unwrap();
+        }
+        let got = collect_dir(dir.path(), |n| n.ends_with(".jsonl")).unwrap();
+        let names: Vec<_> = got
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["a.jsonl", "b.jsonl"], "filtered + sorted");
+    }
+
+    #[test]
+    fn sql_list_escapes_and_posix_slashes() {
+        let paths = [PathBuf::from(r"C:\a\b.json"), PathBuf::from("d/e'f.json")];
+        let got = sql_list(&paths);
+        assert_eq!(got, "['C:/a/b.json', 'd/e''f.json']");
+        assert_eq!(sql_list(&[]), "[]");
+    }
+
+    #[test]
+    fn fnv1a64_is_stable_and_prefixed() {
+        // Known FNV-1a 64-bit vector: empty input is the offset basis.
+        assert_eq!(fnv1a64(std::iter::empty()), "fnv1a64:cbf29ce484222325");
+        // Same bytes from different sources hash identically (the cross-lens contract).
+        let from_str = fnv1a64(b"abc".iter().copied());
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(b"abc").unwrap();
+        let from_file = fnv1a64(std::fs::read(tmp.path()).unwrap());
+        assert_eq!(from_str, from_file);
+    }
+}

--- a/crates/ix-duck/src/telemetry.rs
+++ b/crates/ix-duck/src/telemetry.rs
@@ -100,6 +100,16 @@ pub(crate) fn fnv1a64(bytes: impl IntoIterator<Item = u8>) -> String {
     format!("fnv1a64:{h:016x}")
 }
 
+/// Path to a vendored test-fixture directory: `<crate>/tests/fixtures/<sub>`. The one
+/// place the `CARGO_MANIFEST_DIR`/`tests/fixtures` layout is encoded, shared by every
+/// lens's test module (was five copies).
+#[cfg(test)]
+pub(crate) fn fixture(sub: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(sub)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/adr/0002-defer-lens-trait-in-ix-duck.md
+++ b/docs/adr/0002-defer-lens-trait-in-ix-duck.md
@@ -1,0 +1,59 @@
+# Defer a `Lens` trait in `ix-duck` — keep heterogeneous lenses concrete
+
+Status: accepted (2026-06-20)
+
+## Context
+
+`ix-duck` exposes five analyst **lenses** over GA telemetry — `chatbot`, `routing`,
+`loops`, `ood`, `maintain`. An architecture review (`/improve-codebase-architecture`,
+2026-06-20) noted that `maintain::evaluate` orchestrates four of them by calling each
+one's bespoke API individually (`chatbot::check_regressions` → `GateReport`,
+`loops::oscillating_loops` → tuples, `ood::flag_ood` → tuples), and that each lens
+returns a different result shape (struct / tuple / type-alias) with no common envelope.
+A `trait Lens { fn ingest(&Connection) -> Result<usize>; fn signal(&Connection) ->
+Signal; }` was raised as a possible deepening: maintain could then iterate lenses
+uniformly and a new signal would be "add a `Lens`," not "edit the orchestrator."
+
+## Decision
+
+**Do not introduce a `Lens` trait now.** Keep the lenses concrete and let `maintain`
+call each one's API directly. Revisit only when a *sixth* maintain signal actually
+needs to be fused.
+
+The same review's **ingestion** finding *was* acted on — the duplicated
+graceful-degrade scanner, `sql_list`, and `fnv1a64` were pulled into a private
+`telemetry` module (this is the real seam, with four/two existing adapters). The
+`Lens` trait is the part deliberately deferred.
+
+## Why (the trade-off)
+
+- **The lenses are genuinely heterogeneous, not parallel.** `chatbot`'s guardrail is a
+  *hard* gate (a regression fails the verdict); `ood` is *advisory* (drift only flags);
+  `loops` is *iteration-scoped* (correlated to a specific commit via `IterationScope`).
+  A single `signal()` shape would either lose this structure or grow options until it
+  re-encodes each lens's specialness — an abstraction that earns nothing.
+- **It would make shallow lenses *look* deep without adding leverage.** A trait over
+  four call-sites that one function makes is a hypothetical seam, not a real one
+  (one adapter ≠ a seam). Per the deletion test, deleting the trait today would just
+  move the four calls back inline — complexity moves, it doesn't concentrate.
+- **`maintain`'s per-lens error framing is load-bearing.** `MaintainError` distinguishes
+  `Chatbot` ("guardrail lens error") / `Loops` ("convergence lens error") / `Ood`
+  ("drift lens error") via distinct `From` impls — which is *why* the ingestion refactor
+  kept the per-lens `*Error` types instead of collapsing them. A uniform `Lens` trait
+  pushes against that grain.
+- **CLAUDE discipline.** Karpathy r2 (simplicity, no speculative future-proofing) and
+  YAGNI both say: don't abstract four heterogeneous call-sites on spec.
+
+## Consequences
+
+- Adding a *fifth* maintain signal today means editing `maintain::evaluate` directly.
+  That is the accepted cost — it is a few lines and keeps each lens's contract explicit.
+- The ingestion seam (`telemetry::{collect_dir, sql_list, fnv1a64, LensError}`) stands
+  on its own and does not depend on this decision.
+
+## Revisit trigger
+
+When a **sixth** lens/signal needs fusing into the maintain verdict — at that point the
+orchestrator's per-lens glue is paying real recurring cost, the trait would *concentrate*
+complexity (deletion test flips to "yes"), and the heterogeneity will have shown its
+actual axes (hard/advisory/scoped), so the trait can be shaped to them rather than guessed.


### PR DESCRIPTION
## Summary

A `/improve-codebase-architecture` review of `crates/ix-duck` found the lenses' real **depth** is their SQL + verdict logic, but their *telemetry ingestion* plumbing was copy-pasted. This concentrates it.

- **The duplication (verified by grep, not survey):** `routing::eval_files`, `loops::ledger_files`, `ood::embedding_files` were **byte-identical** graceful-degrade scanners; `sql_list` was identical in all four lenses; the `fnv1a64` evidence hash (same magic constants + `fnv1a64:` prefix) lived in both `chatbot::baseline_hash` and `maintain::fnv1a64_file`.
- **Why it mattered:** the load-bearing contract `maintain::evaluate` trusts — *absent dir → skip; present-but-unreadable → fail-closed* — was re-asserted in **four** drift-prone copies.

## What changed

- New private `telemetry.rs` (`#[cfg(feature="duck")]`): `collect_dir` (the one scanner, one contract test), `sql_list`, `fnv1a64`, and `pub(crate) LensError`.
- `routing` / `loops` / `ood` delegate scanning to `telemetry::collect_dir` and add one `From<LensError>` — **keeping their public `*Error` types**. (Tracing `maintain` showed it distinguishes guardrail/convergence/drift failures via *distinct* `From` impls — collapsing the enums would reduce locality in the deepest module, so they stay. This refined the review's first pass.)
- `chatbot` keeps its **distinct** two-level `golden-traces/*/leaf` walk (genuinely not duplication), drops only its local `sql_list`, and routes `baseline_hash` through `telemetry::fnv1a64` so its baseline hash stays byte-comparable with `maintain`'s file hash.
- **ADR-0002** records *deferring* a `Lens` trait (the review's 3rd, speculative candidate): the lenses are heterogeneous (hard gate / advisory / scoped); revisit when a 6th maintain signal forces it.

Net **−56 lines** in the lens bodies. No public API change beyond the additive `From<LensError>` impls.

## Testing
- `cargo test -p ix-duck --features duck` → **99 + 1 doc-test pass** (incl. 3 new `telemetry` tests + all lens tests)
- `cargo clippy -p ix-duck --features duck --all-targets -- -D warnings` → **clean**
- `cargo run -p ix-duck --features duck --example ix_chatbot_lens -- check …/fixtures/chatbot-qa` → **`status: pass, 4 prompts, 0 regressions`** (baseline hash via the new shared `fnv1a64`)
- These are exactly the three gates in `ix-duck-chatbot.yml`. CI does not gate `cargo fmt` on this crate (documented rustfmt skew); no committed files were reformatted.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: pure internal refactor of a feature-gated analyst crate; behavior is identical (same tests, same gate verdicts, byte-identical baseline hashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)