### PR TITLE
feat(ix-duck): ML-surface UDFs — distances, t-SNE/MDS, signal, supervised (#157/#158/#159/#162)

### DIFF
--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -310,10 +310,24 @@ impl VTab for IxWaveletDenoise {
         }
         // Cap the decomposition depth at floor(log2(n)) so a short series is never
         // over-decomposed (each level halves the signal).
-        let max_levels = ((series.len() as f64).log2().floor() as usize).max(1);
+        let n_in = series.len();
+        let max_levels = ((n_in as f64).log2().floor() as usize).max(1);
         let levels = (levels_req as usize).min(max_levels);
-        let rows: Vec<(i64, f64)> = wavelet_denoise(&series, levels, threshold)
+        // The Haar transform halves the length at each level and drops an unmatched
+        // tail sample for non-multiples of 2^levels — which would silently lose rows
+        // and break the one-row-per-input contract. Edge-pad up to a multiple of
+        // 2^levels, denoise, then truncate back to the original length.
+        let step = 1usize << levels;
+        let padded_len = n_in.div_ceil(step) * step;
+        let mut padded = series.clone();
+        if padded_len > n_in {
+            let last = *series.last().unwrap();
+            padded.resize(padded_len, last);
+        }
+        let denoised = wavelet_denoise(&padded, levels, threshold);
+        let rows: Vec<(i64, f64)> = denoised
             .iter()
+            .take(n_in)
             .enumerate()
             .map(|(i, &v)| (i as i64, v))
             .collect();
@@ -510,6 +524,24 @@ mod tests {
             .unwrap();
         assert_eq!(n, 8, "denoised series keeps the input length");
         assert!(var < 25.0, "large threshold reduces variance below raw 25, got {var}");
+    }
+
+    #[test]
+    fn wavelet_denoise_preserves_odd_length() {
+        let conn = open_bench().unwrap();
+        // Odd / non-power-of-two input must still emit one row per sample (Codex #164
+        // P2 — Haar drops the unmatched tail without padding).
+        for series in ["[1,2,3,4,5]", "[1,2,3]", "[10,20,30,40,50,60,70]"] {
+            let want = series.matches(',').count() as i64 + 1;
+            let n: i64 = conn
+                .query_row(
+                    &format!("SELECT count(*) FROM ix_wavelet_denoise('{series}', 2, 0.1)"),
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, want, "{series}: one row per input sample");
+        }
     }
 
     #[test]

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -10,6 +10,11 @@
 //! Signal (`ix-signal`), input = a JSON number array (the series):
 //! - `ix_rfft(series)` → `TABLE(bin, magnitude)` — real FFT magnitude spectrum.
 //! - `ix_autocorrelation(series)` → `TABLE(lag, value)`.
+//! - `ix_wavelet_denoise(series, levels BIGINT, threshold DOUBLE)` → `TABLE(i, value)` —
+//!   soft-thresholded series (same length as input).
+//! - `ix_kalman_smooth(series, process_noise DOUBLE, measurement_noise DOUBLE)` →
+//!   `TABLE(i, value)` — constant-velocity 1-D Kalman position estimate (dt=1).
+//! - `ix_dct(series)` → `TABLE(k, coefficient)` — DCT-II coefficients.
 //!
 //! All wrap the real IX crates — no DSP/graph math reimplemented here.
 
@@ -20,7 +25,11 @@ use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 use duckdb::Connection;
 use ix_graph::graph::Graph;
 use ix_signal::correlation::autocorrelation;
+use ix_signal::dct::dct2;
 use ix_signal::fft::rfft;
+use ix_signal::kalman::constant_velocity_1d;
+use ix_signal::wavelet::wavelet_denoise;
+use ndarray::Array1;
 
 // ── shared output plumbing ────────────────────────────────────────────────────
 
@@ -277,12 +286,144 @@ impl VTab for IxAutocorrelation {
     }
 }
 
+// ── ix_wavelet_denoise ─────────────────────────────────────────────────────────
+
+struct IxWaveletDenoise;
+impl VTab for IxWaveletDenoise {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_wavelet_denoise emits (i,value) for the wavelet soft-thresholded series via ix_signal wavelet_denoise (same length as input); a larger threshold removes more high-frequency energy, so output variance does not exceed the input's [T:test conf:0.8 src:ix_duck::graphsig::tests::wavelet_denoise_reduces_variance]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let levels_req = bind.get_parameter(1).to_int64();
+        if levels_req < 1 {
+            return Err("levels must be >= 1".into());
+        }
+        let threshold = bind
+            .get_parameter(2)
+            .to_string()
+            .parse::<f64>()
+            .map_err(|e| format!("threshold must be a number: {e}"))?;
+        if !threshold.is_finite() || threshold < 0.0 {
+            return Err("threshold must be finite and >= 0".into());
+        }
+        // Cap the decomposition depth at floor(log2(n)) so a short series is never
+        // over-decomposed (each level halves the signal).
+        let max_levels = ((series.len() as f64).log2().floor() as usize).max(1);
+        let levels = (levels_req as usize).min(max_levels);
+        let rows: Vec<(i64, f64)> = wavelet_denoise(&series, levels, threshold)
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| (i as i64, v))
+            .collect();
+        two_cols(bind, "i", LogicalTypeId::Bigint, "value", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+// ── ix_kalman_smooth ───────────────────────────────────────────────────────────
+
+struct IxKalmanSmooth;
+impl VTab for IxKalmanSmooth {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_kalman_smooth emits (i,value) where value is the filtered position of a constant-velocity 1-D Kalman filter (ix_signal, dt=1) over the series; fed a constant-velocity ramp it locks onto the trajectory, so the final estimate converges to the final measurement [T:test conf:0.8 src:ix_duck::graphsig::tests::kalman_smooth_tracks_ramp]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let process_noise = parse_pos_finite(&bind.get_parameter(1).to_string(), "process_noise")?;
+        let measurement_noise =
+            parse_pos_finite(&bind.get_parameter(2).to_string(), "measurement_noise")?;
+        // dt = 1: telemetry samples are an evenly-spaced unit-step sequence.
+        let mut kf = constant_velocity_1d(process_noise, measurement_noise, 1.0);
+        let measurements: Vec<Array1<f64>> =
+            series.iter().map(|&z| Array1::from_vec(vec![z])).collect();
+        // state = [position, velocity]; the smoothed signal is the position estimate.
+        let rows: Vec<(i64, f64)> = kf
+            .filter(&measurements)
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (i as i64, s[0]))
+            .collect();
+        two_cols(bind, "i", LogicalTypeId::Bigint, "value", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+/// Parse a positive, finite `f64` parameter (Kalman noise covariances must be > 0).
+fn parse_pos_finite(s: &str, name: &str) -> Result<f64, Box<dyn std::error::Error>> {
+    let v: f64 = s.parse().map_err(|e| format!("{name} must be a number: {e}"))?;
+    if !v.is_finite() || v <= 0.0 {
+        return Err(format!("{name} must be a finite number > 0").into());
+    }
+    Ok(v)
+}
+
+// ── ix_dct ─────────────────────────────────────────────────────────────────────
+
+struct IxDct;
+impl VTab for IxDct {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_dct emits (k,coefficient) for the DCT-II of the series via ix_signal dct2 (same length as input); a constant signal concentrates all energy in the k=0 (DC) coefficient [T:test conf:0.8 src:ix_duck::graphsig::tests::dct_constant_concentrates_at_dc]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let rows: Vec<(i64, f64)> =
+            dct2(&series).iter().enumerate().map(|(i, &v)| (i as i64, v)).collect();
+        two_cols(bind, "k", LogicalTypeId::Bigint, "coefficient", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::Varchar)])
+    }
+}
+
 /// Register the graph + signal table functions.
 pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxPagerank>("ix_pagerank")?;
     conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
     conn.register_table_function::<IxRfft>("ix_rfft")?;
     conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
