### PR TITLE
feat(ix-duck): scheduled maintain producer + verdict snapshot (Phase A, #145)

### DIFF
--- a/.github/workflows/maintain-gate-nightly.yml
+++ b/.github/workflows/maintain-gate-nightly.yml
@@ -59,5 +59,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maintain-verdict-snapshot
-          path: state/quality/maintain-verdict/last.json
+          path: state/quality/maintain-gate/last.json
           if-no-files-found: warn

--- a/.github/workflows/maintain-gate-nightly.yml
+++ b/.github/workflows/maintain-gate-nightly.yml
@@ -1,0 +1,63 @@
+name: maintain gate (nightly, advisory)
+
+# Scheduled maintain-gate PRODUCER (Phase A). Runs the DuckDB+IX maintain gate over the
+# LIVE GuitarAlchemist/ga sibling (checked out read-only) and emits a current-verdict
+# SNAPSHOT in the ga/state/quality scorecard shape (latest hexavalent verdict + a
+# maintain_trend rollup). ADVISORY until Phase 3b: schedule/dispatch only, it never gates
+# a merge. The snapshot is uploaded as an artifact; Phase B federates it into ga/state/quality.
+#
+# formats-not-coupling: this workflow writes ONLY the IX tree (no GA-tree write).
+# Schedule-only (no fork-PR trigger) → no untrusted-PR code path. GA is public → no token.
+# absent-ga → the producer skips (exit 0); ga present + read error → fail-closed (nonzero).
+
+on:
+  schedule:
+    - cron: '37 6 * * *' # daily 06:37 UTC (offset from the 06:23 chatbot nightly)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  produce-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Checkout GA sibling (read-only, public)
+        uses: actions/checkout@v4
+        with:
+          repository: GuitarAlchemist/ga
+          path: ga-sibling
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ix-duck-duck
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build maintain producer (duck feature, bundled engine)
+        run: cargo build -p ix-duck --features duck --example ix_maintain_snapshot
+
+      - name: Produce verdict snapshot over live GA telemetry
+        # GA_ROOT points the producer at the sibling checkout. absent-ga → exit 0;
+        # ga present + lens read error → fail-closed nonzero (the step then fails).
+        env:
+          GA_ROOT: ${{ github.workspace }}/ga-sibling
+        run: cargo run -p ix-duck --features duck --example ix_maintain_snapshot
+
+      - name: Upload verdict snapshot
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maintain-verdict-snapshot
+          path: state/quality/maintain-verdict/last.json
+          if-no-files-found: warn

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -77,6 +77,10 @@ name = "ix_maintain_gate"
 required-features = ["duck"]
 
 [[example]]
+name = "ix_maintain_snapshot"
+required-features = ["duck"]
+
+[[example]]
 name = "ix_voicing_lens"
 required-features = ["duck"]
 

--- a/crates/ix-duck/examples/ix_maintain_snapshot.rs
+++ b/crates/ix-duck/examples/ix_maintain_snapshot.rs
@@ -1,0 +1,89 @@
+//! `ix_maintain_snapshot` — the **scheduled maintain producer** (Phase A tracer-bullet).
+//! Evaluates the maintain gate over the LIVE sibling `../ga` telemetry, then writes a
+//! **current-verdict snapshot** in the `ga/state/quality` scorecard shape (latest hexavalent
+//! verdict + a `maintain_trend` rollup over the append-only ledger). End-to-end on the IX
+//! side: GA data → fused verdict → snapshot file.
+//!
+//!   cargo run -p ix-duck --features duck --example ix_maintain_snapshot
+//!   cargo run -p ix-duck --features duck --example ix_maintain_snapshot -- <out.json>
+//!   GA_ROOT=ga-sibling cargo run … --example ix_maintain_snapshot       # CI sibling checkout
+//!
+//! Discipline (per issue #145 / ADR-0002):
+//!   * **formats-not-coupling** — writes ONLY the IX tree; Phase B federates into ga/state/quality.
+//!   * **absent-ga → skip** — no sibling corpus ⇒ exit 0 (nothing to produce, not a failure).
+//!   * **fail-closed** — ga present but unreadable ⇒ nonzero exit, no snapshot written.
+//!   * **atomic** — temp + rename, so a reader never sees a half-written scorecard.
+//!   * **advisory until Phase 3b** — the verdict is not binding.
+
+use std::path::PathBuf;
+
+use ix_duck::maintain::{self, MaintainConfig, MaintainInputs};
+
+/// `GA_ROOT` (CI sibling checkout) else `../ga` relative to the IX repo root.
+fn ga_root() -> PathBuf {
+    if let Ok(root) = std::env::var("GA_ROOT") {
+        return PathBuf::from(root);
+    }
+    let cwd = std::env::current_dir().unwrap_or_default();
+    let ix_root = cwd.canonicalize().unwrap_or(cwd);
+    ix_root
+        .parent()
+        .map(|p| p.join("ga"))
+        .unwrap_or_else(|| PathBuf::from("../ga"))
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("state/quality/maintain-verdict/last.json"));
+
+    let ga = ga_root();
+    let ga_quality = ga.join("state/quality");
+    let corpus = ga_quality.join("chatbot-qa");
+
+    // absent-ga → skip (exit 0): there is nothing to produce, which is not a failure.
+    // The guardrail corpus is the load-bearing input; without it the gate can't decide.
+    if !corpus.exists() {
+        eprintln!(
+            "ix_maintain_snapshot: no GA sibling corpus at {} — skipping (exit 0)",
+            corpus.display()
+        );
+        return Ok(());
+    }
+
+    // Metric is IX-local + harness-written (the externally-derived yield ledger).
+    let hits = PathBuf::from("state/thinking-machine/hits.jsonl");
+    let loops_dir = ga_quality.join("loops");
+    let emb_dir = ga_quality.join("query-embeddings");
+    let run_at = chrono::Utc::now().to_rfc3339();
+
+    let inputs = MaintainInputs {
+        hits_path: &hits,
+        corpus_dir: &corpus,
+        loops_dir: Some(&loops_dir),
+        query_embeddings_dir: Some(&emb_dir),
+        iteration: None, // whole-history advisory (Phase 1) — scheduled, not per-iteration
+        run_at: &run_at,
+    };
+
+    let conn = ix_duck::open_bench()?;
+    // fail-closed: ga present but a lens errors (unreadable corpus, malformed JSON) → the `?`
+    // propagates and main returns Err ⇒ nonzero exit, and no snapshot is written.
+    let verdict = maintain::evaluate(&conn, &MaintainConfig::default(), &inputs)?;
+
+    // Reuse maintain_trend over the IX-local append-only ledger for the convergence rollup.
+    let ledger = PathBuf::from("state/thinking-machine/maintain-gate.jsonl");
+    let trend = maintain::maintain_trend(&conn, &ledger)?;
+
+    let snapshot = maintain::build_snapshot(&verdict, &trend);
+    maintain::write_snapshot_atomic(&snapshot, &out)?;
+
+    eprintln!(
+        "ix_maintain_snapshot: {} ({}) → {}",
+        snapshot.status,
+        snapshot.oracle_status,
+        out.display()
+    );
+    Ok(())
+}

