### PR TITLE
fix(ci): submodule-auto-update — force-push bot branch + idempotent PR create

### DIFF
--- a/.github/workflows/submodule-auto-update.yml
+++ b/.github/workflows/submodule-auto-update.yml
@@ -80,14 +80,24 @@ jobs:
           LATEST=${{ steps.check.outputs.latest }}
           BRANCH="chore/update-demerzel-$(date +%Y%m%d)"
 
-          git checkout -b "$BRANCH"
+          git checkout -B "$BRANCH"
           git commit -m "chore: update Demerzel submodule ($BEHIND commits)"
-          git push origin "$BRANCH"
+          # Bot-owned dated branch: a same-day re-run must REPLACE it, not hit a
+          # non-fast-forward rejection (the prior "failed to push some refs" failure).
+          # Force-push is safe — nothing but this job writes this branch.
+          git push --force origin "$BRANCH"
 
           # Get recent commit messages for PR body
           cd governance/demerzel
           CHANGES=$(git log --oneline "$CURRENT..$LATEST" | head -15)
           cd ../..
+
+          # Idempotent: if a PR for this branch is already open, the force-push above
+          # refreshed it — creating another would error. Skip cleanly.
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')" ]; then
+            echo "PR already open for $BRANCH; force-push refreshed it."
+            exit 0
+          fi
 
           gh pr create \
             --title "chore: update Demerzel submodule ($BEHIND commits behind)" \


### PR DESCRIPTION
## Summary
From the GitHub Actions review. The only **RED** workflow was `submodule-auto-update.yml` (failed 2026-06-20).

**Root cause:** the "Create PR for large update" step pushes a dated branch `chore/update-demerzel-YYYYMMDD` with a plain `git push`. The workflow is `repository_dispatch`-triggered and can fire more than once a day → the second run hits the existing remote branch → **non-fast-forward rejection** (`failed to push some refs`, exit 1). Permissions were already fine (contents+pull-requests write, PAT fallback) — it was purely the push.

**Fix:** force-push the bot-owned dated branch (`git push --force`), and skip `gh pr create` if a PR for that branch is already open (the force-push refreshes it). Idempotent daily PR; no duplicate-create error. YAML validated with PyYAML.

## Not changed (with reasons)
- **agent-blackbox.yml** (the "risk-report" that fails on every PR) — it fails at *Enforce verdict* → the external agent-blackbox harness computes `verdict: fail`. That's the harness's scoring (verify vs harness-audit dimensions), not a workflow-YAML bug. It's already **non-required** (doesn't block merge). Fixing it properly needs a root-cause dive into the harness's verdict computation; "making it honest" by disabling the gate is a governance change that needs your sign-off — so I left it. **Recommend a focused follow-up** to find why the verdict is `fail` (verify exit vs a 0-score audit dimension).
- **adversarial-qa.yml** — looks dormant (last run 2026-05-23) but is **correctly path-gated** (`crates/ga-chatbot/**`, `state/voicings/**`, `tests/adversarial/**`); no recent PR touched those paths. Working as intended, no change.
- The other 13 workflows are green.

## Post-Deploy Monitoring & Validation
After merge, watch the next `Auto-Update Demerzel Submodule` run (or re-dispatch it) — the "Create PR for large update" step should push + open/refresh the PR without the non-fast-forward error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)