+    conn.register_table_function::<IxWaveletDenoise>("ix_wavelet_denoise")?;
+    conn.register_table_function::<IxKalmanSmooth>("ix_kalman_smooth")?;
+    conn.register_table_function::<IxDct>("ix_dct")?;
     Ok(())
 }
 
@@ -351,6 +492,80 @@ mod tests {
             )
             .unwrap();
         assert_eq!(peak_bin, 1, "one-cycle tone peaks at bin 1");
+    }
+
+    #[test]
+    fn wavelet_denoise_reduces_variance() {
+        let conn = open_bench().unwrap();
+        // High-frequency square wave around mean 5 (raw var_pop = 25). A large
+        // threshold kills the detail coefficients → the denoised series collapses
+        // toward the mean, so its variance must not exceed the raw series'.
+        let noisy = "[10,0,10,0,10,0,10,0]";
+        let (n, var): (i64, f64) = conn
+            .query_row(
+                &format!("SELECT count(*), var_pop(value) FROM ix_wavelet_denoise('{noisy}', 3, 50.0)"),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(n, 8, "denoised series keeps the input length");
+        assert!(var < 25.0, "large threshold reduces variance below raw 25, got {var}");
+    }
+
+    #[test]
+    fn kalman_smooth_tracks_ramp() {
+        let conn = open_bench().unwrap();
+        // A clean constant-velocity ramp 0..7 is exactly the filter's motion model;
+        // from a cold start [0,0] it locks on, so the final estimate lands near the
+        // final measurement (7). One estimate per measurement.
+        let ramp = "[0,1,2,3,4,5,6,7]";
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_kalman_smooth('{ramp}', 0.01, 0.5)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 8, "one filtered estimate per measurement");
+        let last: f64 = conn
+            .query_row(
+                &format!("SELECT value FROM ix_kalman_smooth('{ramp}', 0.01, 0.5) WHERE i=7"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            (5.0..=9.0).contains(&last),
+            "filter tracks the ramp to ~7, got {last}"
+        );
+    }
+
+    #[test]
+    fn kalman_smooth_rejects_nonpositive_noise() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT value FROM ix_kalman_smooth('[1,2,3]', 0.0, 1.0)",
+                [],
+                |r| r.get::<_, f64>(0)
+            )
+            .is_err(),
+            "process_noise=0 must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn dct_constant_concentrates_at_dc() {
+        let conn = open_bench().unwrap();
+        // A constant signal has all its energy in the DC (k=0) coefficient.
+        let dc_bin: i64 = conn
+            .query_row(
+                "SELECT k FROM ix_dct('[1,1,1,1,1,1,1,1]') ORDER BY abs(coefficient) DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dc_bin, 0, "constant signal → energy at the k=0 DC coefficient");
     }
 
     #[test]

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -294,6 +294,38 @@ mod tests {
     }
 
     #[test]
