### PR TITLE
refactor(ix-duck): decompose the maintain gate into deep modules (provenance/git/verdict_fusion/evidence/ledger)

### DIFF
--- a/crates/ix-duck/src/maintain/evidence.rs
+++ b/crates/ix-duck/src/maintain/evidence.rs
@@ -1,0 +1,34 @@
+//! Evidence provenance — hash the *inputs*, not just the verdict line, so a later audit
+//! can detect a swapped input (input provenance > verdict provenance). The metric source
+//! is content-hashed via [`super::hash`]; the guardrail carries its baseline ref; and an
+//! iteration scope contributes its verified `git:<sha>` as provenance.
+
+use super::hash;
+use super::{Evidence, IterationScope, MaintainInputs};
+use crate::chatbot::GateReport;
+
+/// Build the evidence vec for one verdict: metric (content-hashed `hits.jsonl`),
+/// guardrail-baseline (the gate's baseline ref), and — when scoped — the iteration commit.
+pub(crate) fn build_evidence(inputs: &MaintainInputs, report: &GateReport) -> Vec<Evidence> {
+    let mut evidence = vec![
+        Evidence {
+            kind: "metric".into(),
+            source: inputs.hits_path.to_string_lossy().into_owned(),
+            hash: hash::fnv1a64_file(inputs.hits_path).unwrap_or_else(|| "absent".into()),
+        },
+        Evidence {
+            kind: "guardrail-baseline".into(),
+            source: inputs.corpus_dir.to_string_lossy().into_owned(),
+            hash: report.baseline_ref.clone(),
+        },
+    ];
+    // The correlation key IS provenance — it ties this verdict to a verified commit.
+    if let Some(IterationScope { loop_id, commit_sha, repo_dir }) = &inputs.iteration {
+        evidence.push(Evidence {
+            kind: format!("iteration-commit:{loop_id}"),
+            source: repo_dir.to_string_lossy().into_owned(),
+            hash: format!("git:{commit_sha}"),
+        });
+    }
+    evidence
+}

--- a/crates/ix-duck/src/maintain/git.rs
+++ b/crates/ix-duck/src/maintain/git.rs
@@ -1,0 +1,173 @@
+//! Ports & adapters for the two git questions the provenance check asks: *does this
+//! commit object exist?* and *are tracked files dirty?* The [`Git`] trait is the port;
+//! [`RealGit`] is the production adapter (shelling out to `git`), and a test-only
+//! `FakeGit` lets the provenance decision be unit-tested without a real repo.
+//!
+//! The decision is kept PURE over the trait ([`commit_check`]), preserving the
+//! three-way distinction that makes the gate fail *correctly*:
+//! - **could-not-run** → [`CommitCheck::Unverifiable`] (a missing-git environment is
+//!   never misreported as a forgery alarm),
+//! - **ran-and-answered-no** → [`CommitCheck::NotACommit`] (forged/wrong sha),
+//! - real-but-dirty-tracked → [`CommitCheck::DirtyTracked`],
+//! - real-and-clean → [`CommitCheck::Verified`].
+//!
+//! Hex-validation comes first, so a `sha` like `--help` can never reach git as a flag.
+
+use std::path::Path;
+
+/// Outcome of externally verifying an iteration's `commit_sha` against real git state.
+/// Distinguishes "git could not answer" from "git says forged" so the gate never reports
+/// a missing-git environment as a forgery alarm, and ignores other agents' untracked WIP
+/// so a shared tree doesn't spuriously fail a valid iteration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum CommitCheck {
+    /// git could not be run at all (not installed / repo error) — we cannot decide.
+    Unverifiable,
+    /// The sha is malformed, or git ran and it is not a real commit object (forged/wrong).
+    NotACommit,
+    /// The commit is real, but TRACKED files have uncommitted edits — the metric may
+    /// reflect work not captured by the sha. (Untracked files are deliberately ignored:
+    /// a multi-agent tree is full of other agents' untracked WIP, which is not ours.)
+    DirtyTracked,
+    /// The commit is real and no tracked files are modified.
+    Verified,
+}
+
+/// The two git questions the provenance check needs, as a port. Each returns `Some`
+/// when git *answered*, `None` when git *could not be run* — preserving the
+/// could-not-run vs. answered-no distinction the verdict depends on.
+pub(crate) trait Git {
+    /// Does `sha^{commit}` resolve to a real commit object in `repo_dir`?
+    /// `Some(true)` = yes, `Some(false)` = ran and no, `None` = git could not run.
+    fn commit_exists(&self, repo_dir: &Path, sha: &str) -> Option<bool>;
+
+    /// Are any TRACKED files modified in `repo_dir` (untracked WIP excluded)?
+    /// `Some(true)` = dirty, `Some(false)` = clean, `None` = git could not run.
+    fn tracked_dirty(&self, repo_dir: &Path) -> Option<bool>;
+}
+
+/// Production adapter: shells out to `git` (`cat-file -e` then
+/// `status --porcelain --untracked-files=no`).
+pub(crate) struct RealGit;
+
+impl Git for RealGit {
+    fn commit_exists(&self, repo_dir: &Path, sha: &str) -> Option<bool> {
+        use std::process::Command;
+        match Command::new("git")
+            .arg("-C")
+            .arg(repo_dir)
+            .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
+            .output()
+        {
+            Err(_) => None, // git couldn't run (≠ "forged")
+            Ok(o) => Some(o.status.success()),
+        }
+    }
+
+    fn tracked_dirty(&self, repo_dir: &Path) -> Option<bool> {
+        use std::process::Command;
+        // `--untracked-files=no` excludes other agents' untracked WIP, so a shared tree
+        // doesn't spuriously fail a valid iteration.
+        match Command::new("git")
+            .arg("-C")
+            .arg(repo_dir)
+            .args(["status", "--porcelain", "--untracked-files=no"])
+            .output()
+        {
+            Ok(o) if o.status.success() => Some(!o.stdout.is_empty()),
+            _ => None,
+        }
+    }
+}
+
+/// Decide [`CommitCheck`] over a [`Git`] port — PURE given the port's answers.
+/// Hex-validates first (so a `sha` like `--help` can't reach git as a flag), then asks
+/// existence, then tracked-dirtiness. A git invocation that fails to *run* (vs answers
+/// "no") is [`CommitCheck::Unverifiable`], not [`CommitCheck::NotACommit`].
+pub(crate) fn commit_check(git: &dyn Git, repo_dir: &Path, sha: &str) -> CommitCheck {
+    let hex = !sha.is_empty() && sha.len() <= 64 && sha.bytes().all(|b| b.is_ascii_hexdigit());
+    if !hex {
+        return CommitCheck::NotACommit;
+    }
+    match git.commit_exists(repo_dir, sha) {
+        None => return CommitCheck::Unverifiable, // git couldn't run
+        Some(false) => return CommitCheck::NotACommit,
+        Some(true) => {}
+    }
+    match git.tracked_dirty(repo_dir) {
+        Some(false) => CommitCheck::Verified,
+        Some(true) => CommitCheck::DirtyTracked,
+        None => CommitCheck::Unverifiable,
+    }
+}
+
+#[cfg(all(test, feature = "duck"))]
+pub(crate) mod fake {
+    use super::*;
+
+    /// A scriptable [`Git`] for unit-testing the provenance decision without a real repo.
+    /// `exists`/`dirty` are the canned answers (`None` models "git could not run").
+    pub(crate) struct FakeGit {
+        pub exists: Option<bool>,
+        pub dirty: Option<bool>,
+    }
+
+    impl FakeGit {
+        pub fn verified() -> Self {
+            Self { exists: Some(true), dirty: Some(false) }
+        }
+        pub fn forged() -> Self {
+            Self { exists: Some(false), dirty: Some(false) }
+        }
+        pub fn dirty() -> Self {
+            Self { exists: Some(true), dirty: Some(true) }
+        }
+        /// git could not run at all (not installed / repo error).
+        pub fn unverifiable() -> Self {
+            Self { exists: None, dirty: None }
+        }
+    }
+
+    impl Git for FakeGit {
+        fn commit_exists(&self, _repo_dir: &Path, _sha: &str) -> Option<bool> {
+            self.exists
+        }
+        fn tracked_dirty(&self, _repo_dir: &Path) -> Option<bool> {
+            self.dirty
+        }
+    }
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::fake::FakeGit;
+    use super::*;
+
+    fn check(git: &dyn Git, sha: &str) -> CommitCheck {
+        commit_check(git, Path::new("."), sha)
+    }
+
+    const GOOD_SHA: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    #[test]
+    fn non_hex_sha_is_not_a_commit_without_touching_git() {
+        // A flag-like sha must be rejected by hex-validation before reaching git.
+        assert_eq!(check(&FakeGit::verified(), "--help"), CommitCheck::NotACommit);
+        assert_eq!(check(&FakeGit::verified(), ""), CommitCheck::NotACommit);
+    }
+
+    #[test]
+    fn three_way_distinction_is_preserved() {
+        assert_eq!(check(&FakeGit::verified(), GOOD_SHA), CommitCheck::Verified);
+        assert_eq!(check(&FakeGit::forged(), GOOD_SHA), CommitCheck::NotACommit);
+        assert_eq!(check(&FakeGit::dirty(), GOOD_SHA), CommitCheck::DirtyTracked);
+        // could-not-run is Unverifiable, never a forgery alarm.
+        assert_eq!(check(&FakeGit::unverifiable(), GOOD_SHA), CommitCheck::Unverifiable);
+    }
+
+    #[test]
+    fn exists_but_status_unrunnable_is_unverifiable_not_dirty() {
+        let git = FakeGit { exists: Some(true), dirty: None };
+        assert_eq!(check(&git, GOOD_SHA), CommitCheck::Unverifiable);
+    }
+}

