### PR TITLE
refactor(ix-duck): finish the source seam — migrate chatbot, lift ArtifactLens

### DIFF
--- a/crates/ix-duck/src/chatbot.rs
+++ b/crates/ix-duck/src/chatbot.rs
@@ -19,6 +19,8 @@ use std::path::{Path, PathBuf};
 use duckdb::Connection;
 use serde::Serialize;
 
+use crate::source::{self, Files};
+
 /// Errors from the flight recorder: corpus I/O (fail-closed) vs DuckDB.
 #[derive(Debug)]
 pub enum ChatbotError {
@@ -46,6 +48,17 @@ impl From<std::io::Error> for ChatbotError {
 impl From<duckdb::Error> for ChatbotError {
     fn from(e: duckdb::Error) -> Self {
         ChatbotError::Duck(e)
+    }
+}
+/// The shared artifact-source error maps onto the lens's own fail-closed taxonomy,
+/// so the public `ChatbotError` surface is unchanged while enumeration goes through
+/// [`source::select_files`].
+impl From<source::SourceError> for ChatbotError {
+    fn from(e: source::SourceError) -> Self {
+        match e {
+            source::SourceError::Io(e) => ChatbotError::Io(e),
+            source::SourceError::Duck(e) => ChatbotError::Duck(e),
+        }
     }
 }
 
@@ -84,6 +97,12 @@ pub struct Regression {
 }
 
 // ---- corpus enumeration ---------------------------------------------------
+//
+// The chatbot corpus is one level deeper than the flat lenses: a
+// `golden-traces/<promptId>/<leaf>` tree, not a single dir of dated files. So the
+// traversal stays here (resolving prompt subdirs), but the per-dir listing,
+// sorting, escaping and SQL-list building all route through `source` — there is no
+// chatbot-private `sql_list` or per-file match loop anymore.
 
 fn golden_traces_dir(corpus_dir: &Path) -> PathBuf {
     corpus_dir.join("golden-traces")
@@ -93,12 +112,16 @@ fn golden_traces_dir(corpus_dir: &Path) -> PathBuf {
 /// `_signature.json`). Explicit enumeration (vs a wildcard handed to DuckDB) makes
 /// the "absent corpus → skip" path real and keeps untrusted input bounded.
 ///
+/// The nested traversal (resolving each prompt subdir) is the chatbot-specific bit;
+/// the per-dir listing + sort + match runs through [`source::select_files`], so the
+/// list-building and escaping live in one place across all lenses.
+///
 /// Fail-closed: an absent `golden-traces` dir (`NotFound`) returns an empty list
 /// (→ skipped), but any *other* I/O error on a present corpus (permissions, broken
 /// mount) is propagated — never silently treated as absent.
 fn collect(
     corpus_dir: &Path,
-    predicate: impl Fn(&str) -> bool,
+    matches: fn(&str) -> bool,
 ) -> Result<Vec<PathBuf>, ChatbotError> {
     let mut out = Vec::new();
     let gt = golden_traces_dir(corpus_dir);
@@ -112,16 +135,10 @@ fn collect(
         if !p.is_dir() {
             continue;
         }
-        for f in std::fs::read_dir(&p)? {
-            let fp = f?.path();
-            if fp
-                .file_name()
-                .and_then(|n| n.to_str())
-                .is_some_and(&predicate)
-            {
-                out.push(fp);
-            }
-        }
+        // Per-prompt-dir listing goes through the shared selector (filter + per-dir
+        // sort live in `source`); we concatenate and re-sort the union below so the
+        // overall ordering is identical to the old flat `out.sort()`.
+        out.extend(source::select_files(Files { dir: &p, matches })?);
     }
     out.sort();
     Ok(out)
@@ -133,19 +150,6 @@ fn run_files(corpus_dir: &Path) -> Result<Vec<PathBuf>, ChatbotError> {
 
 fn signature_files(corpus_dir: &Path) -> Result<Vec<PathBuf>, ChatbotError> {
     collect(corpus_dir, |n| n == "_signature.json")
-}
-
-/// Render a slice of paths as a DuckDB list literal `['p1', 'p2', …]`, POSIX-slashed
-/// and single-quote-escaped (paths never contain `://`, validated by the caller).
-fn sql_list(paths: &[PathBuf]) -> String {
-    let items: Vec<String> = paths
-        .iter()
-        .map(|p| {
-            let s = p.to_string_lossy().replace('\\', "/").replace('\'', "''");
-            format!("'{s}'")
-        })
-        .collect();
-    format!("[{}]", items.join(", "))
 }
 
 // ---- Slice A: trace warehouse ---------------------------------------------
@@ -164,7 +168,7 @@ pub fn build_traces(conn: &Connection, corpus_dir: &Path) -> Result<usize, Chatb
         )?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = source::sql_list(&files);
     conn.execute_batch(&format!(
         // Read `response.*` via `json_extract(to_json(response), …)` rather than struct-field
         // access: a subfield absent from EVERY trace file would otherwise be a bind-time
@@ -292,7 +296,7 @@ pub fn build_grounding(conn: &Connection, corpus_dir: &Path) -> Result<usize, Ch
         conn.execute_batch(&format!("CREATE OR REPLACE TABLE chatbot_grounding ({cols});"))?;
         return Ok(0);
     }
-    let list = sql_list(&files);
+    let list = source::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_grounding AS
          WITH g AS (
@@ -475,7 +479,7 @@ fn build_signatures(conn: &Connection, corpus_dir: &Path) -> Result<(), ChatbotE
         )?;
         return Ok(());
     }
-    let list = sql_list(&files);
+    let list = source::sql_list(&files);
     conn.execute_batch(&format!(
         "CREATE OR REPLACE TABLE chatbot_signatures AS
          SELECT t.promptId AS prompt_id,

--- a/crates/ix-duck/src/loops.rs
+++ b/crates/ix-duck/src/loops.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 use duckdb::Connection;
 
-use crate::source::{self, Col, Files};
+use crate::source::{self, ArtifactLens, Col};
 
 /// Errors from the loop lens — the shared artifact-source error
 /// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
@@ -47,16 +47,19 @@ fn is_iterations_jsonl(name: &str) -> bool {
     name.ends_with(".iterations.jsonl")
 }
 
+/// The loop lens is a flat artifact lens: a dir of `*.iterations.jsonl` → the
+/// `loop_iterations` table via [`LOOP_SPEC`].
+const LENS: ArtifactLens = ArtifactLens {
+    table: "loop_iterations",
+    matches: is_iterations_jsonl,
+    spec: LOOP_SPEC,
+};
+
 /// Build `loop_iterations` (one row per loop × iteration). Returns the row count
 /// (including any seed/test rows); 0 when the directory is absent/empty.
 // @ai:invariant build_loop_iterations creates loop_iterations with one row per JSONL line across every *.iterations.jsonl in loops_dir [T:test conf:0.9 src:ix_duck::loops::tests::rows_one_per_iteration]
 pub fn build_loop_iterations(conn: &Connection, loops_dir: &Path) -> Result<usize, LoopError> {
-    source::materialize(
-        conn,
-        "loop_iterations",
-        Files { dir: loops_dir, matches: is_iterations_jsonl },
-        LOOP_SPEC,
-    )
+    LENS.materialize(conn, loops_dir)
 }
 
 /// Real (non-seed, non-test) rows only — the predicate every analysis shares so a

--- a/crates/ix-duck/src/ood.rs
+++ b/crates/ix-duck/src/ood.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 
 use duckdb::Connection;
 
-use crate::source::{self, Col, Files};
+use crate::source::{self, ArtifactLens, Col};
 
 /// Errors from the OOD lens — the shared artifact-source error
 /// ([`crate::source::SourceError`]); aliased so the lens's public API keeps its name.
@@ -47,16 +47,19 @@ fn is_jsonl(name: &str) -> bool {
     name.ends_with(".jsonl")
 }
 
+/// The OOD lens is a flat artifact lens: a dir of `*.jsonl` query-embedding logs →
+/// the `query_embeddings` table via [`EMBEDDING_SPEC`].
+const LENS: ArtifactLens = ArtifactLens {
+    table: "query_embeddings",
+    matches: is_jsonl,
+    spec: EMBEDDING_SPEC,
+};
+
 /// Build `query_embeddings` (one row per routed query). Returns the row count;
 /// 0 when the directory is absent/empty.
 // @ai:invariant build_query_embeddings creates query_embeddings with one row per JSONL line, embedding as DOUBLE[] [T:test conf:0.9 src:ix_duck::ood::tests::rows_one_per_query]
 pub fn build_query_embeddings(conn: &Connection, dir: &Path) -> Result<usize, OodError> {
-    source::materialize(
-        conn,
-        "query_embeddings",
-        Files { dir, matches: is_jsonl },
-        EMBEDDING_SPEC,
-    )
+    LENS.materialize(conn, dir)
 }
 
 /// Mean top-`k` cosine to nearest neighbours, per **distinct** query embedding

--- a/crates/ix-duck/src/routing.rs
+++ b/crates/ix-duck/src/routing.rs
@@ -42,6 +42,11 @@ const OVERALL_SPEC: &[Col] = &[
 /// per-intent row count; 0 when the directory is absent/empty.
 // @ai:invariant build_routing_evals creates routing_evals with one row per (run, intent) parsed from each routing-eval-*.json perIntent map [T:test conf:0.9 src:ix_duck::routing::tests::evals_row_per_run_intent]
 pub fn build_routing_evals(conn: &Connection, quality_dir: &Path) -> Result<usize, RoutingError> {
+    // Interface stays explicit here (not an `ArtifactLens`) because this lens emits TWO
+    // tables from ONE directory read: the flat `routing_overall` AND the `perIntent`
+    // map-explode share a single `select_files` enumeration. An `ArtifactLens` would
+    // re-read the dir per table; selecting once and feeding both via `materialize_files`
+    // is the correct shape.
     let files = source::select_files(Files { dir: quality_dir, matches: is_routing_eval })?;
     // routing_overall is a flat projection → the deep artifact-source path owns the safe
     // read + empty-fallback (it can't drift back into struct-access / coalesce-0).

--- a/crates/ix-duck/src/source.rs
+++ b/crates/ix-duck/src/source.rs
@@ -188,6 +188,34 @@ pub fn materialize(
     materialize_files(conn, table, &files, spec)
 }
 
+/// A flat artifact lens: the *whole* shape of "read a dir of matching files → project a
+/// fixed set of columns → a named table" captured as one value, so a lens declares it
+/// once as a `const` and the read path is a single `.materialize(conn, dir)` call.
+///
+/// This makes the implicit lens shape — directory + file predicate + column spec →
+/// table — explicit and reusable. The flat lenses (`loops`, `ood`) and routing's
+/// top-line `routing_overall` are exactly this. Lenses whose projection isn't flat
+/// keep a bespoke `SELECT` (routing's `perIntent` map-explode, chatbot's nested
+/// `golden-traces` + grounding/signature shapes) and reuse [`select_files`] /
+/// [`sql_list`] / [`READ_FLAGS`] directly instead.
+#[derive(Clone, Copy)]
+pub struct ArtifactLens {
+    /// The DuckDB table this lens materializes into.
+    pub table: &'static str,
+    /// Filename predicate selecting the artifact files inside the lens directory.
+    pub matches: fn(&str) -> bool,
+    /// The flat column projection (owns the absence-as-NULL-safe read invariant).
+    pub spec: &'static [Col],
+}
+
+impl ArtifactLens {
+    /// Materialize the lens's table from `dir`. Absent/empty dir → an empty table with
+    /// the declared schema (graceful degrade). Returns the row count.
+    pub fn materialize(&self, conn: &Connection, dir: &Path) -> Result<usize, SourceError> {
+        materialize(conn, self.table, Files { dir, matches: self.matches }, self.spec)
+    }
+}
+
 #[cfg(all(test, feature = "duck"))]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What & why

Architecture review **Candidate 2**: finish the `crates/ix-duck/src/source.rs` artifact-source seam. `source.rs` was already a real seam — `loops.rs`, `ood.rs`, `routing.rs` lean on it (`select_files` / `sql_list` / `materialize`, the absence-as-NULL-safe projection over `read_json_auto`). But `chatbot.rs` re-implemented file enumeration plus a `sql_list()` that was **byte-identical** to `source::sql_list()`, and the "read dir → materialize → query" lens shape was implicit/copy-pasted.

## Behavior preserved

- `cargo test -p ix-duck --features duck` → **116 passed, 0 failed — unchanged** (the regression-gate tests are the behavior oracle).
- `cargo clippy -p ix-duck --features duck --all-targets -- -D warnings` → clean.
- `cargo build -p ix-duck --features duck --examples` → builds; `ix_chatbot_lens` / `ix_routing_lens` / `ix_ood_lens` run (graceful-degrade on absent corpus, as expected).
- Chatbot's emitted SQL is identical (only the file-enumeration / list-building seam changed, never the `SELECT` text).

## What migrated to `source`

- **chatbot.rs** dropped its private `sql_list()` (identical to `source::sql_list()`) and its per-file match loop. Enumeration now routes the per-prompt-dir listing + sort + filter + escaping through `source::select_files` / `source::sql_list`. The nested `golden-traces/<promptId>/<leaf>` traversal stays (it is genuinely one level deeper than the flat lenses), but the list-building no longer copy-pastes `source`. A `From<SourceError> for ChatbotError` keeps the public error surface unchanged.

## ArtifactLens shape

- New `source::ArtifactLens { table, matches, spec }` captures the implicit lens shape — *directory + file predicate + flat column spec → table* — as one value with a `.materialize(conn, dir)` method.
- **loops.rs** and **ood.rs** now declare a `const LENS: ArtifactLens` and read through it (the clean flat fits).

## Left explicit (with reasons, in-comment)

- **routing.rs**: emits **two** tables from **one** dir read — flat `routing_overall` + the `perIntent` map-explode share a single `select_files` enumeration. An `ArtifactLens` would re-read the dir per table; selecting once and feeding both via `materialize_files` is the correct shape. *Interface stays explicit here.*
- **chatbot.rs**: nested corpus + three bespoke `SELECT`s (traces / grounding / signatures). Reuses `select_files` / `sql_list` directly rather than the flat-spec lens.

## Constraints honored

- `chatbot::baseline_hash` (FNV-1a) left untouched (parallel stream owns hash dedup).
- Did **not** touch maintain.rs / git.rs / provenance.rs / verdict_fusion.rs / evidence.rs / ledger.rs / hash.rs.
- Public lens entry points (`chatbot::check_regressions`, `routing::*`, `loops::*`, `ood::*` called by maintain.rs) unchanged.
- All `@ai:` annotation `src:` test paths remain reachable (no test renamed/removed).

Files touched: `chatbot.rs`, `loops.rs`, `ood.rs`, `routing.rs`, `source.rs` (+28 LoC for `ArtifactLens`); net 84 insertions / 41 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)