+    fn ix_minkowski_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        // p=1 → manhattan (|3|+|4| = 7)
+        let m1: f64 = conn
+            .query_row(
+                "SELECT ix_minkowski([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[], 1.0)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((m1 - 7.0).abs() < 1e-12, "p=1 → manhattan 7.0, got {m1}");
+
+        // p=2 → euclidean (3-4-5 → 5)
+        let m2: f64 = conn
+            .query_row(
+                "SELECT ix_minkowski([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[], 2.0)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((m2 - 5.0).abs() < 1e-12, "p=2 → euclidean 5.0, got {m2}");
+
+        // Dimension mismatch surfaces as a SQL error, not a panic.
+        let err = conn.query_row(
+            "SELECT ix_minkowski([1.0,0.0]::DOUBLE[], [1.0]::DOUBLE[], 2.0)",
+            [],
+            |r| r.get::<_, f64>(0),
+        );
+        assert!(err.is_err(), "dimension mismatch should be a SQL error");
+    }
+
+    #[test]
     fn ix_cosine_passes_null_through() {
         let conn = open_bench().unwrap();
         // A NULL list argument yields SQL NULL, not a spurious number.

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -69,6 +69,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Supervised fit/predict UDFs over `ix-supervised` — `ix_linreg_fit`/`_predict`
+/// and `ix_logistic_fit`/`_predict`, models round-tripped as JSON `VARCHAR` blobs.
+/// Registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod supervised;
+
 /// Artifact source — the deep module every lens reads through: safe materialization of
 /// a GA-emitted JSON artifact set into a bench table (file selection + read_json_auto
 /// flags + the json_extract projection + empty-fallback). See `CONTEXT.md` → "Artifact source".

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -236,6 +236,64 @@ mod tests {
     }
 
     #[test]
+    fn ix_manhattan_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        let d: f64 = conn
+            .query_row(
+                "SELECT ix_manhattan([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((d - 7.0).abs() < 1e-12, "|3|+|4| → 7.0, got {d}");
+
+        // Dimension mismatch surfaces as a SQL error, not a panic.
+        let err = conn.query_row(
+            "SELECT ix_manhattan([1.0,0.0]::DOUBLE[], [1.0]::DOUBLE[])",
+            [],
+            |r| r.get::<_, f64>(0),
+        );
+        assert!(err.is_err(), "dimension mismatch should be a SQL error");
+    }
+
+    #[test]
+    fn ix_chebyshev_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        let d: f64 = conn
+            .query_row(
+                "SELECT ix_chebyshev([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((d - 4.0).abs() < 1e-12, "max(|3|,|4|) → 4.0, got {d}");
+    }
+
+    #[test]
+    fn ix_cosine_distance_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        // identical → 0.0
+        let same: f64 = conn
+            .query_row(
+                "SELECT ix_cosine_distance([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(same.abs() < 1e-12, "identical → 0.0, got {same}");
+
+        // orthogonal → 1.0
+        let orth: f64 = conn
+            .query_row(
+                "SELECT ix_cosine_distance([1.0,0.0]::DOUBLE[], [0.0,1.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((orth - 1.0).abs() < 1e-12, "orthogonal → 1.0, got {orth}");
+    }
+
+    #[test]
     fn ix_cosine_passes_null_through() {
         let conn = open_bench().unwrap();
         // A NULL list argument yields SQL NULL, not a spurious number.

--- a/crates/ix-duck/src/supervised.rs
+++ b/crates/ix-duck/src/supervised.rs
@@ -1,0 +1,284 @@
+//! Supervised fit/predict UDFs over `ix-supervised`.
+//!
+//! DuckDB has `regr_slope`/`regr_intercept` (simple OLS aggregates) but nothing
+//! that fits a *multivariate* model you can persist and re-apply. These UDFs do,
+//! following the same **fit → blob → predict** shape as the `sketch` module: fit
+//! returns the trained model as a JSON `VARCHAR` you store in a column, then
+//! `predict` re-applies it to a feature vector.
+//!
+//! | model | fit | predict |
+//! |---|---|---|
+//! | linear   | `ix_linreg_fit(x_json, y_json)`   | `ix_linreg_predict(model, x_json)` → DOUBLE |
+//! | logistic | `ix_logistic_fit(x_json, y_json)` | `ix_logistic_predict(model, x_json)` → BIGINT (class) |
+//!
+//! `x_json` for **fit** is a JSON 2-D array `[[…features…], …]` (one row per
+//! sample); `y_json` is a 1-D array (`DOUBLE`s for linear, integer class ids for
+//! logistic). `x_json` for **predict** is a single 1-D feature vector. The whole
+//! training set enters as one scalar string, so a typical call is
+//! `SELECT ix_linreg_fit('[[1],[2],[3]]', '[2,4,6]')`.
+//!
+//! Pure wraps of `ix-supervised` — linear round-trips through its own
+//! `LinearRegressionState`; logistic serializes its public `(weights, bias)`.
+//! No model math here.
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::ffi::duckdb_string_t;
+use duckdb::types::DuckString;
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_supervised::linear_regression::{LinearRegression, LinearRegressionState};
+use ix_supervised::logistic_regression::LogisticRegression;
+use ix_supervised::traits::{Classifier, Regressor};
+use ndarray::{Array1, Array2};
+use std::error::Error;
+use std::ffi::CString;
+
+use crate::tablefn::parse_matrix;
+
+type Res = Result<(), Box<dyn Error>>;
+
+fn ty(id: LogicalTypeId) -> LogicalTypeHandle {
+    LogicalTypeHandle::from(id)
+}
+
+/// Read a `VARCHAR` column into owned `String`s (one per row).
+fn read_varchar(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<String> {
+    let v = input.flat_vector(col);
+    let slice = unsafe { v.as_slice_with_len::<duckdb_string_t>(n) };
+    slice
+        .iter()
+        .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string())
+        .collect()
+}
+
+fn write_varchar(output: &mut dyn WritableVector, vals: &[String]) -> Res {
+    let out = output.flat_vector();
+    for (i, v) in vals.iter().enumerate() {
+        out.insert(i, CString::new(v.as_str())?);
+    }
+    Ok(())
+}
+
+fn write_f64(output: &mut dyn WritableVector, vals: &[f64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<f64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+fn write_i64(output: &mut dyn WritableVector, vals: &[i64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<i64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+/// Parse a single 1-D JSON feature vector into a `(1, n_features)` matrix (the
+/// `predict` input shape).
+fn parse_feature_row(json: &str) -> Result<Array2<f64>, Box<dyn Error>> {
+    let feat: Vec<f64> =
+        serde_json::from_str(json).map_err(|e| format!("expected a JSON number array: {e}"))?;
+    if feat.is_empty() {
+        return Err("feature vector is empty".into());
+    }
+    let n = feat.len();
+    Ok(Array2::from_shape_vec((1, n), feat)?)
+}
+
+// ── linear regression ──────────────────────────────────────────────────────────
+
+struct IxLinregFit;
+impl VScalar for IxLinregFit {
+    type State = ();
+    // @ai:invariant ix_linreg_fit fits ix_supervised LinearRegression over the JSON (x 2-D, y 1-D) and returns its LinearRegressionState as a JSON blob; mismatched row counts -> SQL error (no panic) [T:test conf:0.85 src:ix_duck::supervised::tests::linreg_fit_predict_recovers_slope]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let xs = read_varchar(input, 0, n);
+        let ys = read_varchar(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = parse_matrix(&xs[i])?;
+            let y: Vec<f64> = serde_json::from_str(&ys[i])
+                .map_err(|e| format!("ix_linreg_fit: y must be a JSON number array: {e}"))?;
+            if y.len() != x.nrows() {
+                return Err(format!(
+                    "ix_linreg_fit: y length ({}) != number of samples ({})",
+                    y.len(),
+                    x.nrows()
+                )
+                .into());
+            }
+            let mut model = LinearRegression::new();
+            model.fit(&x, &Array1::from_vec(y));
+            let state = model
+                .save_state()
+                .ok_or("ix_linreg_fit: model did not fit")?;
+            out.push(serde_json::to_string(&state)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxLinregPredict;
+impl VScalar for IxLinregPredict {
+    type State = ();
+    // @ai:invariant ix_linreg_predict reloads a LinearRegressionState blob and returns the model's prediction for the JSON feature vector; a model fit on y=2x predicts ~2*x [T:test conf:0.85 src:ix_duck::supervised::tests::linreg_fit_predict_recovers_slope]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let models = read_varchar(input, 0, n);
+        let xs = read_varchar(input, 1, n);
+        let mut out = vec![0.0f64; n];
+        for i in 0..n {
+            let state: LinearRegressionState = serde_json::from_str(&models[i])
+                .map_err(|e| format!("ix_linreg_predict: invalid model blob: {e}"))?;
+            let model = LinearRegression::load_state(&state);
+            let x = parse_feature_row(&xs[i])?;
+            out[i] = model.predict(&x)[0];
+        }
+        write_f64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Double),
+        )]
+    }
+}
+
+// ── logistic regression ────────────────────────────────────────────────────────
+
+struct IxLogisticFit;
+impl VScalar for IxLogisticFit {
+    type State = ();
+    // @ai:invariant ix_logistic_fit fits ix_supervised LogisticRegression over the JSON (x 2-D, y 1-D class ids) and returns its (weights, bias) as a JSON blob; mismatched row counts -> SQL error (no panic) [T:test conf:0.85 src:ix_duck::supervised::tests::logistic_fit_predict_separates_classes]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let xs = read_varchar(input, 0, n);
+        let ys = read_varchar(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = parse_matrix(&xs[i])?;
+            let y: Vec<usize> = serde_json::from_str(&ys[i])
+                .map_err(|e| format!("ix_logistic_fit: y must be a JSON int array: {e}"))?;
+            if y.len() != x.nrows() {
+                return Err(format!(
+                    "ix_logistic_fit: y length ({}) != number of samples ({})",
+                    y.len(),
+                    x.nrows()
+                )
+                .into());
+            }
+            let mut model = LogisticRegression::new();
+            model.fit(&x, &Array1::from_vec(y));
+            let weights = model
+                .weights
+                .as_ref()
+                .ok_or("ix_logistic_fit: model did not fit")?
+                .to_vec();
+            // LogisticRegression has no save_state; its (weights, bias) fully
+            // determine predictions, so serialize that tuple directly.
+            out.push(serde_json::to_string(&(weights, model.bias))?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxLogisticPredict;
+impl VScalar for IxLogisticPredict {
+    type State = ();
+    // @ai:invariant ix_logistic_predict reloads a (weights, bias) blob and returns the predicted class id for the JSON feature vector; points on opposite sides of a fitted boundary get different classes [T:test conf:0.85 src:ix_duck::supervised::tests::logistic_fit_predict_separates_classes]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let models = read_varchar(input, 0, n);
+        let xs = read_varchar(input, 1, n);
+        let mut out = vec![0i64; n];
+        for i in 0..n {
+            let (weights, bias): (Vec<f64>, f64) = serde_json::from_str(&models[i])
+                .map_err(|e| format!("ix_logistic_predict: invalid model blob: {e}"))?;
+            let mut model = LogisticRegression::new();
+            model.weights = Some(Array1::from_vec(weights));
+            model.bias = bias;
+            let x = parse_feature_row(&xs[i])?;
+            out[i] = model.predict(&x)[0] as i64;
+        }
+        write_i64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Bigint),
+        )]
+    }
+}
+
+/// Register the supervised fit/predict UDFs.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxLinregFit>("ix_linreg_fit")?;
+    conn.register_scalar_function::<IxLinregPredict>("ix_linreg_predict")?;
+    conn.register_scalar_function::<IxLogisticFit>("ix_logistic_fit")?;
+    conn.register_scalar_function::<IxLogisticPredict>("ix_logistic_predict")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    #[test]
+    fn linreg_fit_predict_recovers_slope() {
+        let conn = open_bench().unwrap();
+        // Fit y = 2x on a perfect line, then predict at x=6 → ~12.
+        let pred: f64 = conn
+            .query_row(
+                "SELECT ix_linreg_predict(\
+                    ix_linreg_fit('[[1],[2],[3],[4],[5]]', '[2,4,6,8,10]'), '[6]')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((pred - 12.0).abs() < 1e-6, "y=2x model predicts ~12 at x=6, got {pred}");
+    }
+
+    #[test]
+    fn linreg_fit_rejects_mismatched_lengths() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT ix_linreg_fit('[[1],[2],[3]]', '[2,4]')",
+                [],
+                |r| r.get::<_, String>(0)
+            )
+            .is_err(),
+            "y shorter than x must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn logistic_fit_predict_separates_classes() {
+        let conn = open_bench().unwrap();
+        // 1-D, linearly separable: class 0 below ~2.5, class 1 above. A point at
+        // x=0 should predict class 0; x=5 should predict class 1.
+        let model = "ix_logistic_fit('[[0],[1],[2],[3],[4],[5]]', '[0,0,0,1,1,1]')";
+        let lo: i64 = conn
+            .query_row(&format!("SELECT ix_logistic_predict({model}, '[0]')"), [], |r| r.get(0))
+            .unwrap();
+        let hi: i64 = conn
+            .query_row(&format!("SELECT ix_logistic_predict({model}, '[5]')"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(lo, 0, "x=0 is in the low class");
+        assert_eq!(hi, 1, "x=5 is in the high class");
+    }
+}

--- a/crates/ix-duck/src/supervised.rs
+++ b/crates/ix-duck/src/supervised.rs
@@ -107,11 +107,24 @@ impl VScalar for IxLinregFit {
                 )
                 .into());
             }
-            let mut model = LinearRegression::new();
-            model.fit(&x, &Array1::from_vec(y));
-            let state = model
-                .save_state()
-                .ok_or("ix_linreg_fit: model did not fit")?;
+            // LinearRegression::fit solves the normal equation with `.expect("X^T X
+            // is singular")`, which PANICS on collinear/underdetermined data (duplicated
+            // features, fewer rows than parameters). A panic must not unwind through the
+            // DuckDB FFI boundary (UB) — catch it and surface a SQL error instead.
+            let fit = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let mut model = LinearRegression::new();
+                model.fit(&x, &Array1::from_vec(y));
+                model.save_state()
+            }));
+            let state = match fit {
+                Ok(Some(s)) => s,
+                Ok(None) => return Err("ix_linreg_fit: model did not fit".into()),
+                Err(_) => {
+                    return Err("ix_linreg_fit: singular/underdetermined training data \
+                                (XᵀX not invertible — collinear features or too few rows)"
+                        .into())
+                }
+            };
             out.push(serde_json::to_string(&state)?);
         }
         write_varchar(output, &out)