--- a/crates/ix-duck/src/maintain/hash.rs
+++ b/crates/ix-duck/src/maintain/hash.rs
@@ -1,0 +1,44 @@
+//! FNV-1a 64-bit hashing for evidence provenance — stable across platforms so a later
+//! audit can detect a swapped input. The evidence layer hashes its input bytes (input
+//! provenance > verdict provenance), so the verdict records *what it was computed from*.
+
+use std::path::Path;
+
+/// FNV-1a 64-bit hash over a byte stream — the platform-stable primitive both the
+/// in-memory and file hashes share.
+pub(crate) fn fnv1a64(bytes: impl IntoIterator<Item = u8>) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+/// FNV-1a 64-bit hash of a file's bytes, rendered as `fnv1a64:<hex>`; `None` if absent.
+pub(crate) fn fnv1a64_file(path: &Path) -> Option<String> {
+    let bytes = std::fs::read(path).ok()?;
+    Some(format!("fnv1a64:{:016x}", fnv1a64(bytes)))
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a64_is_stable_and_seeded() {
+        // Empty input → the FNV offset basis (unchanged seed).
+        assert_eq!(fnv1a64(std::iter::empty()), 0xcbf2_9ce4_8422_2325);
+        // Known vector: "a" → 0xaf63dc4c8601ec8c (standard FNV-1a 64).
+        assert_eq!(fnv1a64(*b"a"), 0xaf63_dc4c_8601_ec8c);
+    }
+
+    #[test]
+    fn fnv1a64_file_renders_prefixed_hex_and_none_when_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("x.bin");
+        std::fs::write(&p, b"a").unwrap();
+        assert_eq!(fnv1a64_file(&p).as_deref(), Some("fnv1a64:af63dc4c8601ec8c"));
+        assert_eq!(fnv1a64_file(&dir.path().join("nope")), None);
+    }
+}

--- a/crates/ix-duck/src/maintain/ledger.rs
+++ b/crates/ix-duck/src/maintain/ledger.rs
@@ -1,0 +1,315 @@
+//! The verdict ledger (Candidate 4) — the append-only **write side** and the
+//! convergence-trend **read side** of the maintain gate, plus the GA-envelope snapshot
+//! materialization. [`VerdictLedger`] owns a ledger path and offers
+//! [`append`](VerdictLedger::append) (one JSON line per verdict),
+//! [`summarize`](VerdictLedger::summarize) (aggregate into a [`TrendSummary`]), and
+//! [`materialize`](VerdictLedger::materialize) (write the current-verdict scorecard
+//! snapshot atomically).
+//!
+//! The free functions [`append_to_ledger`] / [`maintain_trend`] / [`build_snapshot`] /
+//! [`write_snapshot_atomic`] remain as the stable public surface (re-exported from
+//! `maintain`); the struct is the deeper, fluent API over the same primitives.
+
+use std::path::Path;
+
+use duckdb::Connection;
+use serde::Serialize;
+
+use super::{MaintainError, MaintainVerdict};
+
+/// A convergence summary over the verdict ledger — the **read side** of the maintain-gate
+/// "trend table" (the same `state/thinking-machine/maintain-gate.jsonl` the gate appends to,
+/// schema `maintain-gate.contract.md`). `ix-duck` reads it via `read_json_auto`, so a
+/// Demerzel / IXQL convergence loop can ask "are we converging?" in one query rather than
+/// re-deriving it from raw verdicts.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TrendSummary {
+    pub total: i64,
+    pub accepts: i64,
+    pub rejects: i64,
+    pub escalates: i64,
+    /// `status == "C"`: metric improved while a held capability regressed (reward-hack).
+    pub reward_hacks: i64,
+    /// `(status, count)` descending — the hexavalent verdict distribution.
+    pub by_status: Vec<(String, i64)>,
+    /// The most recent verdict's status (by `run_at`), if any.
+    pub latest_status: Option<String>,
+}
+
+/// One lens verdict, flattened for the scorecard snapshot — the tri-state `ok` of a
+/// [`Signal`](super::Signal) rendered as a coarse `"ok" | "bad" | "unknown"` string so a
+/// dashboard reads it without re-encoding `Option<bool>`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SnapshotSignal {
+    pub lens: String,
+    pub status: String,
+    pub detail: String,
+}
+
+/// A **current-verdict** snapshot in GA's canonical dashboard-envelope shape
+/// (`ga/docs/contracts/quality-snapshot.schema.json`): the GA-required envelope fields
+/// (`domain`/`emitted_at`/`metric_name`/`metric_value`/`oracle_status`/`summary`) PLUS the
+/// maintain-specific fused verdict (`advisory`/`status`/`decision`/`signals`/`maintain_trend`),
+/// carried as additive pass-through fields the envelope permits. Holds the latest hexavalent
+/// verdict plus a [`maintain_trend`] rollup, so a dashboard reads ONE file instead of
+/// re-deriving the verdict from the append-only ledger. `emitted_at` is the freshness stamp (a
+/// stale snapshot must never read green); `oracle_status` is the coarse traffic-light, `status`
+/// the richer hexavalent verdict.
+///
+/// Phase A writes this to the IX tree (**formats-not-coupling** — no GA-tree write here);
+/// Phase B federates it into `ga/state/quality/maintain-gate`. **Advisory until Phase 3b**.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerdictSnapshot {
+    pub schema_version: String,
+    /// Producer slug — the GA envelope `domain` (lower-kebab). Matches the registry domain + dir.
+    pub domain: String,
+    /// Freshness — RFC3339 (mirrors `run_at`). The GA envelope's `emitted_at`; consumers compare
+    /// it so stale never reads green.
+    pub emitted_at: String,
+    /// Headline metric identifier (GA envelope `metric_name`).
+    pub metric_name: String,
+    /// Headline metric value (GA envelope) — the externally-derived yield delta (`0.0` when no
+    /// metric evidence; the `signals`/`oracle_status` carry the "no evidence" nuance).
+    pub metric_value: f64,
+    /// Traffic-light state: `ok | warn | error`, mapped from the hexavalent verdict (GA envelope).
+    pub oracle_status: String,
+    /// One-line human summary (GA envelope).
+    pub summary: String,
+    /// Non-binding marker — `true` until IX Phase-3b makes the verdict gating (maintain-specific).
+    pub advisory: bool,
+    /// The raw hexavalent verdict (T/P/U/D/F/C) — richer than `oracle_status` (maintain-specific).
+    pub status: String,
+    /// `accept | reject | escalate` (maintain-specific).
+    pub decision: String,
+    /// Per-signal lens verdicts — locked sub-signal keys (metric / guardrail / convergence /
+    /// drift / provenance). The GA-readable cross-signal contract surface.
+    pub signals: Vec<SnapshotSignal>,
+    /// Convergence rollup over the append-only verdict ledger (reuses [`maintain_trend`]).
+    pub maintain_trend: TrendSummary,
+}
+
+/// Append the verdict as one JSON line to a tamper-evident, append-only ledger.
+pub fn append_to_ledger(verdict: &MaintainVerdict, path: &Path) -> std::io::Result<()> {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let line = serde_json::to_string(verdict).map_err(std::io::Error::other)?;
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(f, "{line}")
+}
+
+/// Aggregate the append-only verdict ledger into a [`TrendSummary`] (the convergence-trend
+/// read side of opportunity #3 in `docs/adr/0001-…`). An absent ledger → an empty summary
+/// (degrade, never error) — the convergence loop reads "no data yet".
+// @ai:invariant maintain_trend aggregates the verdict ledger by decision/status and reads an absent ledger as an empty summary rather than erroring [T:test conf:0.9 src:ix_duck::maintain::tests::maintain_trend_aggregates_the_ledger]
+pub fn maintain_trend(conn: &Connection, ledger_path: &Path) -> Result<TrendSummary, MaintainError> {
+    if !ledger_path.exists() {
+        return Ok(TrendSummary::default());
+    }
+    let p = ledger_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace('\'', "''");
+    let src = format!("read_json_auto('{p}', union_by_name=true)");
+    let (total, accepts, rejects, escalates, reward_hacks): (i64, i64, i64, i64, i64) = conn
+        .query_row(
+            &format!(
+                "SELECT count(*),
+                        count(*) FILTER (WHERE decision = 'accept'),
+                        count(*) FILTER (WHERE decision = 'reject'),
+                        count(*) FILTER (WHERE decision = 'escalate'),
+                        count(*) FILTER (WHERE status = 'C')
+                 FROM {src}"
+            ),
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )?;
+    let by_status: Vec<(String, i64)> = {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT status, count(*) FROM {src} GROUP BY status ORDER BY count(*) DESC, status"
+        ))?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<duckdb::Result<_>>()?;
+        rows
+    };
+    let latest_status: Option<String> = conn
+        .query_row(
+            &format!("SELECT status FROM {src} ORDER BY run_at DESC LIMIT 1"),
+            [],
+            |r| r.get(0),
+        )
+        .ok();
+    Ok(TrendSummary {
+        total,
+        accepts,
+        rejects,
+        escalates,
+        reward_hacks,
+        by_status,
+        latest_status,
+    })
+}
+
+/// Map the hexavalent verdict to the scorecard's coarse oracle status: accept→`ok`,
+/// accept-with-flags / escalate→`warn`, reject→`error`.
+fn oracle_status(hex: &str) -> &'static str {
+    match hex {
+        "T" => "ok",
+        "P" | "U" | "D" => "warn",
+        "F" | "C" => "error",
+        _ => "warn",
+    }
+}
+
+/// Build a GA-envelope-shaped [`VerdictSnapshot`] from a fused verdict + a ledger trend rollup.
+/// Pure (no I/O): the caller supplies the trend (via [`maintain_trend`]) and writes the
+/// result with [`write_snapshot_atomic`].
+// @ai:invariant build_snapshot emits GA's canonical dashboard envelope (domain + emitted_at + metric_name + metric_value + oracle_status + summary) plus the maintain verdict (advisory + hexavalent status + per-signal + maintain_trend) [T:test conf:0.9 src:ix_duck::maintain::tests::snapshot_is_scorecard_shaped]
+pub fn build_snapshot(verdict: &MaintainVerdict, trend: &TrendSummary) -> VerdictSnapshot {
+    let signals = verdict
+        .signals
+        .iter()
+        .map(|s| SnapshotSignal {
+            lens: s.lens.clone(),
+            status: match s.ok {
+                Some(true) => "ok",
+                Some(false) => "bad",
+                None => "unknown",
+            }
+            .to_string(),
+            detail: s.detail.clone(),
+        })
+        .collect();
+    VerdictSnapshot {
+        schema_version: "maintain-verdict-snapshot.v0.1".into(),
+        domain: "maintain-gate".into(),
+        emitted_at: verdict.run_at.clone(),
+        metric_name: "maintain_yield_delta".into(),
+        metric_value: verdict.metric_delta.unwrap_or(0.0),
+        oracle_status: oracle_status(&verdict.status).into(),
+        summary: verdict.reason.clone(),
+        advisory: true,
+        status: verdict.status.clone(),
+        decision: verdict.decision.clone(),
+        signals,
+        maintain_trend: trend.clone(),
+    }
+}
+
+/// Write the snapshot **atomically** (temp file in the same dir + rename) so a concurrent
+/// reader never sees a half-written scorecard. `rename` is atomic on the same filesystem and
+/// replaces an existing target on both Unix and Windows.
+pub fn write_snapshot_atomic(snapshot: &VerdictSnapshot, path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(snapshot).map_err(std::io::Error::other)?;
+    // Temp lives beside the target so the rename stays on one filesystem (atomic).
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json.as_bytes())?;
+    std::fs::rename(&tmp, path)
+}
+
+/// An append-only verdict ledger at a fixed path — the deeper, fluent API over the same
+/// primitives (`append` / `summarize` / `materialize`) the free functions expose.
+pub struct VerdictLedger<'a> {
+    path: &'a Path,
+}
+
+impl<'a> VerdictLedger<'a> {
+    /// Open (lazily) the ledger at `path`. No I/O until [`append`](Self::append).
+    pub fn new(path: &'a Path) -> Self {
+        Self { path }
+    }
+
+    /// Append one verdict as a JSON line (creating parents if needed).
+    pub fn append(&self, verdict: &MaintainVerdict) -> std::io::Result<()> {
+        append_to_ledger(verdict, self.path)
+    }
+
+    /// Aggregate the ledger into a [`TrendSummary`] (absent ledger → empty summary).
+    pub fn summarize(&self, conn: &Connection) -> Result<TrendSummary, MaintainError> {
+        maintain_trend(conn, self.path)
+    }
+
+    /// Build the current-verdict scorecard for `verdict` (folding in this ledger's trend)
+    /// and write it atomically to `snapshot_path`.
+    pub fn materialize(
+        &self,
+        conn: &Connection,
+        verdict: &MaintainVerdict,
+        snapshot_path: &Path,
+    ) -> Result<(), MaintainError> {
+        let trend = self.summarize(conn)?;
+        let snap = build_snapshot(verdict, &trend);
+        write_snapshot_atomic(&snap, snapshot_path)?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+
+    /// A minimal verdict for ledger round-trips — only the fields the trend reads matter.
+    fn verdict(run_at: &str, status: &str, decision: &str) -> MaintainVerdict {
+        MaintainVerdict {
+            schema_version: "maintain-gate.v0.1".into(),
+            run_at: run_at.into(),
+            status: status.into(),
+            decision: decision.into(),
+            metric_delta: None,
+            metric_up: None,
+            guardrail_held: None,
+            converging: None,
+            drifting: None,
+            signals: vec![],
+            evidence: vec![],
+            reason: "x".into(),
+        }
+    }
+
+    #[test]
+    fn append_then_summarize_round_trips() {
+        let conn = crate::open_bench().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("maintain-gate.jsonl");
+        let ledger = VerdictLedger::new(&path);
+
+        // Absent ledger summarizes to an empty trend (degrade, never error).
+        assert_eq!(ledger.summarize(&conn).unwrap().total, 0);
+
+        ledger.append(&verdict("2026-06-18T00:00:00Z", "T", "accept")).unwrap();
+        ledger.append(&verdict("2026-06-18T00:01:00Z", "C", "reject")).unwrap();
+        ledger.append(&verdict("2026-06-18T00:02:00Z", "U", "escalate")).unwrap();
+
+        // Append is additive: 3 writes = 3 lines.
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body.lines().count(), 3, "append-only");
+
+        // Summarize reads back exactly what was appended.
+        let t = ledger.summarize(&conn).unwrap();
+        assert_eq!(t.total, 3);
+        assert_eq!(t.accepts, 1);
+        assert_eq!(t.rejects, 1);
+        assert_eq!(t.escalates, 1);
+        assert_eq!(t.reward_hacks, 1, "the one status=C");
+        assert_eq!(t.latest_status.as_deref(), Some("U"), "latest by run_at");
+
+        // Materialize folds the same trend into a GA-envelope snapshot.
+        let snap_path = dir.path().join("snap").join("last.json");
+        ledger
+            .materialize(&conn, &verdict("2026-06-18T00:03:00Z", "T", "accept"), &snap_path)
+            .unwrap();
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&snap_path).unwrap()).unwrap();
+        assert_eq!(parsed["domain"], "maintain-gate");
+        assert_eq!(parsed["status"], "T");
+        assert_eq!(parsed["maintain_trend"]["total"], 3, "trend rides along");
+    }
+}