--- a/crates/ix-duck/examples/ix_maintain_snapshot.rs
+++ b/crates/ix-duck/examples/ix_maintain_snapshot.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = std::env::args()
         .nth(1)
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("state/quality/maintain-verdict/last.json"));
+        .unwrap_or_else(|| PathBuf::from("state/quality/maintain-gate/last.json"));
 
     let ga = ga_root();
     let ga_quality = ga.join("state/quality");

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -648,6 +648,102 @@ pub fn maintain_trend(
     })
 }
 
+/// One lens verdict, flattened for the scorecard snapshot — the tri-state `ok` of a
+/// [`Signal`] rendered as a coarse `"ok" | "bad" | "unknown"` string so a dashboard reads
+/// it without re-encoding `Option<bool>`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SnapshotSignal {
+    pub lens: String,
+    pub status: String,
+    pub detail: String,
+}
+
+/// A **current-verdict** snapshot in the `ga/state/quality` scorecard shape: the latest
+/// hexavalent maintain verdict plus a [`maintain_trend`] rollup, so a dashboard reads ONE
+/// file instead of re-deriving the verdict from the append-only ledger. Carries a freshness
+/// `timestamp` (a stale snapshot must never read as green) and a coarse `oracle_status`
+/// alongside the raw hexavalent `status` (richer than the scorecard's three states).
+///
+/// Phase A writes this to the IX tree (**formats-not-coupling** — no GA-tree write here);
+/// Phase B federates it into `ga/state/quality`. Advisory until Phase 3b.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerdictSnapshot {
+    pub schema_version: String,
+    /// Freshness — RFC3339 (mirrors `run_at`). Consumers compare this so stale never reads green.
+    pub timestamp: String,
+    /// Scorecard oracle status: `ok | warn | error`, mapped from the hexavalent verdict.
+    pub oracle_status: String,
+    /// The raw hexavalent verdict (T/P/U/D/F/C) — richer than `oracle_status`.
+    pub status: String,
+    /// `accept | reject | escalate`.
+    pub decision: String,
+    /// Scorecard metric: the externally-derived yield delta (`0.0` when no metric evidence —
+    /// the verdict's own `signals`/`oracle_status` carry the "no evidence" nuance).
+    pub metric_value: f64,
+    pub summary: String,
+    /// Per-signal lens verdicts (metric / guardrail / convergence / drift / provenance).
+    pub signals: Vec<SnapshotSignal>,
+    /// Convergence rollup over the append-only verdict ledger (reuses [`maintain_trend`]).
+    pub maintain_trend: TrendSummary,
+}
+
+/// Map the hexavalent verdict to the scorecard's coarse oracle status: accept→`ok`,
+/// accept-with-flags / escalate→`warn`, reject→`error`.
+fn oracle_status(hex: &str) -> &'static str {
+    match hex {
+        "T" => "ok",
+        "P" | "U" | "D" => "warn",
+        "F" | "C" => "error",
+        _ => "warn",
+    }
+}
+
+/// Build a scorecard-shaped [`VerdictSnapshot`] from a fused verdict + a ledger trend rollup.
+/// Pure (no I/O): the caller supplies the trend (via [`maintain_trend`]) and writes the
+/// result with [`write_snapshot_atomic`].
+// @ai:invariant build_snapshot carries the latest hexavalent verdict in a scorecard-shaped envelope (timestamp + oracle_status + metric_value + per-signal) plus a maintain_trend rollup [T:test conf:0.9 src:ix_duck::maintain::tests::snapshot_is_scorecard_shaped]
+pub fn build_snapshot(verdict: &MaintainVerdict, trend: &TrendSummary) -> VerdictSnapshot {
+    let signals = verdict
+        .signals
+        .iter()
+        .map(|s| SnapshotSignal {
+            lens: s.lens.clone(),
+            status: match s.ok {
+                Some(true) => "ok",
+                Some(false) => "bad",
+                None => "unknown",
+            }
+            .to_string(),
+            detail: s.detail.clone(),
+        })
+        .collect();
+    VerdictSnapshot {
+        schema_version: "maintain-verdict-snapshot.v0.1".into(),
+        timestamp: verdict.run_at.clone(),
+        oracle_status: oracle_status(&verdict.status).into(),
+        status: verdict.status.clone(),
+        decision: verdict.decision.clone(),
+        metric_value: verdict.metric_delta.unwrap_or(0.0),
+        summary: verdict.reason.clone(),
+        signals,
+        maintain_trend: trend.clone(),
+    }
+}
+
+/// Write the snapshot **atomically** (temp file in the same dir + rename) so a concurrent
+/// reader never sees a half-written scorecard. `rename` is atomic on the same filesystem and
+/// replaces an existing target on both Unix and Windows.
+pub fn write_snapshot_atomic(snapshot: &VerdictSnapshot, path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(snapshot).map_err(std::io::Error::other)?;
+    // Temp lives beside the target so the rename stays on one filesystem (atomic).
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json.as_bytes())?;
+    std::fs::rename(&tmp, path)
+}
+
 #[cfg(all(test, feature = "duck"))]
 mod tests {
     use super::*;
@@ -687,6 +783,57 @@ mod tests {
         assert_eq!(v.decision, "accept");
         assert_eq!(exit_code(&v.status), 0);
         assert!(v.metric_delta.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn snapshot_is_scorecard_shaped() {
+        let conn = crate::open_bench().unwrap();
+        let hits = fx("hits_up.jsonl");
+        let corpus = fx("corpus-pass");
+        let v = evaluate(&conn, &MaintainConfig::default(), &inputs(&hits, &corpus)).unwrap();
+        assert_eq!(v.status, "T", "precondition: a clean accept");
+
+        let trend = TrendSummary {
+            total: 3,
+            accepts: 2,
+            ..Default::default()
+        };
+        let snap = build_snapshot(&v, &trend);
+
+        // Scorecard envelope: freshness timestamp mirrors run_at, coarse oracle status maps
+        // from the hexavalent verdict, and the raw hexavalent verdict is preserved.
+        assert_eq!(snap.timestamp, v.run_at, "freshness stamp = run_at");
+        assert_eq!(snap.oracle_status, "ok", "T maps to ok");
+        assert_eq!(snap.status, "T");
+        assert_eq!(snap.decision, "accept");
+        assert!(snap.metric_value > 0.0, "metric carried into scorecard");
+        assert!(!snap.summary.is_empty());
+        // Per-signal lens verdicts are carried (metric + guardrail at minimum).
+        assert!(snap.signals.iter().any(|s| s.lens == "metric" && s.status == "ok"));
+        assert!(snap.signals.iter().any(|s| s.lens == "guardrail"));
+        // The maintain_trend rollup rides along.
+        assert_eq!(snap.maintain_trend.total, 3);
+
+        // A reject maps to the error oracle state (stale/red never reads green).
+        let vr = evaluate(
+            &conn,
+            &MaintainConfig::default(),
+            &inputs(&hits, &fx("corpus-regression")),
+        )
+        .unwrap();
+        assert_eq!(vr.status, "C");
+        assert_eq!(build_snapshot(&vr, &trend).oracle_status, "error");
+
+        // Atomic write round-trips (into a fresh, not-yet-existing subdir) and the bytes
+        // parse as the scorecard JSON.
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("maintain-verdict").join("last.json");
+        write_snapshot_atomic(&snap, &out).unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&out).unwrap()).unwrap();
+        assert_eq!(parsed["oracle_status"], "ok");
+        assert_eq!(parsed["status"], "T");
+        assert!(parsed["timestamp"].is_string());
     }
 
     #[test]

--- a/crates/ix-duck/src/maintain.rs
+++ b/crates/ix-duck/src/maintain.rs
@@ -658,30 +658,43 @@ pub struct SnapshotSignal {
     pub detail: String,
 }
 
-/// A **current-verdict** snapshot in the `ga/state/quality` scorecard shape: the latest
-/// hexavalent maintain verdict plus a [`maintain_trend`] rollup, so a dashboard reads ONE
-/// file instead of re-deriving the verdict from the append-only ledger. Carries a freshness
-/// `timestamp` (a stale snapshot must never read as green) and a coarse `oracle_status`
-/// alongside the raw hexavalent `status` (richer than the scorecard's three states).
+/// A **current-verdict** snapshot in GA's canonical dashboard-envelope shape
+/// (`ga/docs/contracts/quality-snapshot.schema.json`): the GA-required envelope fields
+/// (`domain`/`emitted_at`/`metric_name`/`metric_value`/`oracle_status`/`summary`) PLUS the
+/// maintain-specific fused verdict (`advisory`/`status`/`decision`/`signals`/`maintain_trend`),
+/// carried as additive pass-through fields the envelope permits. Holds the latest hexavalent
+/// verdict plus a [`maintain_trend`] rollup, so a dashboard reads ONE file instead of
+/// re-deriving the verdict from the append-only ledger. `emitted_at` is the freshness stamp (a
+/// stale snapshot must never read green); `oracle_status` is the coarse traffic-light, `status`
+/// the richer hexavalent verdict.
 ///
 /// Phase A writes this to the IX tree (**formats-not-coupling** — no GA-tree write here);
-/// Phase B federates it into `ga/state/quality`. Advisory until Phase 3b.
+/// Phase B federates it into `ga/state/quality/maintain-gate`. **Advisory until Phase 3b**.
 #[derive(Debug, Clone, Serialize)]
 pub struct VerdictSnapshot {
     pub schema_version: String,
-    /// Freshness — RFC3339 (mirrors `run_at`). Consumers compare this so stale never reads green.
-    pub timestamp: String,
-    /// Scorecard oracle status: `ok | warn | error`, mapped from the hexavalent verdict.
-    pub oracle_status: String,
-    /// The raw hexavalent verdict (T/P/U/D/F/C) — richer than `oracle_status`.
-    pub status: String,
-    /// `accept | reject | escalate`.
-    pub decision: String,
-    /// Scorecard metric: the externally-derived yield delta (`0.0` when no metric evidence —
-    /// the verdict's own `signals`/`oracle_status` carry the "no evidence" nuance).
+    /// Producer slug — the GA envelope `domain` (lower-kebab). Matches the registry domain + dir.
+    pub domain: String,
+    /// Freshness — RFC3339 (mirrors `run_at`). The GA envelope's `emitted_at`; consumers compare
+    /// it so stale never reads green.
+    pub emitted_at: String,
+    /// Headline metric identifier (GA envelope `metric_name`).
+    pub metric_name: String,
+    /// Headline metric value (GA envelope) — the externally-derived yield delta (`0.0` when no
+    /// metric evidence; the `signals`/`oracle_status` carry the "no evidence" nuance).
     pub metric_value: f64,
+    /// Traffic-light state: `ok | warn | error`, mapped from the hexavalent verdict (GA envelope).
+    pub oracle_status: String,
+    /// One-line human summary (GA envelope).
     pub summary: String,
-    /// Per-signal lens verdicts (metric / guardrail / convergence / drift / provenance).
+    /// Non-binding marker — `true` until IX Phase-3b makes the verdict gating (maintain-specific).
+    pub advisory: bool,
+    /// The raw hexavalent verdict (T/P/U/D/F/C) — richer than `oracle_status` (maintain-specific).
+    pub status: String,
+    /// `accept | reject | escalate` (maintain-specific).
+    pub decision: String,
+    /// Per-signal lens verdicts — locked sub-signal keys (metric / guardrail / convergence /
+    /// drift / provenance). The GA-readable cross-signal contract surface.
     pub signals: Vec<SnapshotSignal>,
     /// Convergence rollup over the append-only verdict ledger (reuses [`maintain_trend`]).
     pub maintain_trend: TrendSummary,
@@ -698,10 +711,10 @@ fn oracle_status(hex: &str) -> &'static str {
     }
 }
 