@@ -264,6 +277,19 @@ mod tests {
             .is_err(),
             "y shorter than x must be a SQL error"
         );
+    }
+
+    #[test]
+    fn linreg_fit_singular_is_sql_error_not_panic() {
+        let conn = open_bench().unwrap();
+        // Collinear features (col2 = 2·col1) make XᵀX singular → fit() would panic;
+        // the UDF must catch it and return a SQL error (Codex #164 P2).
+        let err = conn.query_row(
+            "SELECT ix_linreg_fit('[[1,2],[2,4],[3,6]]', '[3,6,9]')",
+            [],
+            |r| r.get::<_, String>(0),
+        );
+        assert!(err.is_err(), "singular training data must be a SQL error, not a panic");
     }
 
     #[test]

--- a/crates/ix-duck/src/tablefn.rs
+++ b/crates/ix-duck/src/tablefn.rs
@@ -328,14 +328,20 @@ impl VTab for IxMdsProject {
     type InitData = ProjectInit;
     type BindData = ProjectBind;
 
-    // @ai:invariant ix_mds_project runs classical (distance-preserving) MDS over the pairwise Euclidean distances of the JSON input vectors and emits one row per input with its min(n_components, n_features)-D embedding; well-separated points stay separated [T:test conf:0.8 src:ix_duck::tablefn::tests::mds_project_preserves_separation]
+    // @ai:invariant ix_mds_project runs classical (distance-preserving) MDS over the pairwise Euclidean distances of the JSON input vectors and emits one row per input with its min(n_components, n_features, n_samples-1)-D embedding; well-separated points stay separated [T:test conf:0.8 src:ix_duck::tablefn::tests::mds_project_preserves_separation]
     fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
         let x = parse_matrix(&bind.get_parameter(0).to_string())?;
         let k_req = bind.get_parameter(1).to_int64();
         if k_req < 1 {
             return Err("n_components must be >= 1".into());
         }
-        let k = (k_req as usize).min(x.ncols());
+        if x.nrows() < 2 {
+            return Err("ix_mds_project needs at least 2 vectors".into());
+        }
+        // classical_mds rejects k >= n_samples, so cap by n_samples-1 too — not just
+        // feature count — or a small/wide slice like ('[[0,0],[1,1]]', 2) would error
+        // despite the advertised "caps the requested dimension" contract.
+        let k = (k_req as usize).min(x.ncols()).min(x.nrows() - 1);
         let distances = pairwise_euclidean(&x);
         let projected_mat =
             classical_mds(&distances, k).map_err(|e| format!("ix_mds_project: {e}"))?;
@@ -918,6 +924,28 @@ mod tests {
             )
             .is_err(),
             "perplexity=0 must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn mds_project_caps_components_at_n_minus_one() {
+        let conn = open_bench().unwrap();
+        // 2 samples, 2 features, k=2: classical_mds rejects k>=n, so the cap must drop
+        // k to n-1=1 rather than erroring (Codex #164 P2).
+        let dim: i64 = conn
+            .query_row(
+                "SELECT len(coords) FROM ix_mds_project('[[0,0],[1,1]]', 2) LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dim, 1, "k capped at n_samples-1");
+        // A single vector has no pairwise distances → clean SQL error, not a panic.
+        assert!(
+            conn.query_row("SELECT coords[1] FROM ix_mds_project('[[1,2,3]]', 1)", [], |r| r
+                .get::<_, f64>(0))
+                .is_err(),
+            "single vector must be a SQL error"
         );
     }
 

--- a/crates/ix-duck/src/tablefn.rs
+++ b/crates/ix-duck/src/tablefn.rs
@@ -28,6 +28,11 @@
 //!     cluster labels `0..k-1`. `k` is capped at the sample count; deterministic
 //!     (seed 42). The centroid/mixture complement to `ix_dbscan`'s density labels —
 //!     all three feed `ix_silhouette`. Wrap `ix_unsupervised::{kmeans,gmm}`.
+//! - `ix_tsne_project(json_vectors VARCHAR, n_components BIGINT, perplexity DOUBLE)` /
+//!   `ix_mds_project(json_vectors VARCHAR, n_components BIGINT)`
+//!     → `TABLE(row BIGINT, coords DOUBLE[])`, the non-linear (t-SNE, seed 42) and
+//!     distance-preserving (classical MDS) companions to `ix_pca_project`. Wrap
+//!     `ix_unsupervised::{tsne::TSNE, mds::classical_mds}` — no reimplementation.
 //!
 //! A whole set enters in one SQL call as JSON scalar params (a 2-D number array
 //! for vectors, a 1-D int array for labels):
@@ -47,8 +52,10 @@ use ix_math::distance::euclidean;
 use ix_unsupervised::dbscan::DBSCAN;
 use ix_unsupervised::gmm::GMM;
 use ix_unsupervised::kmeans::KMeans;
+use ix_unsupervised::mds::{classical_mds, pairwise_euclidean};
 use ix_unsupervised::pca::PCA;
 use ix_unsupervised::traits::{Clusterer, DimensionReducer};
+use ix_unsupervised::tsne::TSNE;
 use ndarray::{Array1, Array2};
 
 /// Register every IX table function on `conn`.
@@ -59,6 +66,8 @@ pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxDbscan>("ix_dbscan")?;
     conn.register_table_function::<IxKmeans>("ix_kmeans")?;
     conn.register_table_function::<IxGmm>("ix_gmm")?;
+    conn.register_table_function::<IxTsneProject>("ix_tsne_project")?;
+    conn.register_table_function::<IxMdsProject>("ix_mds_project")?;
     Ok(())
 }
 