--- a/crates/ix-duck/src/maintain/lens_runner.rs
+++ b/crates/ix-duck/src/maintain/lens_runner.rs
@@ -1,0 +1,211 @@
+//! Lens runner — the I/O side of the gate. Threads the DuckDB `conn` through the four
+//! lenses (metric / guardrail / convergence / drift) and the iteration-provenance check,
+//! resolving each to its tri-state ([`Option<bool>`]) and assembling the per-signal
+//! report. Behaviour is IDENTICAL to the original inline orchestration: the loop ledger
+//! is built once (shared by the key-match and the convergence lens), a dormant lens is
+//! `None` (never a positive signal), and the provenance signal is only pushed when scoped.
+//!
+//! [`run`] returns a [`LensResults`] of the *decided* signals; `evaluate` then feeds them
+//! to the pure [`super::verdict_fusion::fuse`] and [`super::evidence::build_evidence`].
+
+use std::path::Path;
+
+use duckdb::Connection;
+
+use super::provenance::{key_matched, provenance_failure, verify_commit};
+use super::{MaintainConfig, MaintainError, MaintainInputs, Signal};
+use crate::chatbot::{self, GateReport};
+
+/// The decided outcome of running every lens over one iteration — the hand-off from the
+/// I/O side ([`run`]) to the pure verdict fusion + evidence build.
+pub(crate) struct LensResults {
+    /// Externally-derived yield delta (`None` = no metric evidence).
+    pub delta: Option<f64>,
+    /// `Some(true)` = metric improved past the epsilon; `None` = no evidence.
+    pub metric_up: Option<bool>,
+    /// The guardrail gate report (carries status + baseline ref for evidence).
+    pub report: GateReport,
+    /// `Some(true)` held, `Some(false)` regressed, `None` inconclusive (caps at U).
+    pub guardrail_held: Option<bool>,
+    /// `Some(true)` converging, `Some(false)` oscillating, `None` not consulted/dormant.
+    pub converging: Option<bool>,
+    /// `Some(true)` drifting OOD, `Some(false)` in-distribution, `None` not consulted.
+    pub drifting: Option<bool>,
+    /// `Some(reason)` if the iteration's correlation key can't be trusted.
+    pub provenance_fail: Option<&'static str>,
+    /// The per-lens signal report, in emission order.
+    pub signals: Vec<Signal>,
+}
+
+/// Yield delta from an externally-derived `hits.jsonl`: mean `coverage_max` over
+/// `compiled` rows in the later half minus the earlier half, split at the median
+/// `ts_ms`. `None` if the file is absent/empty or a half has no compiled rows
+/// (split by ts, NOT the cumulative mean — the blended mean hides pre/post).
+fn metric_delta(conn: &Connection, hits_path: &Path) -> Result<Option<f64>, MaintainError> {
+    if !hits_path.exists() {
+        return Ok(None);
+    }
+    let p = hits_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .replace('\'', "''");
+    let (before, after): (Option<f64>, Option<f64>) = conn.query_row(
+        &format!(
+            "WITH rows AS (SELECT ts_ms, outcome, coverage_max FROM read_json_auto('{p}')),
+                  m AS (SELECT median(ts_ms) AS mid FROM rows)
+             SELECT avg(coverage_max) FILTER (WHERE outcome='compiled' AND ts_ms <  (SELECT mid FROM m)),
+                    avg(coverage_max) FILTER (WHERE outcome='compiled' AND ts_ms >= (SELECT mid FROM m))
+             FROM rows"
+        ),
+        [],
+        |r| Ok((r.get(0)?, r.get(1)?)),
+    )?;
+    Ok(match (before, after) {
+        (Some(b), Some(a)) => Some(a - b),
+        _ => None,
+    })
+}
+
+/// Run every lens over one iteration, returning the decided signals + per-signal report.
+/// Pure-by-handoff: no verdict decision here — that lives in [`super::verdict_fusion`].
+pub(crate) fn run(
+    conn: &Connection,
+    cfg: &MaintainConfig,
+    inputs: &MaintainInputs,
+) -> Result<LensResults, MaintainError> {
+    // --- metric lens (externally derived) ---
+    let delta = metric_delta(conn, inputs.hits_path)?;
+    let metric_up = delta.map(|d| d >= cfg.min_metric_delta);
+
+    // --- guardrail lens ---
+    let report = chatbot::check_regressions(conn, inputs.corpus_dir)?;
+    // pass → held; regression → broke; degraded/skipped → no signal (caps at U).
+    let guardrail_held = match report.status.as_str() {
+        "pass" => Some(true),
+        "regression" => Some(false),
+        _ => None,
+    };
+
+    let mut signals = vec![
+        Signal {
+            lens: "metric".into(),
+            ok: metric_up,
+            detail: match delta {
+                Some(d) => format!("yield delta {d:+.4}"),
+                None => "no externally-derived metric evidence".into(),
+            },
+        },
+        Signal {
+            lens: "guardrail".into(),
+            ok: guardrail_held,
+            detail: format!(
+                "chatbot gate: {} ({} regression(s))",
+                report.status,
+                report.regressions.len()
+            ),
+        },
+    ];
+
+    // --- iteration provenance (Phase 3a): verify the correlation key against git ---
+    let trust = inputs
+        .iteration
+        .as_ref()
+        .map(|s| verify_commit(s.repo_dir, s.commit_sha));
+
+    // Build the loop ledger once — both the key match and the convergence lens use it.
+    let loops_built = match inputs.loops_dir {
+        Some(dir) => {
+            crate::loops::build_loop_iterations(conn, dir)?;
+            true
+        }
+        None => false,
+    };
+
+    // Correlation: a scope must match a REAL recorded row for (loop_id, commit_sha).
+    // Verifying the commit exists in git is NOT enough — a clean but unrelated commit
+    // for a loop with earlier improving rows would otherwise be scored as that loop and
+    // wrongly return T (Codex P1).
+    let key = key_matched(conn, inputs.iteration.as_ref(), loops_built)?;
+
+    // --- convergence lens (loops) + drift lens (ood) ---
+    // Phase 3a: convergence is scoped to the iteration's `loop_id` when a scope is
+    // given (Phase 1 aggregated the whole ledger). Drift scoping awaits a query→loop
+    // tag in Contract B — until then drift stays corpus-level advisory (documented).
+    //
+    // A supplied-but-empty/dormant lens is *unknown* (None), NOT a positive signal:
+    // reading "no data" as converging / in-distribution would be a green light from
+    // no evidence — the opposite of fail-closed (and, when required, must escalate).
+    let converging = if loops_built {
+        let summaries = crate::loops::loop_summary(conn)?; // excludes seed/test rows
+        match &inputs.iteration {
+            Some(scope) => {
+                if summaries.iter().any(|s| s.loop_id == scope.loop_id) {
+                    // This loop is converging iff it is not in the oscillating set.
+                    let osc = crate::loops::oscillating_loops(conn)?;
+                    Some(!osc.iter().any(|(id, _, _)| id == scope.loop_id))
+                } else {
+                    None // no real rows for this loop yet
+                }
+            }
+            None if summaries.is_empty() => None,
+            None => Some(crate::loops::oscillating_loops(conn)?.is_empty()),
+        }
+    } else {
+        None
+    };
+    let drifting = match inputs.query_embeddings_dir {
+        Some(dir) => {
+            // Need ≥2 queries to score nearest-neighbour density; fewer → unknown.
+            if crate::ood::build_query_embeddings(conn, dir)? < 2 {
+                None
+            } else {
+                Some(!crate::ood::flag_ood(conn, cfg.ood_k, cfg.ood_threshold)?.is_empty())
+            }
+        }
+        None => None,
+    };
+    signals.push(Signal {
+        lens: "convergence".into(),
+        ok: converging,
+        detail: match converging {
+            Some(true) => "loops converging (no oscillation)".into(),
+            Some(false) => "loops OSCILLATING — thrash, not convergence".into(),
+            None if cfg.require_loops => "required but loop ledger dormant".into(),
+            None => "no loop data (advisory)".into(),
+        },
+    });
+    signals.push(Signal {
+        lens: "drift".into(),
+        ok: drifting.map(|d| !d),
+        detail: match drifting {
+            Some(true) => "queries DRIFTING out-of-distribution".into(),
+            Some(false) => "queries in-distribution".into(),
+            None if cfg.require_ood => "required but embedding sink dormant".into(),
+            None => "no query embeddings (advisory)".into(),
+        },
+    });
+
+    // Provenance is trusted only if the commit is real + clean of tracked WIP AND a
+    // recorded loop row exists for (loop_id, commit_sha) — see `provenance_failure`.
+    let provenance_fail = provenance_failure(inputs.iteration.as_ref(), trust, key);
+    if inputs.iteration.is_some() {
+        signals.push(Signal {
+            lens: "provenance".into(),
+            ok: Some(provenance_fail.is_none()),
+            detail: provenance_fail
+                .unwrap_or("iteration commit verified, no tracked WIP, loop row matched")
+                .to_string(),
+        });
+    }
+
+    Ok(LensResults {
+        delta,
+        metric_up,
+        report,
+        guardrail_held,
+        converging,
+        drifting,
+        provenance_fail,
+        signals,
+    })
+}