-/// Build a scorecard-shaped [`VerdictSnapshot`] from a fused verdict + a ledger trend rollup.
+/// Build a GA-envelope-shaped [`VerdictSnapshot`] from a fused verdict + a ledger trend rollup.
 /// Pure (no I/O): the caller supplies the trend (via [`maintain_trend`]) and writes the
 /// result with [`write_snapshot_atomic`].
-// @ai:invariant build_snapshot carries the latest hexavalent verdict in a scorecard-shaped envelope (timestamp + oracle_status + metric_value + per-signal) plus a maintain_trend rollup [T:test conf:0.9 src:ix_duck::maintain::tests::snapshot_is_scorecard_shaped]
+// @ai:invariant build_snapshot emits GA's canonical dashboard envelope (domain + emitted_at + metric_name + metric_value + oracle_status + summary) plus the maintain verdict (advisory + hexavalent status + per-signal + maintain_trend) [T:test conf:0.9 src:ix_duck::maintain::tests::snapshot_is_scorecard_shaped]
 pub fn build_snapshot(verdict: &MaintainVerdict, trend: &TrendSummary) -> VerdictSnapshot {
     let signals = verdict
         .signals
@@ -719,12 +732,15 @@ pub fn build_snapshot(verdict: &MaintainVerdict, trend: &TrendSummary) -> Verdic
         .collect();
     VerdictSnapshot {
         schema_version: "maintain-verdict-snapshot.v0.1".into(),
-        timestamp: verdict.run_at.clone(),
+        domain: "maintain-gate".into(),
+        emitted_at: verdict.run_at.clone(),
+        metric_name: "maintain_yield_delta".into(),
+        metric_value: verdict.metric_delta.unwrap_or(0.0),
         oracle_status: oracle_status(&verdict.status).into(),
+        summary: verdict.reason.clone(),
+        advisory: true,
         status: verdict.status.clone(),
         decision: verdict.decision.clone(),
-        metric_value: verdict.metric_delta.unwrap_or(0.0),
-        summary: verdict.reason.clone(),
         signals,
         maintain_trend: trend.clone(),
     }
@@ -800,14 +816,18 @@ mod tests {
         };
         let snap = build_snapshot(&v, &trend);
 
-        // Scorecard envelope: freshness timestamp mirrors run_at, coarse oracle status maps
-        // from the hexavalent verdict, and the raw hexavalent verdict is preserved.
-        assert_eq!(snap.timestamp, v.run_at, "freshness stamp = run_at");
+        // GA envelope required fields: domain/emitted_at/metric_name/metric_value/oracle_status/
+        // summary. emitted_at is the freshness stamp; oracle_status maps from the hexavalent verdict.
+        assert_eq!(snap.domain, "maintain-gate");
+        assert_eq!(snap.emitted_at, v.run_at, "freshness stamp = run_at");
+        assert_eq!(snap.metric_name, "maintain_yield_delta");
+        assert!(snap.metric_value > 0.0, "headline metric carried");
         assert_eq!(snap.oracle_status, "ok", "T maps to ok");
+        assert!(!snap.summary.is_empty());
+        // Maintain-specific: advisory marker + raw hexavalent verdict + decision.
+        assert!(snap.advisory, "non-binding until Phase-3b");
         assert_eq!(snap.status, "T");
         assert_eq!(snap.decision, "accept");
-        assert!(snap.metric_value > 0.0, "metric carried into scorecard");
-        assert!(!snap.summary.is_empty());
         // Per-signal lens verdicts are carried (metric + guardrail at minimum).
         assert!(snap.signals.iter().any(|s| s.lens == "metric" && s.status == "ok"));
         assert!(snap.signals.iter().any(|s| s.lens == "guardrail"));
@@ -824,16 +844,18 @@ mod tests {
         assert_eq!(vr.status, "C");
         assert_eq!(build_snapshot(&vr, &trend).oracle_status, "error");
 
-        // Atomic write round-trips (into a fresh, not-yet-existing subdir) and the bytes
-        // parse as the scorecard JSON.
+        // Atomic write round-trips (into a fresh, not-yet-existing subdir) and the bytes parse
+        // as the GA envelope (required fields present).
         let dir = tempfile::tempdir().unwrap();
-        let out = dir.path().join("maintain-verdict").join("last.json");
+        let out = dir.path().join("maintain-gate").join("last.json");
         write_snapshot_atomic(&snap, &out).unwrap();
         let parsed: serde_json::Value =
             serde_json::from_slice(&std::fs::read(&out).unwrap()).unwrap();
+        assert_eq!(parsed["domain"], "maintain-gate");
         assert_eq!(parsed["oracle_status"], "ok");
         assert_eq!(parsed["status"], "T");
-        assert!(parsed["timestamp"].is_string());
+        assert!(parsed["emitted_at"].is_string());
+        assert!(parsed["metric_name"].is_string());
     }
 
     #[test]


### PR DESCRIPTION
## Phase A — the tracer-bullet producer (closes #145)

The prerequisite for the GA maintain-verdict tile. A scheduled IX job fuses the DuckDB+IX maintain lenses over the **live `../ga`** telemetry and emits a **current-verdict snapshot** in the `ga/state/quality` scorecard shape (latest hexavalent verdict + a `maintain_trend` rollup). End-to-end on the IX side: **GA data → fused verdict → snapshot file.** Without this producer the append-only ledger has only manual entries and everything downstream is green-but-dead.

### What's here
- **`ix-duck::maintain`** — `VerdictSnapshot` (scorecard-shaped: `timestamp`/`oracle_status`/`metric_value`/`summary`/per-signal), pure `build_snapshot`, and `write_snapshot_atomic` (temp + rename). Reuses `maintain_trend` for the convergence rollup.
- **`examples/ix_maintain_snapshot`** — the producer CLI. **absent-ga → skip (exit 0)**; **ga present + lens read error → fail-closed** (nonzero, no write); **atomic** write; writes **ONLY the IX tree** (formats-not-coupling — Phase B federates into `ga/state/quality`).
- **`.github/workflows/maintain-gate-nightly.yml`** — schedule/`workflow_dispatch`, `permissions: contents: read`, read-only `ga` sibling checkout, bundled engine + cache (mirrors `chatbot-trace-regression-nightly.yml`). **Advisory until Phase 3b** — never gates a merge.
- **`@ai:invariant`** test-bound to the snapshot shape (`snapshot_is_scorecard_shaped`).

### Acceptance criteria (all verified)
- [x] Nightly produces a fresh, schema-valid snapshot from live `../ga` data — proved live (verdict `U`, guardrail read the 1 real chatbot-qa regression, convergence/drift read live ga dirs).
- [x] Scorecard-shaped: `timestamp`, status/metric, `summary`, per-signal (metric/guardrail/convergence/drift).
- [x] Atomic write; absent-ga → skip (exit 0, no write — verified); ga present + read error → fail-closed (`?` propagation → nonzero exit).
- [x] `@ai:invariant` test-bound; `cargo test`/`clippy -p ix-duck --features duck` green (20 tests pass, clippy clean).

### Discipline notes
- **Advisory until Phase-3b** — the verdict is not presented as binding.
- **Formats-not-coupling** — no GA-tree write here (that's Phase B / ix#146 + ga#445).
- Snapshot carries a freshness `timestamp` so **stale never reads as green**.

Plan: `docs/plans/2026-06-20-001-feat-ga-maintain-verdict-tile-plan.md` (#144) · Decision: `docs/adr/0002-ga-consumes-maintain-verdict-not-an-ix-duck-gate.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)