@@ -176,6 +185,173 @@ impl VTab for IxPcaProject {
         output.set_len(rows);
         init.cursor.store(start + rows, Ordering::Relaxed);
         Ok(())
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        ])
+    }
+}
+
+// ── ix_tsne_project / ix_mds_project (DimensionReducer companions to PCA) ──────
+//
+// All three project a (json_vectors, k[, …]) call to TABLE(row BIGINT, coords DOUBLE[]),
+// so they share the streaming `func` (row index + a length-`k` coords list per row).
+// Only the projection differs: PCA (linear, above), t-SNE (non-linear, perplexity),
+// classical MDS (distance-preserving). Both new estimators are seeded for determinism.
+
+#[repr(C)]
+struct ProjectBind {
+    /// Projected coordinates: one inner Vec (length `k`) per input row.
+    projected: Vec<Vec<f64>>,
+    k: usize,
+}
+#[repr(C)]
+struct ProjectInit {
+    cursor: AtomicUsize,
+}
+
+/// Shared streaming `func` for projection table functions: emit `row` (BIGINT) and
+/// `coords` (LIST<DOUBLE>, length `k`) in output-vector-sized chunks via the cursor.
+fn emit_coord_rows(
+    projected: &[Vec<f64>],
+    k: usize,
+    cursor: &AtomicUsize,
+    output: &mut DataChunkHandle,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let n = projected.len();
+    let start = cursor.load(Ordering::Relaxed);
+    if start >= n {
+        output.set_len(0);
+        return Ok(());
+    }
+    let cap = output.flat_vector(0).capacity();
+    let rows = (n - start).min(cap);
+
+    // col 0: row index (BIGINT)
+    {
+        let mut idx_vec = output.flat_vector(0);
+        let slice = unsafe { idx_vec.as_mut_slice_with_len::<i64>(rows) };
+        for (i, s) in slice.iter_mut().enumerate().take(rows) {
+            *s = (start + i) as i64;
+        }
+    }
+    // col 1: coords (LIST<DOUBLE>)
+    {
+        let total = rows * k;
+        let flat: Vec<f64> = (0..rows)
+            .flat_map(|i| projected[start + i].iter().copied())
+            .collect();
+        let mut lv = output.list_vector(1);
+        {
+            let mut child = lv.child(total);
+            let cslice = unsafe { child.as_mut_slice_with_len::<f64>(total) };
+            cslice[..total].copy_from_slice(&flat);
+        }
+        lv.set_len(total);
+        for i in 0..rows {
+            lv.set_entry(i, i * k, k);
+        }
+    }
+    output.set_len(rows);
+    cursor.store(start + rows, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Declare the shared (row, coords) result columns and turn an `(n_samples, k)`
+/// coordinate matrix into the row-wise `ProjectBind`.
+fn project_bind(bind: &BindInfo, projected_mat: Array2<f64>, k: usize) -> ProjectBind {
+    let projected: Vec<Vec<f64>> = (0..projected_mat.nrows())
+        .map(|r| projected_mat.row(r).to_vec())
+        .collect();
+    bind.add_result_column("row", LogicalTypeHandle::from(LogicalTypeId::Bigint));
+    bind.add_result_column(
+        "coords",
+        LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Double)),
+    );
+    ProjectBind { projected, k }
+}
+
+struct IxTsneProject;
+
+impl VTab for IxTsneProject {
+    type InitData = ProjectInit;
+    type BindData = ProjectBind;
+
+    // @ai:invariant ix_tsne_project fits ix_unsupervised TSNE (seed 42, given perplexity) over the JSON input vectors and emits one row per input with its min(n_components, n_features)-D embedding; deterministic for fixed seed [T:test conf:0.8 src:ix_duck::tablefn::tests::tsne_project_shape_and_deterministic]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let x = parse_matrix(&bind.get_parameter(0).to_string())?;
+        let k_req = bind.get_parameter(1).to_int64();
+        if k_req < 1 {
+            return Err("n_components must be >= 1".into());
+        }
+        let perplexity = bind.get_parameter(2).to_string().parse::<f64>().ok();
+        let perplexity = match perplexity {
+            Some(p) if p.is_finite() && p > 0.0 => p,
+            _ => return Err("perplexity must be a finite number > 0".into()),
+        };
+        // t-SNE's perplexity must stay below the sample count (it is a soft neighbour
+        // count); cap it so tiny analyst-bench inputs don't blow up the affinities.
+        let perplexity = perplexity.min((x.nrows() as f64 - 1.0).max(1.0));
+        let k = (k_req as usize).min(x.ncols());
+        let mut tsne = TSNE::new(k).with_perplexity(perplexity).with_seed(42);
+        let projected_mat = tsne.fit_transform(&x);
+        Ok(project_bind(bind, projected_mat, k))
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(ProjectInit { cursor: AtomicUsize::new(0) })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        emit_coord_rows(&bind.projected, bind.k, &func.get_init_data().cursor, output)
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+struct IxMdsProject;
+
+impl VTab for IxMdsProject {
+    type InitData = ProjectInit;
+    type BindData = ProjectBind;
+
+    // @ai:invariant ix_mds_project runs classical (distance-preserving) MDS over the pairwise Euclidean distances of the JSON input vectors and emits one row per input with its min(n_components, n_features)-D embedding; well-separated points stay separated [T:test conf:0.8 src:ix_duck::tablefn::tests::mds_project_preserves_separation]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let x = parse_matrix(&bind.get_parameter(0).to_string())?;
+        let k_req = bind.get_parameter(1).to_int64();
+        if k_req < 1 {
+            return Err("n_components must be >= 1".into());
+        }
+        let k = (k_req as usize).min(x.ncols());
+        let distances = pairwise_euclidean(&x);
+        let projected_mat =
+            classical_mds(&distances, k).map_err(|e| format!("ix_mds_project: {e}"))?;
+        Ok(project_bind(bind, projected_mat, k))
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(ProjectInit { cursor: AtomicUsize::new(0) })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        emit_coord_rows(&bind.projected, bind.k, &func.get_init_data().cursor, output)
     }
 
     fn parameters() -> Option<Vec<LogicalTypeHandle>> {
@@ -689,6 +865,101 @@ mod tests {
             )
             .unwrap();
         assert_eq!(dim, 2, "n_components capped at n_features");
+    }
+
+    #[test]
+    fn tsne_project_shape_and_deterministic() {
+        let conn = open_bench().unwrap();
+        let pts = "[[0,0],[0,1],[1,0],[10,10],[10,11],[11,10]]";
+        // one row per input; coords length == n_components.
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_tsne_project('{pts}', 1, 2.0)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 6, "one row per input vector");
+        let dim: i64 = conn
+            .query_row(
+                &format!("SELECT len(coords) FROM ix_tsne_project('{pts}', 1, 2.0) LIMIT 1"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dim, 1, "coords length == n_components");
+
+        // Seeded (42) → deterministic: row 0's coord is identical across two runs.
+        let a: f64 = conn
+            .query_row(
+                &format!("SELECT coords[1] FROM ix_tsne_project('{pts}', 1, 2.0) WHERE row=0"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let b: f64 = conn
+            .query_row(
+                &format!("SELECT coords[1] FROM ix_tsne_project('{pts}', 1, 2.0) WHERE row=0"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((a - b).abs() < 1e-12, "seed 42 → deterministic embedding");
+    }
+
+    #[test]
+    fn tsne_project_rejects_bad_perplexity() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT coords[1] FROM ix_tsne_project('[[0,0],[1,1]]', 1, 0.0)",
+                [],
+                |r| r.get::<_, f64>(0)
+            )
+            .is_err(),
+            "perplexity=0 must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn mds_project_preserves_separation() {
+        let conn = open_bench().unwrap();
+        // Two tight clusters far apart; 1-D classical MDS must keep them apart.
+        let pts = "[[0,0],[0,1],[10,10],[10,11]]";
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_mds_project('{pts}', 1)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 4, "one row per input vector");
+
+        // |coord(row0) − coord(row2)| (cross-cluster) ≫ |coord(row0) − coord(row1)| (within).
+        let cross: f64 = conn
+            .query_row(
+                &format!(
+                    "SELECT abs((SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=0) \
+                              - (SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=2))"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let within: f64 = conn
+            .query_row(
+                &format!(
+                    "SELECT abs((SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=0) \
+                              - (SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=1))"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            cross > within * 3.0,
+            "cross-cluster MDS distance dominates within-cluster (cross={cross}, within={within})"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -291,5 +291,6 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     crate::eval::register(conn)?;
     crate::sketch::register(conn)?;
     crate::code::register(conn)?;
+    crate::supervised::register(conn)?;
     Ok(())
 }

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -1,9 +1,11 @@
 //! IX algorithms exposed as DuckDB scalar UDFs (via the `VScalar` trait).
 //!
-//! `ix_cosine(a, b)` and `ix_euclidean(a, b)` take two `DOUBLE[]` (LIST<DOUBLE>)
+//! The pairwise distance UDFs (`ix_cosine`, `ix_euclidean`, `ix_manhattan`,
+//! `ix_chebyshev`, `ix_cosine_distance`) each take two `DOUBLE[]` (LIST<DOUBLE>)
 //! and return a `DOUBLE`, wrapping the real `ix_math::distance` functions (no
 //! reimplementation). `ix_euclidean` is the primitive for the kNN-distance / OOD
-//! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`).
+//! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`); `ix_cosine_distance`
+//! (= 1 − cosine_similarity) is the metric-space companion for the same recipe.
 //!
 //! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions
 //! in the sibling `tablefn` module; [`register_all`] registers both surfaces.
@@ -12,7 +14,7 @@ use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use duckdb::Connection;
-use ix_math::distance::{cosine_similarity, euclidean};
+use ix_math::distance::{chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan};
 use ix_math::error::MathError;
 use ndarray::Array1;
 
@@ -137,11 +139,85 @@ impl VScalar for IxEuclidean {
     }
 }
 
-/// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`) and
-/// table (`ix_pca_project`, `ix_silhouette`) functions.
+/// `ix_manhattan(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — L1 (city-block) distance.
+struct IxManhattan;
+
+impl VScalar for IxManhattan {
+    type State = ();
+
+    // @ai:invariant ix_manhattan returns ix_math manhattan L1 distance of its two DOUBLE[] args; equal vectors -> 0.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_manhattan_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_manhattan", manhattan)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// `ix_chebyshev(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — L∞ (max-coordinate) distance.
+struct IxChebyshev;
+
+impl VScalar for IxChebyshev {
+    type State = ();
+
+    // @ai:invariant ix_chebyshev returns ix_math chebyshev L∞ distance of its two DOUBLE[] args; equal vectors -> 0.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_chebyshev_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_chebyshev", chebyshev)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// `ix_cosine_distance(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — `1 − cosine_similarity`,
+/// in `[0, 2]`. The metric-space companion to `ix_cosine` for kNN-distance / OOD.
+struct IxCosineDistance;
+
+impl VScalar for IxCosineDistance {
+    type State = ();
+
+    // @ai:invariant ix_cosine_distance returns ix_math cosine_distance (1 − cosine_similarity) of its two DOUBLE[] args; identical vectors -> 0.0, orthogonal -> 1.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_cosine_distance_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_cosine_distance", cosine_distance)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`,
+/// `ix_manhattan`, `ix_chebyshev`, `ix_cosine_distance`) and table
+/// (`ix_pca_project`, `ix_silhouette`) functions.
 pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxCosine>("ix_cosine")?;
     conn.register_scalar_function::<IxEuclidean>("ix_euclidean")?;
+    conn.register_scalar_function::<IxManhattan>("ix_manhattan")?;
+    conn.register_scalar_function::<IxChebyshev>("ix_chebyshev")?;
+    conn.register_scalar_function::<IxCosineDistance>("ix_cosine_distance")?;
     crate::tablefn::register(conn)?;
     crate::bracelet::register(conn)?;
     crate::serial::register(conn)?;

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -6,6 +6,8 @@
 //! reimplementation). `ix_euclidean` is the primitive for the kNN-distance / OOD
 //! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`); `ix_cosine_distance`
 //! (= 1 − cosine_similarity) is the metric-space companion for the same recipe.
+//! `ix_minkowski(a, b, p)` adds a third scalar exponent (p=1 → manhattan, p=2 →
+//! euclidean) and so has its own invoke path.
 //!
 //! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions
 //! in the sibling `tablefn` module; [`register_all`] registers both surfaces.
@@ -14,7 +16,9 @@ use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use duckdb::Connection;
-use ix_math::distance::{chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan};
+use ix_math::distance::{
+    chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan, minkowski,
+};
 use ix_math::error::MathError;
 use ndarray::Array1;
 
@@ -209,6 +213,66 @@ impl VScalar for IxCosineDistance {
     }
 }
 
+/// `ix_minkowski(a DOUBLE[], b DOUBLE[], p DOUBLE) -> DOUBLE` — the Lᵖ family.
+/// `p = 1` reduces to manhattan, `p = 2` to euclidean. Unlike the 2-arg metrics
+/// this reads a third (scalar `DOUBLE`) argument, so it has its own invoke path.
+struct IxMinkowski;
+
+impl VScalar for IxMinkowski {
+    type State = ();
+
+    // @ai:invariant ix_minkowski(a,b,p) returns ix_math minkowski Lᵖ distance; p=1 equals ix_manhattan, p=2 equals ix_euclidean; a NULL list or NULL p yields SQL NULL; dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_minkowski_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let n = input.len();
+        let a_null = null_mask(input, 0, n);
+        let b_null = null_mask(input, 1, n);
+        let p_null = null_mask(input, 2, n);
+        let a = read_list_col(input, 0, n);
+        let b = read_list_col(input, 1, n);
+        // The `p` exponent is a flat DOUBLE column (one value per row).
+        let p_vals: Vec<f64> = {
+            let pv = input.flat_vector(2);
+            let s = pv.as_slice_with_len::<f64>(n);
+            s[..n].to_vec()
+        };
+        let mut out = output.flat_vector();
+        {
+            let out_slice = out.as_mut_slice_with_len::<f64>(n);
+            for i in 0..n {
+                if a_null[i] || b_null[i] || p_null[i] {
+                    out_slice[i] = 0.0; // placeholder; row flagged NULL below
+                    continue;
+                }
+                let av = Array1::from_vec(a[i].clone());
+                let bv = Array1::from_vec(b[i].clone());
+                out_slice[i] =
+                    minkowski(&av, &bv, p_vals[i]).map_err(|e| format!("ix_minkowski: {e}"))?;
+            }
+        }
+        for i in 0..n {
+            if a_null[i] || b_null[i] || p_null[i] {
+                out.set_null(i);
+            }
+        }
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![
+                list_double(),
+                list_double(),
+                LogicalTypeHandle::from(LogicalTypeId::Double),
+            ],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
 /// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`,
 /// `ix_manhattan`, `ix_chebyshev`, `ix_cosine_distance`) and table
 /// (`ix_pca_project`, `ix_silhouette`) functions.
@@ -218,6 +282,7 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxManhattan>("ix_manhattan")?;
     conn.register_scalar_function::<IxChebyshev>("ix_chebyshev")?;
     conn.register_scalar_function::<IxCosineDistance>("ix_cosine_distance")?;
+    conn.register_scalar_function::<IxMinkowski>("ix_minkowski")?;
     crate::tablefn::register(conn)?;
     crate::bracelet::register(conn)?;
     crate::serial::register(conn)?;

--- a/docs/plans/2026-06-21-001-feat-ix-math-inference-primitive-plan.md
+++ b/docs/plans/2026-06-21-001-feat-ix-math-inference-primitive-plan.md
@@ -1,0 +1,113 @@
+---
+title: ix-math::inference — the statistical-inference primitive (two-sample tests, divergences, moments)
+type: feat
+status: draft
+date: 2026-06-21
+origin: investigation "are we missing any ML/math tool in DuckDB/IX?" (2026-06-21)
+reversibility: one-way (new public ix-math surface + new ix-duck UDFs) — see "One-way door" below
+revisit-trigger: first telemetry regression-gate that needs distribution-shift detection, or any consumer importing ix_math::inference
+---
+
+# ix-math::inference — the missing statistical layer
+
+> One-page design produced from the 2026-06-21 gap analysis of the DuckDB/IX surface.
+> Of six gaps found, five are *exposure* gaps (wire an existing IX algorithm through a
+> UDF). **This is the only *algorithm* gap** — the primitive is absent from `ix-math`
+> *and* from DuckDB built-ins. It is therefore the highest-leverage piece and the one
+> that needs design before code.
+
+## Problem / why
+
+`ix-duck` is an analyst bench over **JSONL time-series telemetry** (routing, OOD, loop,
+chatbot, quality lenses). The single most-used analyst question over such data is
+*"did this metric's distribution shift versus baseline?"* — the core of any RSI /
+regression gate. Today neither side can answer it:
+
+- **`ix-math::stats`** has only `mean / variance / std_dev / median / covariance_matrix /
+  correlation_matrix / min_max`. No higher moments, no quantiles, no divergences, no tests.
+- **DuckDB built-ins** give `quantile`, `stddev`, `corr`, `regr_*` — but **no** two-sample
+  test (KS, Mann–Whitney, t-test), **no** divergence (KL, JS), **no** skew/kurtosis/MAD,
+  **no** entropy / mutual-information.
+
+So the `maintain` gate currently compares distributions with hand-rolled thresholds on
+means. That is exactly the Goodhart-prone shortcut the RSI work warned against: a mean can
+hold steady while the *distribution* degrades (variance blow-up, bimodality, tail shift).
+
+Who is in pain: the maintain-gate / RSI loop (and any future telemetry gate) — it cannot
+make a principled "distributions differ" call. What changes: a fail-closed gate can assert
+"today's `coverage_max` distribution differs from the 30-day baseline at p<0.01 (KS)" as a
+**bound, testable** verdict instead of a tuned threshold.
+
+## What we're building
+
+A new pure-Rust module `ix-math::inference` (no new deps — built on `ndarray` + the
+existing `stats` primitives), then a thin UDF layer in `ix-duck`. Two tiers:
+
+### Tier 1 — descriptive (distribution shape over one column)
+| fn | signature | notes |
+|----|-----------|-------|
+| `quantile` | `(x, q) -> f64` | linear interpolation; `q∈[0,1]` |
+| `iqr`, `mad` | `(x) -> f64` | robust spread (MAD = median abs deviation) |
+| `skewness`, `kurtosis` | `(x) -> f64` | 3rd/4th standardized moments (excess kurtosis) |
+| `zscore` | `(x) -> Array1` | `(xᵢ − mean)/std`; the normalize the bench keeps re-deriving |
+| `shannon_entropy` | `(p) -> f64` | over a normalized histogram / probability vector |
+
+### Tier 2 — inferential (two-sample: today vs baseline)
+| fn | signature | returns | notes |
+|----|-----------|---------|-------|
+| `ks_two_sample` | `(a, b) -> TestResult` | `{statistic, p_value}` | **the primary gate primitive** — distribution-free, no normality assumption |
+| `mann_whitney_u` | `(a, b) -> TestResult` | `{u, p_value}` | rank-based location shift |
+| `welch_t_test` | `(a, b) -> TestResult` | `{t, df, p_value}` | unequal-variance means |
+| `kl_divergence` | `(p, q) -> f64` | nats | over aligned histograms; asymmetric |
+| `js_divergence` | `(p, q) -> f64` | nats | symmetric, bounded — safer default than KL |
+
+`TestResult { statistic: f64, p_value: f64 }` — one small public struct.
+
+### UDF layer (`ix-duck`, after the module lands)
+- Scalars over `DOUBLE[]`: `ix_quantile(x, q)`, `ix_skewness(x)`, `ix_kurtosis(x)`,
+  `ix_mad(x)`, `ix_entropy(p)`, `ix_kl(p,q)`, `ix_js(p,q)`.
+- Table fn `ix_two_sample(a DOUBLE[], b DOUBLE[], test VARCHAR) -> (statistic, p_value)`
+  so SQL can pick KS / Mann–Whitney / Welch by name in one call.
+
+## Tracer-bullet slice (Karpathy r2 / aihero)
+
+Smallest end-to-end cut, **all layers**: `ks_two_sample` only →
+`ix_two_sample(..., 'ks')` UDF → one `maintain`-gate query that compares today's
+`coverage_max` vs the baseline window → assert a known-shifted fixture trips p<0.01 and a
+same-distribution fixture does not. Ship that, get feedback, *then* fan out the rest of the
+table. Do **not** build all 10 functions before the first SQL call works.
+
+## Instrumentation (CLAUDE.md "instrument before you ship")
+
+- **Baseline**: the current maintain-gate verdict series in
+  `state/thinking-machine/maintain-gate.jsonl`.
+- **Expected direction**: false-flip rate of the gate should *drop* (mean-threshold
+  flapping replaced by a distribution test); detection of a genuine seeded regression
+  should *fire*.
+- **Guardrail**: KS must not flag two samples drawn from the same fixture (TNR check) —
+  the asymmetric fail-closed discipline from `feedback_llm_judge_panel_failclosed`. A test
+  primitive that cries wolf is worse than none.
+
+## One-way door — sign-off required
+
+New **public `ix-math` API** (a stable-tier crate) + new public `TestResult` type. Per
+CLAUDE.md the stable-surface gate (`pub `-line hash) will trip on the added `pub fn`s →
+this needs the version-bump / beta-demote dance and operator sign-off before merge. The
+**p-value implementations** are the risk: KS/Mann–Whitney asymptotic tails and the
+t-distribution CDF must be validated against a reference (SciPy values pinned in tests),
+or the gate is "green but wrong." No LLM may stand in as the correctness oracle here —
+pin numeric fixtures.
+
+Two-way (cheap to revert): the `ix-duck` UDF names — internal-tier, no downstream contract.
+
+## Out of scope
+
+- Multiple-comparison correction, bootstrap CIs, Bayesian tests — add only if a consumer asks.
+- Replacing DuckDB's native `quantile`/`stddev`/`corr` — we *complement*, never shadow them.
+
+## Links
+
+- Gap analysis: this investigation (2026-06-21).
+- RSI guardrail discipline: `docs/solutions/**` + the maintain-gate ledger.
+- Sibling exposure-gaps (separate issues): ix-signal time-series UDFs, t-SNE/MDS projection,
+  supervised fit/predict, graph centrality.


### PR DESCRIPTION
Closes #157, #158, #159, #162. Part of the DuckDB/IX UDF-surface gap analysis (tracker #163).

Wires existing IX algorithms through the ix-duck bench as SQL UDFs — pure wraps, no algorithm reimplemented:

- **Distance family** (#162): `ix_manhattan`, `ix_chebyshev`, `ix_cosine_distance`, `ix_minkowski(a,b,p)`
- **Dim-reduction** (#158): `ix_tsne_project`, `ix_mds_project` (companions to `ix_pca_project`)
- **Time-series** (#157): `ix_wavelet_denoise`, `ix_kalman_smooth`, `ix_dct`
- **Supervised** (#159): `ix_linreg_fit/predict`, `ix_logistic_fit/predict` (model round-trips as a JSON VARCHAR blob)

Also includes the `docs/plans/2026-06-21-001-feat-ix-math-inference-primitive-plan.md` design note.

**Verification:** +13 ix-duck tests green; `cargo clippy -p ix-duck --features duck --all-targets -D warnings` clean. Default/`--workspace` build untouched (all behind the opt-in `udf`/`duck` features).

Independent of #161 and #160 (disjoint UDF modules; trivial both-add conflicts in `udf.rs`/`graphsig.rs` if merged after them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)