--- a/crates/ix-duck/src/maintain/mod.rs
+++ b/crates/ix-duck/src/maintain/mod.rs
@@ -44,6 +44,25 @@ use serde::Serialize;
 use crate::chatbot;
 use crate::source;
 
+mod evidence;
+mod git;
+mod hash;
+mod ledger;
+mod lens_runner;
+mod provenance;
+mod verdict_fusion;
+
+use evidence::build_evidence;
+use lens_runner::LensResults;
+use verdict_fusion::{fuse, Decided};
+
+// Re-export the ledger's public surface so external callers (examples, ix-agent) keep
+// reaching it at the stable `ix_duck::maintain::*` path after the decomposition.
+pub use ledger::{
+    append_to_ledger, build_snapshot, maintain_trend, write_snapshot_atomic, SnapshotSignal,
+    TrendSummary, VerdictLedger, VerdictSnapshot,
+};
+
 /// Errors from the maintain gate.
 #[derive(Debug)]
 pub enum MaintainError {
@@ -139,84 +158,6 @@ pub struct MaintainInputs<'a> {
     pub run_at: &'a str,
 }
 
-/// Outcome of externally verifying an iteration's `commit_sha` against real git state.
-/// Distinguishes "git could not answer" from "git says forged" so the gate never reports
-/// a missing-git environment as a forgery alarm, and ignores other agents' untracked WIP
-/// so a shared tree doesn't spuriously fail a valid iteration.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum CommitCheck {
-    /// git could not be run at all (not installed / repo error) — we cannot decide.
-    Unverifiable,
-    /// The sha is malformed, or git ran and it is not a real commit object (forged/wrong).
-    NotACommit,
-    /// The commit is real, but TRACKED files have uncommitted edits — the metric may
-    /// reflect work not captured by the sha. (Untracked files are deliberately ignored:
-    /// a multi-agent tree is full of other agents' untracked WIP, which is not ours.)
-    DirtyTracked,
-    /// The commit is real and no tracked files are modified.
-    Verified,
-}
-
-/// Verify `sha` against real git state in `repo_dir` — the anti-forgery check for the
-/// correlation key. Hex-validates first (so a `sha` like `--help` can't reach git as a
-/// flag), then `git cat-file -e <sha>^{commit}` (exists). When the commit is real,
-/// `git status --porcelain --untracked-files=no` decides clean-vs-dirty over *tracked*
-/// files only. A git invocation that fails to *run* (vs answers "no") is `Unverifiable`,
-/// not `NotACommit` — so a missing-git environment is never misreported as forgery.
-fn verify_commit(repo_dir: &Path, sha: &str) -> CommitCheck {
-    use std::process::Command;
-    let hex = !sha.is_empty() && sha.len() <= 64 && sha.bytes().all(|b| b.is_ascii_hexdigit());
-    if !hex {
-        return CommitCheck::NotACommit;
-    }
-    // Does the commit object exist? `Err` = git couldn't run (≠ "forged").
-    match Command::new("git")
-        .arg("-C")
-        .arg(repo_dir)
-        .args(["cat-file", "-e", &format!("{sha}^{{commit}}")])
-        .output()
-    {
-        Err(_) => return CommitCheck::Unverifiable,
-        Ok(o) if !o.status.success() => return CommitCheck::NotACommit,
-        Ok(_) => {}
-    }
-    // Commit is real. Are TRACKED files modified? `--untracked-files=no` excludes other
-    // agents' untracked WIP, so a shared tree doesn't spuriously fail a valid iteration.
-    match Command::new("git")
-        .arg("-C")
-        .arg(repo_dir)
-        .args(["status", "--porcelain", "--untracked-files=no"])
-        .output()
-    {
-        Ok(o) if o.status.success() && o.stdout.is_empty() => CommitCheck::Verified,
-        Ok(o) if o.status.success() => CommitCheck::DirtyTracked,
-        _ => CommitCheck::Unverifiable,
-    }
-}
-
-/// Why (if at all) an iteration's correlation key can't be trusted — `None` means
-/// trusted: the commit is real, clean of tracked WIP, and a recorded loop row matches the
-/// exact `(loop_id, commit_sha)`. Verifying the commit alone is insufficient: a clean but
-/// unrelated commit for a loop with earlier improving rows would otherwise be scored as
-/// that loop (Codex P1). The key is minted by the judged loop, so it earns the same
-/// external-derivation discipline as the metric.
-fn provenance_failure(
-    iteration: Option<&IterationScope>,
-    trust: Option<CommitCheck>,
-    key_matched: Option<bool>,
-) -> Option<&'static str> {
-    iteration?; // no scope → nothing to verify
-    match trust {
-        Some(CommitCheck::Unverifiable) => Some("could not verify commit_sha (git unavailable)"),
-        Some(CommitCheck::NotACommit) => Some("commit_sha is not a real commit (untrusted/forged)"),
-        Some(CommitCheck::DirtyTracked) => {
-            Some("tracked files modified — uncommitted WIP not captured by commit_sha")
-        }
-        _ if key_matched != Some(true) => Some("no recorded loop row for this loop_id/commit_sha"),
-        _ => None,
-    }
-}
-
 /// Provenance of one piece of evidence — what the verdict was computed from, hashed
 /// so a later audit can detect a swapped input (input provenance > verdict provenance).
 #[derive(Debug, Clone, Serialize)]
