### PR TITLE
fix(ci): make rustfmt advisory in verify.ps1 (unblock the Agent-Blackbox gate)

### DIFF
--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -15,5 +15,14 @@ function Invoke-Checked {
     }
 }
 
-Invoke-Checked 'cargo' @('fmt', '--all', '--check')
+# rustfmt is ADVISORY, not a gate. Several crates intentionally use a terser
+# hand style (e.g. ix-duck — see CLAUDE.md), so `cargo fmt --all --check` reports
+# diffs repo-wide and would fail EVERY run. Run it for visibility but never block
+# on it; the hard gate is the test suite below. (Before this, the Agent-Blackbox
+# `risk-report` verdict failed on every PR purely from this fmt skew.)
+& cargo fmt --all --check
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning 'rustfmt --check reported diffs (advisory; not blocking — intentional terse style, see CLAUDE.md).'
+}
+
 Invoke-Checked 'cargo' @('test', '--workspace')


### PR DESCRIPTION
## The permanently-red gate

The Agent-Blackbox **`risk-report`** verdict has failed on **every PR this session** (and well before). Root cause: its evidence step runs `pwsh scripts/verify.ps1`, whose **first line** was `cargo fmt --all --check`. Several crates deliberately use a terser hand style (`ix-duck` etc., per CLAUDE.md), so `--check` reports diffs **repo-wide**, exits nonzero, and `verify.ps1` (`$ErrorActionPreference='Stop'` + an explicit-throw helper) **threw before ever reaching `cargo test`** → `verify_exit=1` → verdict `fail`. The gate was permanently red *and* never actually exercised the test suite.

## Fix

Make rustfmt **advisory**: run `cargo fmt --all --check` for visibility but `Write-Warning` instead of throwing on diffs. The hard gate stays `cargo test --workspace`.

This is the right fix rather than `cargo fmt`-ing the tree (which would fight the intentional terse style the repo maintains). Works identically locally and in CI — no base-ref / changed-files plumbing needed.

## Verified
- `verify.ps1` parses (PowerShell scriptblock check).
- The fmt-diff path **warns + continues** — confirmed a native nonzero exit does not throw under `ErrorActionPreference='Stop'` (exactly why the original wrapped cargo in an explicit-throw helper).

Effect: `risk-report` will reflect the *test* result, not rustfmt noise. (Other risk-report surfaces — harness-audit score, enforce-verdict — are unchanged; this only removes the fmt false-failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)