@@ -262,277 +203,46 @@ pub struct MaintainVerdict {
     pub reason: String,
 }
 
-/// FNV-1a 64-bit hash of a file's bytes — stable across platforms; `None` if absent.
-fn fnv1a64_file(path: &Path) -> Option<String> {
-    let bytes = std::fs::read(path).ok()?;
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in bytes {
-        h ^= b as u64;
-        h = h.wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    Some(format!("fnv1a64:{h:016x}"))
-}
-
-/// Yield delta from an externally-derived `hits.jsonl`: mean `coverage_max` over
-/// `compiled` rows in the later half minus the earlier half, split at the median
-/// `ts_ms`. `None` if the file is absent/empty or a half has no compiled rows
-/// (split by ts, NOT the cumulative mean — the blended mean hides pre/post).
-fn metric_delta(conn: &Connection, hits_path: &Path) -> Result<Option<f64>, MaintainError> {
-    if !hits_path.exists() {
-        return Ok(None);
-    }
-    let p = hits_path
-        .to_string_lossy()
-        .replace('\\', "/")
-        .replace('\'', "''");
-    let (before, after): (Option<f64>, Option<f64>) = conn.query_row(
-        &format!(
-            "WITH rows AS (SELECT ts_ms, outcome, coverage_max FROM read_json_auto('{p}')),
-                  m AS (SELECT median(ts_ms) AS mid FROM rows)
-             SELECT avg(coverage_max) FILTER (WHERE outcome='compiled' AND ts_ms <  (SELECT mid FROM m)),
-                    avg(coverage_max) FILTER (WHERE outcome='compiled' AND ts_ms >= (SELECT mid FROM m))
-             FROM rows"
-        ),
-        [],
-        |r| Ok((r.get(0)?, r.get(1)?)),
-    )?;
-    Ok(match (before, after) {
-        (Some(b), Some(a)) => Some(a - b),
-        _ => None,
-    })
-}
-
 /// Evaluate one iteration: fuse metric ∧ guardrail into a hexavalent verdict.
+///
+/// A thin orchestrator: [`lens_runner::run`] does the I/O (every lens + provenance, over
+/// `conn`), [`verdict_fusion::fuse`] is the pure hexavalent state machine, and
+/// [`evidence::build_evidence`] hashes the inputs. This function only marshals between them.
 // @ai:invariant evaluate returns C (reject) when metric improved while the guardrail regressed — the reward-hack signature is never averaged away [T:test conf:0.95 src:ix_duck::maintain::tests::reward_hack_is_contradiction]
 pub fn evaluate(
     conn: &Connection,
     cfg: &MaintainConfig,
     inputs: &MaintainInputs,
 ) -> Result<MaintainVerdict, MaintainError> {
-    // --- metric lens (externally derived) ---
-    let delta = metric_delta(conn, inputs.hits_path)?;
-    let metric_up = delta.map(|d| d >= cfg.min_metric_delta);
-
-    // --- guardrail lens ---
-    let report = chatbot::check_regressions(conn, inputs.corpus_dir)?;
-    // pass → held; regression → broke; degraded/skipped → no signal (caps at U).
-    let guardrail_held = match report.status.as_str() {
-        "pass" => Some(true),
-        "regression" => Some(false),
-        _ => None,
-    };
-
-    let mut signals = vec![
-        Signal {
-            lens: "metric".into(),
-            ok: metric_up,
-            detail: match delta {
-                Some(d) => format!("yield delta {d:+.4}"),
-                None => "no externally-derived metric evidence".into(),
-            },
-        },
-        Signal {
-            lens: "guardrail".into(),
-            ok: guardrail_held,
-            detail: format!(
-                "chatbot gate: {} ({} regression(s))",
-                report.status,
-                report.regressions.len()
-            ),
-        },
-    ];
-    // --- iteration provenance (Phase 3a): verify the correlation key against git ---
-    let trust = inputs
-        .iteration
-        .as_ref()
-        .map(|s| verify_commit(s.repo_dir, s.commit_sha));
-
-    // Build the loop ledger once — both the key match and the convergence lens use it.
-    let loops_built = match inputs.loops_dir {
-        Some(dir) => {
-            crate::loops::build_loop_iterations(conn, dir)?;
-            true
-        }
-        None => false,
-    };
-
-    // Correlation: a scope must match a REAL recorded row for (loop_id, commit_sha).
-    // Verifying the commit exists in git is NOT enough — a clean but unrelated commit
-    // for a loop with earlier improving rows would otherwise be scored as that loop and
-    // wrongly return T (Codex P1). Parameterised query — `loop_id` is caller-supplied.
-    let key_matched = match (&inputs.iteration, loops_built) {
-        (Some(scope), true) => {
-            let n: i64 = conn.query_row(
-                "SELECT count(*) FROM loop_iterations WHERE loop_id = ? AND commit_sha = ?",
-                duckdb::params![scope.loop_id, scope.commit_sha],
-                |r| r.get(0),
-            )?;
-            Some(n > 0)
-        }
-        (Some(_), false) => Some(false), // scope given but no ledger to match against
-        (None, _) => None,
-    };
-
-    // --- convergence lens (loops) + drift lens (ood) ---
-    // Phase 3a: convergence is scoped to the iteration's `loop_id` when a scope is
-    // given (Phase 1 aggregated the whole ledger). Drift scoping awaits a query→loop
-    // tag in Contract B — until then drift stays corpus-level advisory (documented).
-    //
-    // A supplied-but-empty/dormant lens is *unknown* (None), NOT a positive signal:
-    // reading "no data" as converging / in-distribution would be a green light from
-    // no evidence — the opposite of fail-closed (and, when required, must escalate).
-    let converging = if loops_built {
-        let summaries = crate::loops::loop_summary(conn)?; // excludes seed/test rows
-        match &inputs.iteration {
-            Some(scope) => {
-                if summaries.iter().any(|s| s.loop_id == scope.loop_id) {
-                    // This loop is converging iff it is not in the oscillating set.
-                    let osc = crate::loops::oscillating_loops(conn)?;
-                    Some(!osc.iter().any(|(id, _, _)| id == scope.loop_id))
-                } else {
-                    None // no real rows for this loop yet
-                }
-            }
-            None if summaries.is_empty() => None,
-            None => Some(crate::loops::oscillating_loops(conn)?.is_empty()),
-        }
-    } else {
-        None
-    };
-    let drifting = match inputs.query_embeddings_dir {
-        Some(dir) => {
-            // Need ≥2 queries to score nearest-neighbour density; fewer → unknown.
-            if crate::ood::build_query_embeddings(conn, dir)? < 2 {
-                None
-            } else {
-                Some(!crate::ood::flag_ood(conn, cfg.ood_k, cfg.ood_threshold)?.is_empty())
-            }
-        }
-        None => None,
-    };
-    signals.push(Signal {
-        lens: "convergence".into(),
-        ok: converging,
-        detail: match converging {
-            Some(true) => "loops converging (no oscillation)".into(),
-            Some(false) => "loops OSCILLATING — thrash, not convergence".into(),
-            None if cfg.require_loops => "required but loop ledger dormant".into(),
-            None => "no loop data (advisory)".into(),
-        },
-    });
-    signals.push(Signal {
-        lens: "drift".into(),
-        ok: drifting.map(|d| !d),
-        detail: match drifting {
-            Some(true) => "queries DRIFTING out-of-distribution".into(),
-            Some(false) => "queries in-distribution".into(),
-            None if cfg.require_ood => "required but embedding sink dormant".into(),
-            None => "no query embeddings (advisory)".into(),
-        },
-    });
-    // Provenance is trusted only if the commit is real + clean of tracked WIP AND a
-    // recorded loop row exists for (loop_id, commit_sha) — see `provenance_failure`.
-    let provenance_fail = provenance_failure(inputs.iteration.as_ref(), trust, key_matched);
-    if inputs.iteration.is_some() {
-        signals.push(Signal {
-            lens: "provenance".into(),
-            ok: Some(provenance_fail.is_none()),
-            detail: provenance_fail
-                .unwrap_or("iteration commit verified, no tracked WIP, loop row matched")
-                .to_string(),
-        });
-    }
+    let LensResults {
+        delta,
+        metric_up,
+        report,
+        guardrail_held,
+        converging,
+        drifting,
+        provenance_fail,
+        signals,
+    } = lens_runner::run(conn, cfg, inputs)?;
 
     // --- conjunction → hexavalent status (fail-closed) ---
-    // Untrusted iteration provenance escalates before any lens verdict — a forged,
-    // dirty, or unmatched correlation key means we cannot attribute the evidence to a
-    // real iteration.
-    // A required-but-dormant lens escalates next.
+    // The hexavalent state machine is a PURE function (`verdict_fusion::fuse`): untrusted
+    // provenance escalates before any lens verdict, then a required-but-dormant lens, then
+    // the hard conjunction over (metric_up, guardrail_held) with soft-lens downgrades.
     let dormant_required =
         (cfg.require_loops && converging.is_none()) || (cfg.require_ood && drifting.is_none());
-    let (status, decision, reason) = if let Some(why) = provenance_fail {
-        (
-            "U",
-            "escalate",
-            format!("iteration provenance untrusted: {why}"),
-        )
-    } else if dormant_required {
-        (
-            "U",
-            "escalate",
-            "a required lens is dormant (no signal)".to_string(),
-        )
-    } else {
-        match (metric_up, guardrail_held) {
-            (None, _) => (
-                "U",
-                "escalate",
-                "metric evidence missing — cannot decide".to_string(),
-            ),
-            (_, None) => (
-                "U",
-                "escalate",
-                format!("guardrail inconclusive ({})", report.status),
-            ),
-            (Some(true), Some(false)) => (
-                "C",
-                "reject",
-                "REWARD-HACK: metric improved while a held capability regressed".to_string(),
-            ),
-            (Some(false), Some(false)) => (
-                "F",
-                "reject",
-                "no improvement and guardrail regressed".to_string(),
-            ),
-            (Some(false), Some(true)) => ("F", "reject", "no metric improvement".to_string()),
-            // Hard conjunction holds — the soft lenses can downgrade an accept.
-            (Some(true), Some(true)) => {
-                if converging == Some(false) {
-                    (
-                        "D",
-                        "escalate",
-                        "metric improved but the loop is oscillating (not converging)".to_string(),
-                    )
-                } else if drifting == Some(true) {
-                    (
-                        "P",
-                        "accept",
-                        "metric improved and guardrail held, but queries are drifting \
-                         out-of-distribution"
-                            .to_string(),
-                    )
-                } else {
-                    (
-                        "T",
-                        "accept",
-                        "metric improved and guardrail held".to_string(),
-                    )
-                }
-            }
-        }
-    };
+    let (status, decision, reason) = fuse(&Decided {
+        metric_up,
+        guardrail_held,
+        converging,
+        drifting,
+        provenance_fail,
+        dormant_required,
+        guardrail_report_status: &report.status,
+    });
 
     // --- evidence provenance (hash the inputs, not just the verdict) ---
-    let mut evidence = vec![
-        Evidence {
-            kind: "metric".into(),
-            source: inputs.hits_path.to_string_lossy().into_owned(),
-            hash: fnv1a64_file(inputs.hits_path).unwrap_or_else(|| "absent".into()),
-        },
-        Evidence {
-            kind: "guardrail-baseline".into(),
-            source: inputs.corpus_dir.to_string_lossy().into_owned(),
-            hash: report.baseline_ref.clone(),
-        },
-    ];
-    // The correlation key IS provenance — it ties this verdict to a verified commit.
-    if let Some(scope) = &inputs.iteration {
-        evidence.push(Evidence {
-            kind: format!("iteration-commit:{}", scope.loop_id),
-            source: scope.repo_dir.to_string_lossy().into_owned(),
-            hash: format!("git:{}", scope.commit_sha),
-        });
-    }
+    let evidence = build_evidence(inputs, &report);
 
     Ok(MaintainVerdict {
         schema_version: "maintain-gate.v0.1".into(),
@@ -557,207 +267,6 @@ pub fn exit_code(status: &str) -> i32 {
         "F" | "C" => 1,
         _ => 2, // U | D | anything unexpected → escalate
     }
-}
-
-/// Append the verdict as one JSON line to a tamper-evident, append-only ledger.
-pub fn append_to_ledger(verdict: &MaintainVerdict, path: &Path) -> std::io::Result<()> {
-    use std::io::Write;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let line = serde_json::to_string(verdict).map_err(std::io::Error::other)?;
-    let mut f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
-    writeln!(f, "{line}")
-}
-
-/// A convergence summary over the verdict ledger — the **read side** of the maintain-gate
-/// "trend table" (the same `state/thinking-machine/maintain-gate.jsonl` the gate appends to,
-/// schema `maintain-gate.contract.md`). `ix-duck` reads it via `read_json_auto`, so a
-/// Demerzel / IXQL convergence loop can ask "are we converging?" in one query rather than
-/// re-deriving it from raw verdicts.
-#[derive(Debug, Clone, Default, Serialize)]
-pub struct TrendSummary {
-    pub total: i64,
-    pub accepts: i64,
-    pub rejects: i64,
-    pub escalates: i64,
-    /// `status == "C"`: metric improved while a held capability regressed (reward-hack).
-    pub reward_hacks: i64,
-    /// `(status, count)` descending — the hexavalent verdict distribution.
-    pub by_status: Vec<(String, i64)>,
-    /// The most recent verdict's status (by `run_at`), if any.
-    pub latest_status: Option<String>,
-}
-
-/// Aggregate the append-only verdict ledger into a [`TrendSummary`] (the convergence-trend
-/// read side of opportunity #3 in `docs/adr/0001-…`). An absent ledger → an empty summary
-/// (degrade, never error) — the convergence loop reads "no data yet".
-// @ai:invariant maintain_trend aggregates the verdict ledger by decision/status and reads an absent ledger as an empty summary rather than erroring [T:test conf:0.9 src:ix_duck::maintain::tests::maintain_trend_aggregates_the_ledger]
-pub fn maintain_trend(
-    conn: &Connection,
-    ledger_path: &Path,
-) -> Result<TrendSummary, MaintainError> {
-    if !ledger_path.exists() {
-        return Ok(TrendSummary::default());
-    }
-    let p = ledger_path
-        .to_string_lossy()
-        .replace('\\', "/")
-        .replace('\'', "''");
-    let src = format!("read_json_auto('{p}', union_by_name=true)");
-    let (total, accepts, rejects, escalates, reward_hacks): (i64, i64, i64, i64, i64) = conn
-        .query_row(
-            &format!(
-                "SELECT count(*),
-                        count(*) FILTER (WHERE decision = 'accept'),
-                        count(*) FILTER (WHERE decision = 'reject'),
-                        count(*) FILTER (WHERE decision = 'escalate'),
-                        count(*) FILTER (WHERE status = 'C')
-                 FROM {src}"
-            ),
-            [],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
-        )?;
-    let by_status: Vec<(String, i64)> = {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT status, count(*) FROM {src} GROUP BY status ORDER BY count(*) DESC, status"
-        ))?;
-        let rows = stmt
-            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
-            .collect::<duckdb::Result<_>>()?;
-        rows
-    };
-    let latest_status: Option<String> = conn
-        .query_row(
-            &format!("SELECT status FROM {src} ORDER BY run_at DESC LIMIT 1"),
-            [],
-            |r| r.get(0),
-        )
-        .ok();
-    Ok(TrendSummary {
-        total,
-        accepts,
-        rejects,
-        escalates,
-        reward_hacks,
-        by_status,
-        latest_status,
-    })
-}
-
-/// One lens verdict, flattened for the scorecard snapshot — the tri-state `ok` of a
-/// [`Signal`] rendered as a coarse `"ok" | "bad" | "unknown"` string so a dashboard reads
-/// it without re-encoding `Option<bool>`.
-#[derive(Debug, Clone, Serialize)]
-pub struct SnapshotSignal {
-    pub lens: String,
-    pub status: String,
-    pub detail: String,
-}
-
-/// A **current-verdict** snapshot in GA's canonical dashboard-envelope shape
-/// (`ga/docs/contracts/quality-snapshot.schema.json`): the GA-required envelope fields
-/// (`domain`/`emitted_at`/`metric_name`/`metric_value`/`oracle_status`/`summary`) PLUS the
-/// maintain-specific fused verdict (`advisory`/`status`/`decision`/`signals`/`maintain_trend`),
-/// carried as additive pass-through fields the envelope permits. Holds the latest hexavalent
-/// verdict plus a [`maintain_trend`] rollup, so a dashboard reads ONE file instead of
-/// re-deriving the verdict from the append-only ledger. `emitted_at` is the freshness stamp (a
-/// stale snapshot must never read green); `oracle_status` is the coarse traffic-light, `status`
-/// the richer hexavalent verdict.
-///
-/// Phase A writes this to the IX tree (**formats-not-coupling** — no GA-tree write here);
-/// Phase B federates it into `ga/state/quality/maintain-gate`. **Advisory until Phase 3b**.
-#[derive(Debug, Clone, Serialize)]
-pub struct VerdictSnapshot {
-    pub schema_version: String,
-    /// Producer slug — the GA envelope `domain` (lower-kebab). Matches the registry domain + dir.
-    pub domain: String,
-    /// Freshness — RFC3339 (mirrors `run_at`). The GA envelope's `emitted_at`; consumers compare
-    /// it so stale never reads green.
-    pub emitted_at: String,
-    /// Headline metric identifier (GA envelope `metric_name`).
-    pub metric_name: String,
-    /// Headline metric value (GA envelope) — the externally-derived yield delta (`0.0` when no
-    /// metric evidence; the `signals`/`oracle_status` carry the "no evidence" nuance).
-    pub metric_value: f64,
-    /// Traffic-light state: `ok | warn | error`, mapped from the hexavalent verdict (GA envelope).
-    pub oracle_status: String,
-    /// One-line human summary (GA envelope).
-    pub summary: String,
-    /// Non-binding marker — `true` until IX Phase-3b makes the verdict gating (maintain-specific).
-    pub advisory: bool,
-    /// The raw hexavalent verdict (T/P/U/D/F/C) — richer than `oracle_status` (maintain-specific).
-    pub status: String,
-    /// `accept | reject | escalate` (maintain-specific).
-    pub decision: String,
-    /// Per-signal lens verdicts — locked sub-signal keys (metric / guardrail / convergence /
-    /// drift / provenance). The GA-readable cross-signal contract surface.
-    pub signals: Vec<SnapshotSignal>,
-    /// Convergence rollup over the append-only verdict ledger (reuses [`maintain_trend`]).
-    pub maintain_trend: TrendSummary,
-}
-
-/// Map the hexavalent verdict to the scorecard's coarse oracle status: accept→`ok`,
-/// accept-with-flags / escalate→`warn`, reject→`error`.
-fn oracle_status(hex: &str) -> &'static str {
-    match hex {
-        "T" => "ok",
-        "P" | "U" | "D" => "warn",
-        "F" | "C" => "error",
-        _ => "warn",
-    }
-}
-
-/// Build a GA-envelope-shaped [`VerdictSnapshot`] from a fused verdict + a ledger trend rollup.
-/// Pure (no I/O): the caller supplies the trend (via [`maintain_trend`]) and writes the
-/// result with [`write_snapshot_atomic`].
-// @ai:invariant build_snapshot emits GA's canonical dashboard envelope (domain + emitted_at + metric_name + metric_value + oracle_status + summary) plus the maintain verdict (advisory + hexavalent status + per-signal + maintain_trend) [T:test conf:0.9 src:ix_duck::maintain::tests::snapshot_is_scorecard_shaped]
-pub fn build_snapshot(verdict: &MaintainVerdict, trend: &TrendSummary) -> VerdictSnapshot {
-    let signals = verdict
-        .signals
-        .iter()
-        .map(|s| SnapshotSignal {
-            lens: s.lens.clone(),
-            status: match s.ok {
-                Some(true) => "ok",
-                Some(false) => "bad",
-                None => "unknown",
-            }
-            .to_string(),
-            detail: s.detail.clone(),
-        })
-        .collect();
-    VerdictSnapshot {
-        schema_version: "maintain-verdict-snapshot.v0.1".into(),
-        domain: "maintain-gate".into(),
-        emitted_at: verdict.run_at.clone(),
-        metric_name: "maintain_yield_delta".into(),
-        metric_value: verdict.metric_delta.unwrap_or(0.0),
-        oracle_status: oracle_status(&verdict.status).into(),
-        summary: verdict.reason.clone(),
-        advisory: true,
-        status: verdict.status.clone(),
-        decision: verdict.decision.clone(),
-        signals,
-        maintain_trend: trend.clone(),
-    }
-}
-
-/// Write the snapshot **atomically** (temp file in the same dir + rename) so a concurrent
-/// reader never sees a half-written scorecard. `rename` is atomic on the same filesystem and
-/// replaces an existing target on both Unix and Windows.
-pub fn write_snapshot_atomic(snapshot: &VerdictSnapshot, path: &Path) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let json = serde_json::to_string_pretty(snapshot).map_err(std::io::Error::other)?;
-    // Temp lives beside the target so the rename stays on one filesystem (atomic).
-    let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, json.as_bytes())?;
-    std::fs::rename(&tmp, path)
 }
 
 #[cfg(all(test, feature = "duck"))]

--- a/crates/ix-duck/src/maintain/provenance.rs
+++ b/crates/ix-duck/src/maintain/provenance.rs
@@ -1,0 +1,117 @@
+//! Iteration provenance (Phase 3a) — the anti-forgery check on the correlation key.
+//!
+//! The `commit_sha` is minted GA-side by the loop being judged, so the gate trusts it
+//! only after (a) externally verifying it against real git state, and (b) confirming a
+//! recorded loop row exists for the exact `(loop_id, commit_sha)`. Verifying the commit
+//! alone is insufficient: a clean but unrelated commit for a loop with earlier improving
+//! rows would otherwise be scored as that loop (Codex P1). The decision is PURE over the
+//! [`Git`](super::git::Git) port (via [`super::git::commit_check`]), so the forged / dirty
+//! / unverifiable / verified truth table is unit-testable without a real repo.
+
+use std::path::Path;
+
+use duckdb::Connection;
+
+use super::git::{commit_check, CommitCheck, RealGit};
+use super::{IterationScope, MaintainError};
+
+/// Verify `sha` against real git state in `repo_dir` over the production [`RealGit`]
+/// adapter (the decision logic lives in [`super::git::commit_check`], pure over the port).
+pub(crate) fn verify_commit(repo_dir: &Path, sha: &str) -> CommitCheck {
+    commit_check(&RealGit, repo_dir, sha)
+}
+
+/// Correlation: does a REAL recorded `loop_iterations` row exist for `(loop_id, commit_sha)`?
+/// `None` when there is no scope; `Some(false)` when there is no ledger to match against.
+/// Parameterised query — `loop_id`/`commit_sha` are caller-supplied.
+pub(crate) fn key_matched(
+    conn: &Connection,
+    iteration: Option<&IterationScope>,
+    loops_built: bool,
+) -> Result<Option<bool>, MaintainError> {
+    Ok(match (iteration, loops_built) {
+        (Some(scope), true) => {
+            let n: i64 = conn.query_row(
+                "SELECT count(*) FROM loop_iterations WHERE loop_id = ? AND commit_sha = ?",
+                duckdb::params![scope.loop_id, scope.commit_sha],
+                |r| r.get(0),
+            )?;
+            Some(n > 0)
+        }
+        (Some(_), false) => Some(false), // scope given but no ledger to match against
+        (None, _) => None,
+    })
+}
+
+/// Why (if at all) an iteration's correlation key can't be trusted — `None` means
+/// trusted: the commit is real, clean of tracked WIP, and a recorded loop row matches the
+/// exact `(loop_id, commit_sha)`. The key is minted by the judged loop, so it earns the
+/// same external-derivation discipline as the metric.
+pub(crate) fn provenance_failure(
+    iteration: Option<&IterationScope>,
+    trust: Option<CommitCheck>,
+    key_matched: Option<bool>,
+) -> Option<&'static str> {
+    iteration?; // no scope → nothing to verify
+    match trust {
+        Some(CommitCheck::Unverifiable) => Some("could not verify commit_sha (git unavailable)"),
+        Some(CommitCheck::NotACommit) => Some("commit_sha is not a real commit (untrusted/forged)"),
+        Some(CommitCheck::DirtyTracked) => {
+            Some("tracked files modified — uncommitted WIP not captured by commit_sha")
+        }
+        _ if key_matched != Some(true) => Some("no recorded loop row for this loop_id/commit_sha"),
+        _ => None,
+    }
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::super::git::fake::FakeGit;
+    use super::super::git::commit_check;
+    use super::*;
+
+    const SHA: &str = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    /// A `IterationScope` whose lifetimes outlive the call.
+    fn scope<'a>(loop_id: &'a str, sha: &'a str, repo: &'a Path) -> IterationScope<'a> {
+        IterationScope { loop_id, commit_sha: sha, repo_dir: repo }
+    }
+
+    /// The forged / dirty / unverifiable / verified truth table — the payoff of routing
+    /// the decision through the `Git` port. `provenance_failure` is fed the `CommitCheck`
+    /// a `FakeGit` produces, plus a key-match flag.
+    #[test]
+    fn provenance_truth_table_over_fake_git() {
+        let repo = Path::new(".");
+        let s = scope("l", SHA, repo);
+
+        // No scope → always trusted (nothing to verify), regardless of trust/key.
+        assert_eq!(provenance_failure(None, Some(CommitCheck::NotACommit), Some(false)), None);
+
+        let trust = |g: &FakeGit| commit_check(g, repo, SHA);
+
+        // Forged (commit object does not exist) → untrusted, names "forged".
+        let why = provenance_failure(Some(&s), Some(trust(&FakeGit::forged())), Some(true)).unwrap();
+        assert!(why.contains("forged"), "{why}");
+
+        // Dirty tracked files → untrusted, names "tracked".
+        let why = provenance_failure(Some(&s), Some(trust(&FakeGit::dirty())), Some(true)).unwrap();
+        assert!(why.contains("tracked"), "{why}");
+
+        // Git could not run → untrusted, names "git unavailable".
+        let why =
+            provenance_failure(Some(&s), Some(trust(&FakeGit::unverifiable())), Some(true)).unwrap();
+        assert!(why.contains("git unavailable"), "{why}");
+
+        // Verified commit + matched key → trusted (None).
+        assert_eq!(
+            provenance_failure(Some(&s), Some(trust(&FakeGit::verified())), Some(true)),
+            None
+        );
+
+        // Verified commit but NO matching loop row → untrusted (Codex P1 guard).
+        let why =
+            provenance_failure(Some(&s), Some(trust(&FakeGit::verified())), Some(false)).unwrap();
+        assert!(why.contains("no recorded loop row"), "{why}");
+    }
+}

--- a/crates/ix-duck/src/maintain/verdict_fusion.rs
+++ b/crates/ix-duck/src/maintain/verdict_fusion.rs
@@ -1,0 +1,196 @@
+//! The hexavalent state machine (T/P/U/D/F/C) as a PURE function over the *already
+//! decided* signals. This is Candidate 1's core: the anti-Goodhart conjunction —
+//! **never an average** — extracted from the I/O of `evaluate` so the full truth table
+//! (especially the **C** reward-hack case: metric↑ ∧ guardrail broke) is unit-testable
+//! without DuckDB, git, or fixtures.
+//!
+//! Fail-closed ordering (each step only reached if the prior didn't escalate):
+//! 1. untrusted iteration provenance → **U** (forged / dirty / unmatched key),
+//! 2. a required-but-dormant lens → **U**,
+//! 3. the hard conjunction over (metric_up, guardrail_held):
+//!    - either missing → **U**,
+//!    - metric↑ ∧ guardrail broke → **C** (reward-hack: reject + alarm),
+//!    - otherwise no improvement → **F** (reject),
+//!    - metric↑ ∧ guardrail held → the soft lenses may downgrade the accept:
+//!      oscillating → **D**, drifting → **P**, else clean → **T**.
+
+/// The decided inputs to the state machine — every field is already resolved to its
+/// tri-state (`Option<bool>`), so the function is pure (no I/O, no fixtures).
+pub(crate) struct Decided<'a> {
+    pub metric_up: Option<bool>,
+    pub guardrail_held: Option<bool>,
+    pub converging: Option<bool>,
+    pub drifting: Option<bool>,
+    /// `Some(reason)` if the iteration's correlation key can't be trusted.
+    pub provenance_fail: Option<&'static str>,
+    /// A required lens (`require_loops`/`require_ood`) is dormant (no signal).
+    pub dormant_required: bool,
+    /// The guardrail report status string, for the "inconclusive" reason line.
+    pub guardrail_report_status: &'a str,
+}
+
+/// Fuse the decided signals into `(status, decision, reason)`. The single source of
+/// truth for the hexavalent verdict — `evaluate` only marshals inputs into this.
+// @ai:invariant fuse returns C (reject) when metric improved while the guardrail regressed — the reward-hack signature is never averaged away [T:test conf:0.95 src:ix_duck::maintain::verdict_fusion::tests::reward_hack_is_contradiction]
+pub(crate) fn fuse(d: &Decided) -> (&'static str, &'static str, String) {
+    if let Some(why) = d.provenance_fail {
+        return (
+            "U",
+            "escalate",
+            format!("iteration provenance untrusted: {why}"),
+        );
+    }
+    if d.dormant_required {
+        return (
+            "U",
+            "escalate",
+            "a required lens is dormant (no signal)".to_string(),
+        );
+    }
+    match (d.metric_up, d.guardrail_held) {
+        (None, _) => (
+            "U",
+            "escalate",
+            "metric evidence missing — cannot decide".to_string(),
+        ),
+        (_, None) => (
+            "U",
+            "escalate",
+            format!("guardrail inconclusive ({})", d.guardrail_report_status),
+        ),
+        (Some(true), Some(false)) => (
+            "C",
+            "reject",
+            "REWARD-HACK: metric improved while a held capability regressed".to_string(),
+        ),
+        (Some(false), Some(false)) => (
+            "F",
+            "reject",
+            "no improvement and guardrail regressed".to_string(),
+        ),
+        (Some(false), Some(true)) => ("F", "reject", "no metric improvement".to_string()),
+        // Hard conjunction holds — the soft lenses can downgrade an accept.
+        (Some(true), Some(true)) => {
+            if d.converging == Some(false) {
+                (
+                    "D",
+                    "escalate",
+                    "metric improved but the loop is oscillating (not converging)".to_string(),
+                )
+            } else if d.drifting == Some(true) {
+                (
+                    "P",
+                    "accept",
+                    "metric improved and guardrail held, but queries are drifting \
+                     out-of-distribution"
+                        .to_string(),
+                )
+            } else {
+                (
+                    "T",
+                    "accept",
+                    "metric improved and guardrail held".to_string(),
+                )
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+
+    /// A clean accept baseline; tweak fields per-case.
+    fn base() -> Decided<'static> {
+        Decided {
+            metric_up: Some(true),
+            guardrail_held: Some(true),
+            converging: None,
+            drifting: None,
+            provenance_fail: None,
+            dormant_required: false,
+            guardrail_report_status: "pass",
+        }
+    }
+
+    fn status(d: &Decided) -> &'static str {
+        fuse(d).0
+    }
+
+    #[test]
+    fn clean_accept_is_t() {
+        assert_eq!(status(&base()), "T");
+        assert_eq!(fuse(&base()).1, "accept");
+    }
+
+    #[test]
+    fn reward_hack_is_contradiction() {
+        // The case that matters most: metric↑ while the guardrail broke → C, never averaged.
+        let d = Decided { guardrail_held: Some(false), ..base() };
+        let (s, decision, reason) = fuse(&d);
+        assert_eq!(s, "C");
+        assert_eq!(decision, "reject");
+        assert!(reason.contains("REWARD-HACK"));
+    }
+
+    #[test]
+    fn no_improvement_rejects_to_f() {
+        // metric flat, guardrail held → F.
+        assert_eq!(status(&Decided { metric_up: Some(false), ..base() }), "F");
+        // metric flat AND guardrail broke → still F (no reward-hack: no improvement to alarm).
+        assert_eq!(
+            status(&Decided { metric_up: Some(false), guardrail_held: Some(false), ..base() }),
+            "F"
+        );
+    }
+
+    #[test]
+    fn missing_hard_signal_escalates_to_u() {
+        assert_eq!(status(&Decided { metric_up: None, ..base() }), "U");
+        assert_eq!(status(&Decided { guardrail_held: None, ..base() }), "U");
+    }
+
+    #[test]
+    fn oscillating_disputes_an_accept_to_d() {
+        assert_eq!(status(&Decided { converging: Some(false), ..base() }), "D");
+        assert_eq!(fuse(&Decided { converging: Some(false), ..base() }).1, "escalate");
+    }
+
+    #[test]
+    fn drift_flags_an_accept_to_p() {
+        assert_eq!(status(&Decided { drifting: Some(true), ..base() }), "P");
+        assert_eq!(fuse(&Decided { drifting: Some(true), ..base() }).1, "accept");
+        // Converging + in-distribution explicitly true → still clean T.
+        assert_eq!(
+            status(&Decided { converging: Some(true), drifting: Some(false), ..base() }),
+            "T"
+        );
+    }
+
+    #[test]
+    fn oscillation_dominates_drift() {
+        // Both soft lenses negative — oscillation (D, escalate) outranks drift (P, accept).
+        assert_eq!(
+            status(&Decided { converging: Some(false), drifting: Some(true), ..base() }),
+            "D"
+        );
+    }
+
+    #[test]
+    fn provenance_failure_escalates_before_any_lens() {
+        // Even a perfect accept is capped at U by untrusted provenance.
+        let d = Decided { provenance_fail: Some("forged"), ..base() };
+        let (s, decision, reason) = fuse(&d);
+        assert_eq!(s, "U");
+        assert_eq!(decision, "escalate");
+        assert!(reason.contains("forged"));
+    }
+
+    #[test]
+    fn dormant_required_lens_escalates_after_provenance() {
+        assert_eq!(status(&Decided { dormant_required: true, ..base() }), "U");
+        // Provenance failure still wins the tie (it is checked first).
+        let d = Decided { dormant_required: true, provenance_fail: Some("x"), ..base() };
+        assert!(fuse(&d).2.contains("provenance"));
+    }
+}


### PR DESCRIPTION
## What

Behavior-preserving decomposition of the 1062-line `crates/ix-duck/src/maintain.rs` into deep modules, per the architecture review — **Candidates 1 (verdict fusion), 3 (ports & adapters for git), and 4 (verdict ledger)**. The 119-test ix-duck suite (20 of them in `maintain`) is the behavior oracle; **every existing verdict test stays green, unchanged.**

`maintain.rs` is now `maintain/` with `mod.rs` as a thin orchestrator:

| module | responsibility |
| --- | --- |
| `hash.rs` | `fnv1a64` + `fnv1a64_file` (shared FNV primitive) |
| `git.rs` | **Candidate 3** — a `Git` *port* (`RealGit` adapter + test-only `FakeGit`) with the **pure** `commit_check` decision; the three-way distinction preserved: could-not-run = `Unverifiable`, ran-and-no = `NotACommit`, plus `DirtyTracked` / `Verified`; hex-validation-first kept |
| `provenance.rs` | `verify_commit` (over the port), `provenance_failure`, and the `(loop_id, commit_sha)` key-match correlation — now **unit-testable** (it was untestable before) |
| `verdict_fusion.rs` | **Candidate 1 core** — the hexavalent T/P/U/D/F/C state machine as a **PURE** function over the decided signals (no DuckDB / git / fixtures) |
| `evidence.rs` | `build_evidence` (input-provenance hashing via `hash::`) |
| `lens_runner.rs` | metric / guardrail / convergence / drift + provenance I/O into a `LensResults` struct — behavior **IDENTICAL** (same ledger build, same dormant-lens `None`-vs-`Some` semantics) |
| `ledger.rs` | **Candidate 4** — `VerdictLedger` owning `append` + `summarize` + `materialize`; `TrendSummary` / `VerdictSnapshot` / `SnapshotSignal` move here |

`evaluate()` is now a thin orchestrator: `lens_runner::run` → `verdict_fusion::fuse` → `evidence::build_evidence`.

## Behavior preserved

All **20 existing maintain verdict tests pass unchanged** (full ix-duck lib suite: **132 passed, 0 failed** — was 116, +16 new pure tests). No verdict logic was altered; the hexavalent T/P/U/D/F/C truth table, fail-closed ordering, and the conjunction-never-average rule are byte-for-byte the same, just relocated.

## New pure tests added (the payoff)

- **verdict_fusion** — full T/P/U/D/F/C truth table, including the **C reward-hack** case (metric↑ ∧ guardrail broke) and soft-lens precedence (oscillation **D** outranks drift **P**).
- **provenance via `FakeGit`** — the forged / dirty / unverifiable / verified truth table (previously unreachable without a real repo).
- **ledger round-trip** — append-then-summarize, plus `materialize` snapshot.
- **hash** — FNV stability + prefixed-hex file rendering; **git** — hex-validation-first + the three-way distinction.

## Public API + @ai bindings stable

`evaluate`, `MaintainVerdict`, `MaintainConfig`, `MaintainInputs`, `IterationScope`, `Evidence`, `Signal`, `TrendSummary`, `maintain_trend`, `append_to_ledger`, `exit_code`, `VerdictSnapshot`, `SnapshotSignal`, `build_snapshot`, `write_snapshot_atomic` (plus new `VerdictLedger`) all reachable at `ix_duck::maintain::*` via `pub use` re-exports. The `ix_maintain_gate` / `ix_maintain_snapshot` examples and the feature-gated `ix-agent` maintain-gate tool compile unchanged.

The `@ai:invariant` `src:` bindings are intact: the cited tests (`reward_hack_is_contradiction`, `maintain_trend_aggregates_the_ledger`, `snapshot_is_scorecard_shaped`) stay reachable at their exact `ix_duck::maintain::tests::*` paths — the drift gate is not broken. (These maintain.rs annotations are not in `annotations.snapshot.json`, so no re-snapshot is required.)

## Verification

- `cargo test -p ix-duck --features duck` → 132 passed, 0 failed
- `cargo clippy -p ix-duck --features duck --all-targets -- -D warnings` → clean
- `cargo build -p ix-duck --features duck --examples` → ok
- `cargo check -p ix-agent --features maintain-gate` → ok

Scope-respecting: no changes to `chatbot.rs` / `routing.rs` / `source.rs` (Stream B); the `chatbot::baseline_hash` dedup is left as a deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
