### PR TITLE
feat(ix-duck): ADR-0004 pipeline-mesh correlation substrate + ix_pearson (DRAFT — merge last)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,13 @@ contracts (see `docs/contracts/`), not runtime coupling.
 - **Lens** — a read-only analyst module on the bench (`ix_duck::{chatbot, routing,
   loops, ood, maintain}`) that turns a GA artifact set into a queryable signal. A lens
   owns *analytics*, not ingest.
+- **Pipeline mesh** (`ix_duck::mesh`) — composing **N IX "pipelines"** (each a named
+  SQL view/macro over a stream, built from IX UDFs) and correlating their outputs N×N
+  to find which streams move together (clusters) and which one leads (centrality). The
+  canonical shape is `condition → ix_pearson → ix_connected_components → ix_centrality`.
+  DuckDB SQL is the composition language, **not** IXQL (which is spec-only and stays
+  complementary — see `docs/adr/0004-duckdb-sql-pipeline-mesh.md` + ADR-0001). Advisory
+  analysis only; betweenness/degree (not eigenvector) is the hub lens on bipartite meshes.
 - **Artifact source** (`ix_duck::source`) — the deep module a **lens** reads through:
   given a file selector + a flat **column spec**, it materializes a GA-emitted JSON
   artifact set into a bench table, owning file selection, the `read_json_auto` flags,

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ SAME PR that introduces the change:
    yet auto-detect it. Use the demotion path for the CI to go green, then
    restore the tier in a follow-up release PR.)
 
-The current 12 Stable crates (see table above) cover the safe-to-consume
+The current 10 Stable crates (see table above) cover the safe-to-consume
 subset for `ga`, `tars`, `Demerzel`, and `agent-blackbox`.
 
 ### Beta Crates

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cargo run -p ix-agent
 | ix-ensemble | Stable | Random forest, gradient boosted trees |
 | ix-unsupervised | Stable | KMeans, DBSCAN, PCA, t-SNE, GMM |
 | ix-search | Stable | A*, MCTS, minimax, BFS/DFS |
-| ix-graph | Stable | Markov chains, HMM/Viterbi, agent routing |
+| ix-graph | Beta | Markov chains, HMM/Viterbi, agent routing, components + centrality. Demoted from Stable 2026-06-21 while the new components/centrality surface settles |
 | ix-signal | Stable | FFT, wavelets, Kalman, spectral analysis |
 | ix-cache | Stable | Embedded in-process cache (TTL, LRU, pub/sub) — promoted 2026-05-02 |
 | ix-probabilistic | Stable | Bloom, HLL, Count-Min, Cuckoo — promoted 2026-05-02 |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cargo run -p ix-agent
 
 | Crate | Tier | Notes |
 |-------|------|-------|
-| ix-math | Stable | Core linear algebra, statistics, activations — everything depends on this |
+| ix-math | Beta | Core linear algebra, statistics, activations — everything depends on this. Demoted from Stable 2026-06-21 while the new `inference` surface (two-sample tests, divergences, moments) settles |
 | ix-optimize | Stable | SGD, Adam, PSO, simulated annealing |
 | ix-supervised | Stable | Regression, trees, KNN, SVM, metrics |
 | ix-ensemble | Stable | Random forest, gradient boosted trees |

--- a/crate-maturity.toml
+++ b/crate-maturity.toml
@@ -13,14 +13,13 @@
 # that breaks the public API. See README.md "Stability contract" for the flow.
 
 [crates]
-# --- Stable tier (12 crates, guarded by CI) -----------------------------
+# --- Stable tier (11 crates, guarded by CI) -----------------------------
 ix-math          = "stable"
 ix-optimize      = "stable"
 ix-supervised    = "stable"
 ix-ensemble      = "stable"
 ix-unsupervised  = "stable"
 ix-search        = "stable"
-ix-graph         = "stable"
 ix-signal        = "stable"
 ix-cache         = "stable"
 ix-probabilistic = "stable"
@@ -28,6 +27,7 @@ ix-game          = "stable"
 ix-rl            = "stable"
 
 # --- Beta tier ----------------------------------------------------------
+ix-graph       = "beta"   # demoted from stable 2026-06-21 (new components + centrality surface)
 ix-nn          = "beta"
 ix-pipeline    = "beta"
 ix-agent       = "beta"

--- a/crate-maturity.toml
+++ b/crate-maturity.toml
@@ -13,8 +13,10 @@
 # that breaks the public API. See README.md "Stability contract" for the flow.
 
 [crates]
-# --- Stable tier (12 crates, guarded by CI) -----------------------------
-ix-math          = "stable"
+# --- Stable tier (11 crates, guarded by CI) -----------------------------
+# ix-math demoted to beta 2026-06-21: the additive `inference` module (two-sample
+# tests, divergences, moments) grows the public surface; per the stable-surface
+# flow the tier moves with the API change. Re-promote once the surface settles.
 ix-optimize      = "stable"
 ix-supervised    = "stable"
 ix-ensemble      = "stable"
@@ -28,6 +30,7 @@ ix-game          = "stable"
 ix-rl            = "stable"
 
 # --- Beta tier ----------------------------------------------------------
+ix-math        = "beta"   # demoted from stable 2026-06-21 (new inference surface)
 ix-nn          = "beta"
 ix-pipeline    = "beta"
 ix-agent       = "beta"

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -92,5 +92,9 @@ required-features = ["duck"]
 name = "ix_grothendieck_lens"
 required-features = ["duck"]
 
+[[example]]
+name = "ix_mesh_correlate"
+required-features = ["duck"]
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ix-duck/examples/ix_mesh_correlate.rs
+++ b/crates/ix-duck/examples/ix_mesh_correlate.rs
@@ -1,39 +1,29 @@
-//! `ix_mesh_correlate` — a runnable **mesh of pipelines** over N real-world-style
-//! streams, composed entirely on the DuckDB analyst bench with IX UDFs as stages:
+//! `ix_mesh_correlate` — a runnable demo of the **pipeline mesh** correlation
+//! substrate (ADR-0004): N real-world-style streams composed on the DuckDB analyst
+//! bench with IX UDFs as stages, via the reusable [`ix_duck::mesh`] driver:
 //!
 //! ```text
-//!   N streams ─▶ ix_wavelet_denoise   (per-stream smoothing pipeline)
-//!             ─▶ ix_pearson           (pairwise correlation matrix — the mesh)
-//!             ─▶ threshold ▶ edge list ▶ ix_connected_components  (incident clusters)
-//!             ─▶ ix_centrality        (lead / hub indicator)
+//!   N streams ─▶ ix_wavelet_denoise (condition) ─▶ ix_pearson (N×N correlation)
+//!             ─▶ threshold ─▶ ix_connected_components (incident clusters)
+//!             ─▶ ix_centrality betweenness (lead / hub indicator)
 //! ```
-//!
-//! This is the "external data correlation" substrate: each stream is a JSON series
-//! (sensor, market tick, log-rate, metric…); the mesh correlates all N×N pairs and
-//! distills *which streams move together* (clusters) and *which one drives them*
-//! (centrality). DuckDB SQL is the pipeline-declaration + composition language;
-//! the IX UDFs are the stages. No production state, no source-of-truth — pure
-//! analyst-bench reads, per `docs/DUCKDB.md`.
 //!
 //! Run: `cargo run -p ix-duck --example ix_mesh_correlate --features duck`
 //!
-//! The synthetic streams have a KNOWN structure so the result is verifiable:
-//! P, Q, R are orthogonal (distinct-frequency) signals; H = mean(P,Q,R) is a
-//! latent hub that correlates with each spoke but the spokes do not correlate with
-//! each other; D1, D2 are independent distractors. Expected mesh outcome:
-//! **cluster {H,P,Q,R}**, D1 and D2 isolated, and **H is the most-central (lead)**.
+//! The synthetic streams have a KNOWN hub-and-spoke structure so the result is
+//! verifiable: P, Q, R are orthogonal (distinct-frequency) signals; H = mean(P,Q,R)
+//! is a latent hub correlated with each spoke (but the spokes are mutually
+//! uncorrelated); D1, D2 are independent distractors. Expected mesh outcome:
+//! **cluster {H,P,Q,R}**, D1/D2 isolated, **H the lead** (betweenness).
 
-use std::collections::BTreeMap;
-
+use ix_duck::mesh::{correlate, MeshConfig};
 use ix_duck::open_bench;
 
 const N: usize = 64; // samples per stream (power of two → clean wavelet levels)
-const TAU: f64 = 0.4; // |r| edge threshold (orthogonal pairs ≈ 0, hub↔spoke ≈ 0.58)
 
 /// Deterministic ±0.05 pseudo-noise, so the demo is reproducible without an RNG.
 fn noise(t: usize, seed: u64) -> f64 {
-    let mut x = (t as u64)
-        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+    let mut x = (t as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
         ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
     x ^= x >> 33;
     x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
@@ -48,126 +38,63 @@ fn tone(f: f64, seed: u64) -> Vec<f64> {
         .collect()
 }
 
-fn arr(v: &[f64]) -> String {
-    let body: Vec<String> = v.iter().map(|x| format!("{x:.6}")).collect();
-    format!("[{}]", body.join(","))
-}
-
-// The N×N correlation-matrix fill genuinely indexes corr[i][j]/corr[j][i]/smoothed[j].
-#[allow(clippy::needless_range_loop)]
 fn main() -> ix_duck::Result<()> {
     let conn = open_bench()?;
-    let names = ["H", "P", "Q", "R", "D1", "D2"];
 
-    // ── 1. Build the streams (the "real-world data scenarios") ──────────────────
+    // Build the streams (the "real-world data scenarios").
     let p = tone(1.0, 11);
     let q = tone(2.0, 22);
     let r = tone(3.0, 33);
     let h: Vec<f64> = (0..N).map(|t| (p[t] + q[t] + r[t]) / 3.0 + noise(t, 99)).collect();
-    let d1 = tone(5.0, 44);
-    let d2 = tone(6.0, 55);
-    let raw = [h, p, q, r, d1, d2];
+    let streams = vec![
+        ("H".to_string(), h),
+        ("P".to_string(), p),
+        ("Q".to_string(), q),
+        ("R".to_string(), r),
+        ("D1".to_string(), tone(5.0, 44)),
+        ("D2".to_string(), tone(6.0, 55)),
+    ];
 
-    println!("ix mesh — {} streams × {} samples, |r| edge threshold τ = {TAU}\n", names.len(), N);
+    let cfg = MeshConfig::default();
+    println!(
+        "ix pipeline mesh — {} streams × {N} samples, |r| threshold τ = {}, lead lens = {:?}\n",
+        streams.len(),
+        cfg.threshold,
+        cfg.centrality
+    );
 
-    // ── 2. Smoothing pipeline: ix_wavelet_denoise per stream ────────────────────
-    // Each stream flows through the same wavelet-denoise "pipeline" declared once.
-    let smoothed: Vec<Vec<f64>> = raw
-        .iter()
-        .map(|s| -> ix_duck::Result<Vec<f64>> {
-            let sql = format!(
-                "SELECT value FROM ix_wavelet_denoise('{}', 2, 0.05) ORDER BY i",
-                arr(s)
-            );
-            let mut stmt = conn.prepare(&sql)?;
-            let rows = stmt.query_map([], |row| row.get::<_, f64>(0))?;
-            rows.collect::<Result<Vec<f64>, _>>()
-        })
-        .collect::<Result<_, _>>()?;
-    println!("stage 1 ✓ ix_wavelet_denoise smoothed all {} streams", names.len());
+    let mesh = correlate(&conn, &streams, &cfg)?;
 
-    // ── 3. The mesh: pairwise ix_pearson correlation matrix ─────────────────────
-    let mut corr = vec![vec![0.0f64; names.len()]; names.len()];
-    let mut edges: Vec<(usize, usize)> = Vec::new();
-    for i in 0..names.len() {
-        for j in 0..names.len() {
-            if i == j {
-                corr[i][j] = 1.0;
-                continue;
-            }
-            if j < i {
-                corr[i][j] = corr[j][i];
-                continue;
-            }
-            let rij: f64 = conn.query_row(
-                &format!("SELECT ix_pearson({}::DOUBLE[], {}::DOUBLE[])", arr(&smoothed[i]), arr(&smoothed[j])),
-                [],
-                |row| row.get(0),
-            )?;
-            corr[i][j] = rij;
-            if rij.abs() >= TAU {
-                edges.push((i, j));
-            }
-        }
-    }
-
-    print!("\nstage 2 ✓ ix_pearson correlation matrix\n     ");
-    for n in &names {
+    // Correlation matrix.
+    print!("ix_pearson correlation matrix\n     ");
+    for n in &mesh.names {
         print!("{n:>6}");
     }
     println!();
-    for (i, n) in names.iter().enumerate() {
-        print!("{n:>4} ");
-        for j in 0..names.len() {
-            print!("{:>6.2}", corr[i][j]);
+    for (i, name) in mesh.names.iter().enumerate() {
+        print!("{name:>4} ");
+        for j in 0..mesh.names.len() {
+            print!("{:>6.2}", mesh.correlation[i][j]);
         }
         println!();
     }
 
-    // ── 4. Correlation graph → ix_connected_components (incident clusters) ──────
-    // Self-loops guarantee every stream is a node even if it has no strong edge.
-    let mut edge_json: Vec<String> = (0..names.len()).map(|i| format!("[{i},{i}]")).collect();
-    edge_json.extend(edges.iter().map(|(i, j)| format!("[{i},{j}]")));
-    let edge_list = format!("[{}]", edge_json.join(","));
-
-    let mut clusters: BTreeMap<i64, Vec<&str>> = BTreeMap::new();
-    {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT node, component FROM ix_connected_components('{edge_list}') ORDER BY node"
-        ))?;
-        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
-        for row in rows {
-            let (node, comp) = row?;
-            clusters.entry(comp).or_default().push(names[node as usize]);
-        }
-    }
-    println!("\nstage 3 ✓ ix_connected_components → {} incident clusters:", clusters.len());
-    for (c, members) in &clusters {
-        println!("   cluster {c}: {{ {} }}", members.join(", "));
+    // Clusters.
+    println!("\nix_connected_components → {} incident clusters:", mesh.clusters.len());
+    for (c, members) in mesh.clusters.iter().enumerate() {
+        let labels: Vec<&str> = members.iter().map(|&i| mesh.names[i].as_str()).collect();
+        println!("   cluster {c}: {{ {} }}", labels.join(", "));
     }
 
-    // ── 5. ix_centrality → the lead / hub indicator ─────────────────────────────
-    // Betweenness is the hub measure: the latent driver sits on every spoke-to-spoke
-    // shortest path. (Eigenvector centrality oscillates on a bipartite star, so it's
-    // the wrong lens for hub-and-spoke; it suits dense, mutually-correlated clusters.)
-    let mut lead = ("", -1.0f64);
-    {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT node, score FROM ix_centrality('{edge_list}', 'betweenness') ORDER BY score DESC, node"
-        ))?;
-        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?)))?;
-        println!("\nstage 4 ✓ ix_centrality (betweenness) — lead indicator ranking:");
-        for row in rows {
-            let (node, score) = row?;
-            let name = names[node as usize];
-            println!("   {name:>3}: {score:.3}");
-            if score > lead.1 {
-                lead = (name, score);
-            }
-        }
+    // Lead indicator.
+    println!("\nix_centrality ({:?}) — lead indicator ranking:", cfg.centrality);
+    for &(i, score) in &mesh.centrality {
+        println!("   {:>3}: {score:.3}", mesh.names[i]);
     }
 
-    println!("\n▶ mesh verdict: streams {{H,P,Q,R}} form the correlated cluster; \
-              D1/D2 are independent; lead (hub) stream = {}", lead.0);
+    println!(
+        "\n▶ mesh verdict: {{H,P,Q,R}} correlated; D1/D2 independent; lead (hub) = {}",
+        mesh.lead_name().unwrap_or("?")
+    );
     Ok(())
 }

--- a/crates/ix-duck/examples/ix_mesh_correlate.rs
+++ b/crates/ix-duck/examples/ix_mesh_correlate.rs
@@ -1,0 +1,173 @@
+//! `ix_mesh_correlate` — a runnable **mesh of pipelines** over N real-world-style
+//! streams, composed entirely on the DuckDB analyst bench with IX UDFs as stages:
+//!
+//! ```text
+//!   N streams ─▶ ix_wavelet_denoise   (per-stream smoothing pipeline)
+//!             ─▶ ix_pearson           (pairwise correlation matrix — the mesh)
+//!             ─▶ threshold ▶ edge list ▶ ix_connected_components  (incident clusters)
+//!             ─▶ ix_centrality        (lead / hub indicator)
+//! ```
+//!
+//! This is the "external data correlation" substrate: each stream is a JSON series
+//! (sensor, market tick, log-rate, metric…); the mesh correlates all N×N pairs and
+//! distills *which streams move together* (clusters) and *which one drives them*
+//! (centrality). DuckDB SQL is the pipeline-declaration + composition language;
+//! the IX UDFs are the stages. No production state, no source-of-truth — pure
+//! analyst-bench reads, per `docs/DUCKDB.md`.
+//!
+//! Run: `cargo run -p ix-duck --example ix_mesh_correlate --features duck`
+//!
+//! The synthetic streams have a KNOWN structure so the result is verifiable:
+//! P, Q, R are orthogonal (distinct-frequency) signals; H = mean(P,Q,R) is a
+//! latent hub that correlates with each spoke but the spokes do not correlate with
+//! each other; D1, D2 are independent distractors. Expected mesh outcome:
+//! **cluster {H,P,Q,R}**, D1 and D2 isolated, and **H is the most-central (lead)**.
+
+use std::collections::BTreeMap;
+
+use ix_duck::open_bench;
+
+const N: usize = 64; // samples per stream (power of two → clean wavelet levels)
+const TAU: f64 = 0.4; // |r| edge threshold (orthogonal pairs ≈ 0, hub↔spoke ≈ 0.58)
+
+/// Deterministic ±0.05 pseudo-noise, so the demo is reproducible without an RNG.
+fn noise(t: usize, seed: u64) -> f64 {
+    let mut x = (t as u64)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    x ^= x >> 33;
+    (x as f64 / u64::MAX as f64 - 0.5) * 0.1
+}
+
+/// A pure tone of integer frequency `f` over the window, plus a little noise.
+fn tone(f: f64, seed: u64) -> Vec<f64> {
+    (0..N)
+        .map(|t| (2.0 * std::f64::consts::PI * f * t as f64 / N as f64).sin() + noise(t, seed))
+        .collect()
+}
+
+fn arr(v: &[f64]) -> String {
+    let body: Vec<String> = v.iter().map(|x| format!("{x:.6}")).collect();
+    format!("[{}]", body.join(","))
+}
+
+// The N×N correlation-matrix fill genuinely indexes corr[i][j]/corr[j][i]/smoothed[j].
+#[allow(clippy::needless_range_loop)]
+fn main() -> ix_duck::Result<()> {
+    let conn = open_bench()?;
+    let names = ["H", "P", "Q", "R", "D1", "D2"];
+
+    // ── 1. Build the streams (the "real-world data scenarios") ──────────────────
+    let p = tone(1.0, 11);
+    let q = tone(2.0, 22);
+    let r = tone(3.0, 33);
+    let h: Vec<f64> = (0..N).map(|t| (p[t] + q[t] + r[t]) / 3.0 + noise(t, 99)).collect();
+    let d1 = tone(5.0, 44);
+    let d2 = tone(6.0, 55);
+    let raw = [h, p, q, r, d1, d2];
+
+    println!("ix mesh — {} streams × {} samples, |r| edge threshold τ = {TAU}\n", names.len(), N);
+
+    // ── 2. Smoothing pipeline: ix_wavelet_denoise per stream ────────────────────
+    // Each stream flows through the same wavelet-denoise "pipeline" declared once.
+    let smoothed: Vec<Vec<f64>> = raw
+        .iter()
+        .map(|s| -> ix_duck::Result<Vec<f64>> {
+            let sql = format!(
+                "SELECT value FROM ix_wavelet_denoise('{}', 2, 0.05) ORDER BY i",
+                arr(s)
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| row.get::<_, f64>(0))?;
+            rows.collect::<Result<Vec<f64>, _>>()
+        })
+        .collect::<Result<_, _>>()?;
+    println!("stage 1 ✓ ix_wavelet_denoise smoothed all {} streams", names.len());
+
+    // ── 3. The mesh: pairwise ix_pearson correlation matrix ─────────────────────
+    let mut corr = vec![vec![0.0f64; names.len()]; names.len()];
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for i in 0..names.len() {
+        for j in 0..names.len() {
+            if i == j {
+                corr[i][j] = 1.0;
+                continue;
+            }
+            if j < i {
+                corr[i][j] = corr[j][i];
+                continue;
+            }
+            let rij: f64 = conn.query_row(
+                &format!("SELECT ix_pearson({}::DOUBLE[], {}::DOUBLE[])", arr(&smoothed[i]), arr(&smoothed[j])),
+                [],
+                |row| row.get(0),
+            )?;
+            corr[i][j] = rij;
+            if rij.abs() >= TAU {
+                edges.push((i, j));
+            }
+        }
+    }
+
+    print!("\nstage 2 ✓ ix_pearson correlation matrix\n     ");
+    for n in &names {
+        print!("{n:>6}");
+    }
+    println!();
+    for (i, n) in names.iter().enumerate() {
+        print!("{n:>4} ");
+        for j in 0..names.len() {
+            print!("{:>6.2}", corr[i][j]);
+        }
+        println!();
+    }
+
+    // ── 4. Correlation graph → ix_connected_components (incident clusters) ──────
+    // Self-loops guarantee every stream is a node even if it has no strong edge.
+    let mut edge_json: Vec<String> = (0..names.len()).map(|i| format!("[{i},{i}]")).collect();
+    edge_json.extend(edges.iter().map(|(i, j)| format!("[{i},{j}]")));
+    let edge_list = format!("[{}]", edge_json.join(","));
+
+    let mut clusters: BTreeMap<i64, Vec<&str>> = BTreeMap::new();
+    {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, component FROM ix_connected_components('{edge_list}') ORDER BY node"
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
+        for row in rows {
+            let (node, comp) = row?;
+            clusters.entry(comp).or_default().push(names[node as usize]);
+        }
+    }
+    println!("\nstage 3 ✓ ix_connected_components → {} incident clusters:", clusters.len());
+    for (c, members) in &clusters {
+        println!("   cluster {c}: {{ {} }}", members.join(", "));
+    }
+
+    // ── 5. ix_centrality → the lead / hub indicator ─────────────────────────────
+    // Betweenness is the hub measure: the latent driver sits on every spoke-to-spoke
+    // shortest path. (Eigenvector centrality oscillates on a bipartite star, so it's
+    // the wrong lens for hub-and-spoke; it suits dense, mutually-correlated clusters.)
+    let mut lead = ("", -1.0f64);
+    {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, score FROM ix_centrality('{edge_list}', 'betweenness') ORDER BY score DESC, node"
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?)))?;
+        println!("\nstage 4 ✓ ix_centrality (betweenness) — lead indicator ranking:");
+        for row in rows {
+            let (node, score) = row?;
+            let name = names[node as usize];
+            println!("   {name:>3}: {score:.3}");
+            if score > lead.1 {
+                lead = (name, score);
+            }
+        }
+    }
+
+    println!("\n▶ mesh verdict: streams {{H,P,Q,R}} form the correlated cluster; \
+              D1/D2 are independent; lead (hub) stream = {}", lead.0);
+    Ok(())
+}

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -6,6 +6,8 @@
 //! - `ix_pagerank(edges, damping DOUBLE, iterations BIGINT)` → `TABLE(node, rank)`.
 //! - `ix_shortest_path(edges, src BIGINT, dst BIGINT)` → `TABLE(step, node)` (the
 //!   Dijkstra path src→dst; empty if unreachable).
+//! - `ix_connected_components(edges)` → `TABLE(node, component)` — weakly-connected
+//!   component id per node (edge direction ignored).
 //!
 //! Signal (`ix-signal`), input = a JSON number array (the series):
 //! - `ix_rfft(series)` → `TABLE(bin, magnitude)` — real FFT magnitude spectrum.
@@ -277,10 +279,38 @@ impl VTab for IxAutocorrelation {
     }
 }
 
+// ── ix_connected_components ──────────────────────────────────────────────────────
+
+struct IxConnectedComponents;
+impl VTab for IxConnectedComponents {
+    type InitData = Cursor;
+    type BindData = RowsI64;
+
+    // @ai:invariant ix_connected_components emits (node,component) for the weakly-connected components of the edge-list graph via ix_graph connected_components; two disjoint subgraphs get distinct component ids, an isolated node is its own component [T:test conf:0.8 src:ix_duck::graphsig::tests::connected_components_finds_islands]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let (g, n) = parse_graph(&bind.get_parameter(0).to_string())?;
+        let comp = g.connected_components();
+        let rows: Vec<(i64, i64)> = (0..n).map(|i| (i as i64, comp[i] as i64)).collect();
+        two_cols(bind, "node", LogicalTypeId::Bigint, "component", LogicalTypeId::Bigint);
+        Ok(RowsI64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_i64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::Varchar)])
+    }
+}
+
 /// Register the graph + signal table functions.
 pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxPagerank>("ix_pagerank")?;
     conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
+    conn.register_table_function::<IxConnectedComponents>("ix_connected_components")?;
     conn.register_table_function::<IxRfft>("ix_rfft")?;
     conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
     Ok(())
@@ -321,6 +351,45 @@ mod tests {
                 .is_err(),
             "negative edge weight must be a SQL error"
         );
+    }
+
+    #[test]
+    fn connected_components_finds_islands() {
+        let conn = open_bench().unwrap();
+        // Two disjoint edges: {0–1} and {2–3} → two components (4 nodes).
+        let edges = "[[0,1],[2,3]]";
+        let n_comp: i64 = conn
+            .query_row(
+                &format!("SELECT count(DISTINCT component) FROM ix_connected_components('{edges}')"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n_comp, 2, "two disjoint edges → two components");
+
+        // Nodes 0 and 1 share a component; 0 and 2 do not.
+        let same: bool = conn
+            .query_row(
+                &format!(
+                    "SELECT (SELECT component FROM ix_connected_components('{edges}') WHERE node=0) \
+                          = (SELECT component FROM ix_connected_components('{edges}') WHERE node=1)"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(same, "0 and 1 are connected");
+        let cross: bool = conn
+            .query_row(
+                &format!(
+                    "SELECT (SELECT component FROM ix_connected_components('{edges}') WHERE node=0) \
+                          = (SELECT component FROM ix_connected_components('{edges}') WHERE node=2)"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(!cross, "0 and 2 are in different components");
     }
 
     #[test]

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -8,6 +8,8 @@
 //!   Dijkstra path src→dst; empty if unreachable).
 //! - `ix_connected_components(edges)` → `TABLE(node, component)` — weakly-connected
 //!   component id per node (edge direction ignored).
+//! - `ix_centrality(edges, kind)` → `TABLE(node, score)` — undirected centrality,
+//!   `kind` ∈ `degree | closeness | eigenvector | betweenness`.
 //! - `ix_viterbi(initial, transition, emission, observations)` → `TABLE(step, state)` —
 //!   most-likely hidden-state path of an HMM (initial 1-D, transition/emission 2-D
 //!   JSON matrices, observations a 1-D int array).
@@ -313,6 +315,48 @@ impl VTab for IxConnectedComponents {
     }
 }
 
+// ── ix_centrality ────────────────────────────────────────────────────────────────
+
+struct IxCentrality;
+impl VTab for IxCentrality {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_centrality emits (node,score) for the named undirected centrality (degree|closeness|eigenvector|betweenness) via ix_graph; in a star the hub scores strictly highest on every measure; an unknown kind -> SQL error [T:test conf:0.8 src:ix_duck::graphsig::tests::centrality_hub_dominates]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let (g, n) = parse_graph(&bind.get_parameter(0).to_string())?;
+        let kind = bind.get_parameter(1).to_string().to_lowercase();
+        let scores = match kind.as_str() {
+            "degree" => g.degree_centrality(),
+            "closeness" => g.closeness_centrality(),
+            "eigenvector" => g.eigenvector_centrality(100),
+            "betweenness" => g.betweenness_centrality(),
+            other => {
+                return Err(format!(
+                    "unknown centrality kind '{other}' (expected degree|closeness|eigenvector|betweenness)"
+                )
+                .into())
+            }
+        };
+        let rows: Vec<(i64, f64)> = (0..n).map(|i| (i as i64, scores[i])).collect();
+        two_cols(bind, "node", LogicalTypeId::Bigint, "score", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        ])
+    }
+}
+
 // ── ix_viterbi ───────────────────────────────────────────────────────────────────
 
 struct IxViterbi;
@@ -366,6 +410,7 @@ pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxPagerank>("ix_pagerank")?;
     conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
     conn.register_table_function::<IxConnectedComponents>("ix_connected_components")?;
+    conn.register_table_function::<IxCentrality>("ix_centrality")?;
     conn.register_table_function::<IxViterbi>("ix_viterbi")?;
     conn.register_table_function::<IxRfft>("ix_rfft")?;
     conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
@@ -446,6 +491,34 @@ mod tests {
             )
             .unwrap();
         assert!(!cross, "0 and 2 are in different components");
+    }
+
+    #[test]
+    fn centrality_hub_dominates() {
+        let conn = open_bench().unwrap();
+        // Star: hub 0 joined to leaves 1,2,3. The hub is the top-scoring node for
+        // every centrality measure.
+        let star = "[[0,1],[0,2],[0,3]]";
+        for kind in ["degree", "closeness", "eigenvector", "betweenness"] {
+            let top: i64 = conn
+                .query_row(
+                    &format!("SELECT node FROM ix_centrality('{star}', '{kind}') ORDER BY score DESC, node LIMIT 1"),
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(top, 0, "hub is the top {kind}-centrality node");
+        }
+        // An unknown kind is a SQL error, not a panic.
+        assert!(
+            conn.query_row(
+                &format!("SELECT node FROM ix_centrality('{star}', 'pagerank')"),
+                [],
+                |r| r.get::<_, i64>(0)
+            )
+            .is_err(),
+            "unknown centrality kind must be a SQL error"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -8,6 +8,9 @@
 //!   Dijkstra path src→dst; empty if unreachable).
 //! - `ix_connected_components(edges)` → `TABLE(node, component)` — weakly-connected
 //!   component id per node (edge direction ignored).
+//! - `ix_viterbi(initial, transition, emission, observations)` → `TABLE(step, state)` —
+//!   most-likely hidden-state path of an HMM (initial 1-D, transition/emission 2-D
+//!   JSON matrices, observations a 1-D int array).
 //!
 //! Signal (`ix-signal`), input = a JSON number array (the series):
 //! - `ix_rfft(series)` → `TABLE(bin, magnitude)` — real FFT magnitude spectrum.
@@ -21,8 +24,12 @@ use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 use duckdb::Connection;
 use ix_graph::graph::Graph;
+use ix_graph::hmm::HiddenMarkovModel;
 use ix_signal::correlation::autocorrelation;
 use ix_signal::fft::rfft;
+use ndarray::Array1;
+
+use crate::tablefn::parse_matrix;
 
 // ── shared output plumbing ────────────────────────────────────────────────────
 
@@ -306,11 +313,60 @@ impl VTab for IxConnectedComponents {
     }
 }
 
+// ── ix_viterbi ───────────────────────────────────────────────────────────────────
+
+struct IxViterbi;
+impl VTab for IxViterbi {
+    type InitData = Cursor;
+    type BindData = RowsI64;
+
+    // @ai:invariant ix_viterbi emits the most-likely hidden-state path as (step,state) from ix_graph HMM viterbi given the initial/transition/emission/observations JSON; a near-deterministic HMM recovers the generating state sequence; a non-stochastic matrix or out-of-range observation -> SQL error (no panic) [T:test conf:0.8 src:ix_duck::graphsig::tests::viterbi_decodes_biased_hmm]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let initial: Vec<f64> = serde_json::from_str(&bind.get_parameter(0).to_string())
+            .map_err(|e| format!("initial must be a JSON number array: {e}"))?;
+        let transition = parse_matrix(&bind.get_parameter(1).to_string())?;
+        let emission = parse_matrix(&bind.get_parameter(2).to_string())?;
+        let obs: Vec<i64> = serde_json::from_str(&bind.get_parameter(3).to_string())
+            .map_err(|e| format!("observations must be a JSON int array: {e}"))?;
+        if obs.iter().any(|&o| o < 0) {
+            return Err("observation symbols must be non-negative".into());
+        }
+        let hmm = HiddenMarkovModel::new(Array1::from_vec(initial), transition, emission)
+            .map_err(|e| format!("ix_viterbi: {e}"))?;
+        let m = hmm.n_observations();
+        if obs.iter().any(|&o| o as usize >= m) {
+            return Err(format!("ix_viterbi: observation symbol out of range 0..{m}").into());
+        }
+        let observations: Vec<usize> = obs.iter().map(|&o| o as usize).collect();
+        let (path, _log_prob) = hmm.viterbi(&observations);
+        let rows: Vec<(i64, i64)> =
+            path.iter().enumerate().map(|(i, &s)| (i as i64, s as i64)).collect();
+        two_cols(bind, "step", LogicalTypeId::Bigint, "state", LogicalTypeId::Bigint);
+        Ok(RowsI64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_i64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        ])
+    }
+}
+
 /// Register the graph + signal table functions.
 pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxPagerank>("ix_pagerank")?;
     conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
     conn.register_table_function::<IxConnectedComponents>("ix_connected_components")?;
+    conn.register_table_function::<IxViterbi>("ix_viterbi")?;
     conn.register_table_function::<IxRfft>("ix_rfft")?;
     conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
     Ok(())
@@ -390,6 +446,42 @@ mod tests {
             )
             .unwrap();
         assert!(!cross, "0 and 2 are in different components");
+    }
+
+    #[test]
+    fn viterbi_decodes_biased_hmm() {
+        let conn = open_bench().unwrap();
+        // 2-state HMM whose emissions strongly couple state i to symbol i, so the
+        // most-likely path tracks the observed symbols: obs [0,0,1,1] → states [0,0,1,1].
+        let init = "[0.5,0.5]";
+        let trans = "[[0.7,0.3],[0.3,0.7]]";
+        let emis = "[[0.9,0.1],[0.1,0.9]]";
+        let obs = "[0,0,1,1]";
+        let path: Vec<i64> = {
+            let mut stmt = conn
+                .prepare(&format!(
+                    "SELECT state FROM ix_viterbi('{init}','{trans}','{emis}','{obs}') ORDER BY step"
+                ))
+                .unwrap();
+            stmt.query_map([], |r| r.get::<_, i64>(0)).unwrap().map(|x| x.unwrap()).collect()
+        };
+        assert_eq!(path, vec![0, 0, 1, 1], "biased HMM decodes states matching the symbols");
+    }
+
+    #[test]
+    fn viterbi_rejects_non_stochastic() {
+        let conn = open_bench().unwrap();
+        // Emission row 0 = [0.5,0.1] sums to 0.6 ≠ 1 → HMM construction must fail as a
+        // SQL error, not a panic.
+        assert!(
+            conn.query_row(
+                "SELECT state FROM ix_viterbi('[0.5,0.5]','[[0.7,0.3],[0.3,0.7]]','[[0.5,0.1],[0.1,0.9]]','[0]')",
+                [],
+                |r| r.get::<_, i64>(0)
+            )
+            .is_err(),
+            "non-stochastic emission matrix must be a SQL error"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/graphsig.rs
+++ b/crates/ix-duck/src/graphsig.rs
@@ -10,6 +10,11 @@
 //! Signal (`ix-signal`), input = a JSON number array (the series):
 //! - `ix_rfft(series)` → `TABLE(bin, magnitude)` — real FFT magnitude spectrum.
 //! - `ix_autocorrelation(series)` → `TABLE(lag, value)`.
+//! - `ix_wavelet_denoise(series, levels BIGINT, threshold DOUBLE)` → `TABLE(i, value)` —
+//!   soft-thresholded series (same length as input).
+//! - `ix_kalman_smooth(series, process_noise DOUBLE, measurement_noise DOUBLE)` →
+//!   `TABLE(i, value)` — constant-velocity 1-D Kalman position estimate (dt=1).
+//! - `ix_dct(series)` → `TABLE(k, coefficient)` — DCT-II coefficients.
 //!
 //! All wrap the real IX crates — no DSP/graph math reimplemented here.
 
@@ -20,7 +25,11 @@ use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 use duckdb::Connection;
 use ix_graph::graph::Graph;
 use ix_signal::correlation::autocorrelation;
+use ix_signal::dct::dct2;
 use ix_signal::fft::rfft;
+use ix_signal::kalman::constant_velocity_1d;
+use ix_signal::wavelet::wavelet_denoise;
+use ndarray::Array1;
 
 // ── shared output plumbing ────────────────────────────────────────────────────
 
@@ -277,12 +286,144 @@ impl VTab for IxAutocorrelation {
     }
 }
 
+// ── ix_wavelet_denoise ─────────────────────────────────────────────────────────
+
+struct IxWaveletDenoise;
+impl VTab for IxWaveletDenoise {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_wavelet_denoise emits (i,value) for the wavelet soft-thresholded series via ix_signal wavelet_denoise (same length as input); a larger threshold removes more high-frequency energy, so output variance does not exceed the input's [T:test conf:0.8 src:ix_duck::graphsig::tests::wavelet_denoise_reduces_variance]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let levels_req = bind.get_parameter(1).to_int64();
+        if levels_req < 1 {
+            return Err("levels must be >= 1".into());
+        }
+        let threshold = bind
+            .get_parameter(2)
+            .to_string()
+            .parse::<f64>()
+            .map_err(|e| format!("threshold must be a number: {e}"))?;
+        if !threshold.is_finite() || threshold < 0.0 {
+            return Err("threshold must be finite and >= 0".into());
+        }
+        // Cap the decomposition depth at floor(log2(n)) so a short series is never
+        // over-decomposed (each level halves the signal).
+        let max_levels = ((series.len() as f64).log2().floor() as usize).max(1);
+        let levels = (levels_req as usize).min(max_levels);
+        let rows: Vec<(i64, f64)> = wavelet_denoise(&series, levels, threshold)
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| (i as i64, v))
+            .collect();
+        two_cols(bind, "i", LogicalTypeId::Bigint, "value", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+// ── ix_kalman_smooth ───────────────────────────────────────────────────────────
+
+struct IxKalmanSmooth;
+impl VTab for IxKalmanSmooth {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_kalman_smooth emits (i,value) where value is the filtered position of a constant-velocity 1-D Kalman filter (ix_signal, dt=1) over the series; fed a constant-velocity ramp it locks onto the trajectory, so the final estimate converges to the final measurement [T:test conf:0.8 src:ix_duck::graphsig::tests::kalman_smooth_tracks_ramp]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let process_noise = parse_pos_finite(&bind.get_parameter(1).to_string(), "process_noise")?;
+        let measurement_noise =
+            parse_pos_finite(&bind.get_parameter(2).to_string(), "measurement_noise")?;
+        // dt = 1: telemetry samples are an evenly-spaced unit-step sequence.
+        let mut kf = constant_velocity_1d(process_noise, measurement_noise, 1.0);
+        let measurements: Vec<Array1<f64>> =
+            series.iter().map(|&z| Array1::from_vec(vec![z])).collect();
+        // state = [position, velocity]; the smoothed signal is the position estimate.
+        let rows: Vec<(i64, f64)> = kf
+            .filter(&measurements)
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (i as i64, s[0]))
+            .collect();
+        two_cols(bind, "i", LogicalTypeId::Bigint, "value", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+/// Parse a positive, finite `f64` parameter (Kalman noise covariances must be > 0).
+fn parse_pos_finite(s: &str, name: &str) -> Result<f64, Box<dyn std::error::Error>> {
+    let v: f64 = s.parse().map_err(|e| format!("{name} must be a number: {e}"))?;
+    if !v.is_finite() || v <= 0.0 {
+        return Err(format!("{name} must be a finite number > 0").into());
+    }
+    Ok(v)
+}
+
+// ── ix_dct ─────────────────────────────────────────────────────────────────────
+
+struct IxDct;
+impl VTab for IxDct {
+    type InitData = Cursor;
+    type BindData = RowsF64;
+
+    // @ai:invariant ix_dct emits (k,coefficient) for the DCT-II of the series via ix_signal dct2 (same length as input); a constant signal concentrates all energy in the k=0 (DC) coefficient [T:test conf:0.8 src:ix_duck::graphsig::tests::dct_constant_concentrates_at_dc]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let series = parse_series(&bind.get_parameter(0).to_string())?;
+        let rows: Vec<(i64, f64)> =
+            dct2(&series).iter().enumerate().map(|(i, &v)| (i as i64, v)).collect();
+        two_cols(bind, "k", LogicalTypeId::Bigint, "coefficient", LogicalTypeId::Double);
+        Ok(RowsF64 { rows })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(new_cursor())
+    }
+    fn func(func: &TableFunctionInfo<Self>, output: &mut DataChunkHandle) -> Result<(), Box<dyn std::error::Error>> {
+        emit_f64(&func.get_bind_data().rows, func.get_init_data(), output);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![LogicalTypeHandle::from(LogicalTypeId::Varchar)])
+    }
+}
+
 /// Register the graph + signal table functions.
 pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxPagerank>("ix_pagerank")?;
     conn.register_table_function::<IxShortestPath>("ix_shortest_path")?;
     conn.register_table_function::<IxRfft>("ix_rfft")?;
     conn.register_table_function::<IxAutocorrelation>("ix_autocorrelation")?;
+    conn.register_table_function::<IxWaveletDenoise>("ix_wavelet_denoise")?;
+    conn.register_table_function::<IxKalmanSmooth>("ix_kalman_smooth")?;
+    conn.register_table_function::<IxDct>("ix_dct")?;
     Ok(())
 }
 
@@ -351,6 +492,80 @@ mod tests {
             )
             .unwrap();
         assert_eq!(peak_bin, 1, "one-cycle tone peaks at bin 1");
+    }
+
+    #[test]
+    fn wavelet_denoise_reduces_variance() {
+        let conn = open_bench().unwrap();
+        // High-frequency square wave around mean 5 (raw var_pop = 25). A large
+        // threshold kills the detail coefficients → the denoised series collapses
+        // toward the mean, so its variance must not exceed the raw series'.
+        let noisy = "[10,0,10,0,10,0,10,0]";
+        let (n, var): (i64, f64) = conn
+            .query_row(
+                &format!("SELECT count(*), var_pop(value) FROM ix_wavelet_denoise('{noisy}', 3, 50.0)"),
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(n, 8, "denoised series keeps the input length");
+        assert!(var < 25.0, "large threshold reduces variance below raw 25, got {var}");
+    }
+
+    #[test]
+    fn kalman_smooth_tracks_ramp() {
+        let conn = open_bench().unwrap();
+        // A clean constant-velocity ramp 0..7 is exactly the filter's motion model;
+        // from a cold start [0,0] it locks on, so the final estimate lands near the
+        // final measurement (7). One estimate per measurement.
+        let ramp = "[0,1,2,3,4,5,6,7]";
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_kalman_smooth('{ramp}', 0.01, 0.5)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 8, "one filtered estimate per measurement");
+        let last: f64 = conn
+            .query_row(
+                &format!("SELECT value FROM ix_kalman_smooth('{ramp}', 0.01, 0.5) WHERE i=7"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            (5.0..=9.0).contains(&last),
+            "filter tracks the ramp to ~7, got {last}"
+        );
+    }
+
+    #[test]
+    fn kalman_smooth_rejects_nonpositive_noise() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT value FROM ix_kalman_smooth('[1,2,3]', 0.0, 1.0)",
+                [],
+                |r| r.get::<_, f64>(0)
+            )
+            .is_err(),
+            "process_noise=0 must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn dct_constant_concentrates_at_dc() {
+        let conn = open_bench().unwrap();
+        // A constant signal has all its energy in the DC (k=0) coefficient.
+        let dc_bin: i64 = conn
+            .query_row(
+                "SELECT k FROM ix_dct('[1,1,1,1,1,1,1,1]') ORDER BY abs(coefficient) DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dc_bin, 0, "constant signal → energy at the k=0 DC coefficient");
     }
 
     #[test]

--- a/crates/ix-duck/src/inference.rs
+++ b/crates/ix-duck/src/inference.rs
@@ -1,0 +1,359 @@
+//! Statistical-inference UDFs over `ix-math::inference` — the distribution-shape
+//! and two-sample-test layer DuckDB built-ins lack.
+//!
+//! Scalars take `LIST<DOUBLE>` (materialize a column with `list(col)`):
+//!
+//! | UDF | meaning |
+//! |---|---|
+//! | `ix_skewness(x)` / `ix_kurtosis(x)` | biased Fisher–Pearson skew / excess kurtosis |
+//! | `ix_mad(x)` | median absolute deviation (robust spread) |
+//! | `ix_quantile(x, q)` | the `q`-quantile (numpy linear) |
+//! | `ix_entropy(p)` | Shannon entropy in nats |
+//! | `ix_kl(p, q)` / `ix_js(p, q)` | KL / Jensen–Shannon divergence |
+//!
+//! And the regression-gate primitive, a table function over two JSON samples:
+//! `ix_two_sample(a_json, b_json, kind)` → `TABLE(statistic, p_value)`, `kind` ∈
+//! `ks | mannwhitney | welch`. The motivating use is *"did this metric's
+//! distribution shift vs baseline?"* — e.g.
+//! `SELECT p_value FROM ix_two_sample(today, baseline, 'ks')`.
+//!
+//! Pure wraps of `ix-math::inference` — no statistics reimplemented here.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
+use duckdb::Connection;
+use ix_math::error::MathError;
+use ix_math::inference::{
+    iqr as _iqr, js_divergence, kl_divergence, ks_two_sample, kurtosis, mad, mann_whitney_u,
+    quantile, shannon_entropy, skewness, welch_t_test, TestResult,
+};
+
+use crate::udf::read_list_col;
+
+type Res = Result<(), Box<dyn std::error::Error>>;
+
+fn list_double() -> LogicalTypeHandle {
+    LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Double))
+}
+fn double() -> LogicalTypeHandle {
+    LogicalTypeHandle::from(LogicalTypeId::Double)
+}
+
+/// Shared driver for `LIST<DOUBLE> -> DOUBLE` scalars.
+fn invoke_unary(
+    input: &mut DataChunkHandle,
+    output: &mut dyn WritableVector,
+    name: &str,
+    f: impl Fn(&[f64]) -> Result<f64, MathError>,
+) -> Res {
+    let n = input.len();
+    let a = read_list_col(input, 0, n);
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<f64>(n) };
+    for i in 0..n {
+        slice[i] = f(&a[i]).map_err(|e| format!("{name}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Shared driver for `(LIST<DOUBLE>, LIST<DOUBLE>) -> DOUBLE` scalars.
+fn invoke_binary(
+    input: &mut DataChunkHandle,
+    output: &mut dyn WritableVector,
+    name: &str,
+    f: impl Fn(&[f64], &[f64]) -> Result<f64, MathError>,
+) -> Res {
+    let n = input.len();
+    let a = read_list_col(input, 0, n);
+    let b = read_list_col(input, 1, n);
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<f64>(n) };
+    for i in 0..n {
+        slice[i] = f(&a[i], &b[i]).map_err(|e| format!("{name}: {e}"))?;
+    }
+    Ok(())
+}
+
+fn unary_sig() -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(vec![list_double()], double())]
+}
+fn binary_sig() -> Vec<ScalarFunctionSignature> {
+    vec![ScalarFunctionSignature::exact(
+        vec![list_double(), list_double()],
+        double(),
+    )]
+}
+
+macro_rules! unary_udf {
+    ($name:ident, $sql:literal, $f:path, $doc:literal) => {
+        #[doc = $doc]
+        struct $name;
+        impl VScalar for $name {
+            type State = ();
+            unsafe fn invoke(
+                _: &(),
+                input: &mut DataChunkHandle,
+                output: &mut dyn WritableVector,
+            ) -> Res {
+                invoke_unary(input, output, $sql, $f)
+            }
+            fn signatures() -> Vec<ScalarFunctionSignature> {
+                unary_sig()
+            }
+        }
+    };
+}
+
+// @ai:invariant ix_skewness/ix_kurtosis/ix_mad/ix_entropy each wrap the same-named ix_math::inference fn over a LIST<DOUBLE>; zero-variance input (skew/kurtosis) or all-zero p (entropy) -> SQL error (no panic) [T:test conf:0.85 src:ix_duck::inference::tests::descriptive_scalars_match_ix_math]
+unary_udf!(IxSkewness, "ix_skewness", skewness, "`ix_skewness(x DOUBLE[]) -> DOUBLE`");
+unary_udf!(IxKurtosis, "ix_kurtosis", kurtosis, "`ix_kurtosis(x DOUBLE[]) -> DOUBLE`");
+unary_udf!(IxMad, "ix_mad", mad, "`ix_mad(x DOUBLE[]) -> DOUBLE`");
+unary_udf!(IxEntropy, "ix_entropy", shannon_entropy, "`ix_entropy(p DOUBLE[]) -> DOUBLE`");
+unary_udf!(IxIqr, "ix_iqr", _iqr, "`ix_iqr(x DOUBLE[]) -> DOUBLE`");
+
+/// `ix_quantile(x DOUBLE[], q DOUBLE) -> DOUBLE` — the `q`-quantile (numpy linear).
+struct IxQuantile;
+impl VScalar for IxQuantile {
+    type State = ();
+    // @ai:invariant ix_quantile(x,q) wraps ix_math::inference::quantile; q=0.5 is the median, q outside [0,1] -> SQL error [T:test conf:0.85 src:ix_duck::inference::tests::quantile_scalar]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let a = read_list_col(input, 0, n);
+        let qs: Vec<f64> = {
+            let v = input.flat_vector(1);
+            v.as_slice_with_len::<f64>(n)[..n].to_vec()
+        };
+        let mut out = output.flat_vector();
+        let slice = out.as_mut_slice_with_len::<f64>(n);
+        for i in 0..n {
+            slice[i] = quantile(&a[i], qs[i]).map_err(|e| format!("ix_quantile: {e}"))?;
+        }
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), double()],
+            double(),
+        )]
+    }
+}
+
+/// `ix_kl(p DOUBLE[], q DOUBLE[]) -> DOUBLE` — Kullback–Leibler divergence (nats).
+struct IxKl;
+impl VScalar for IxKl {
+    type State = ();
+    // @ai:invariant ix_kl wraps ix_math::inference::kl_divergence; equal distributions -> 0, q zero where p positive -> SQL error [T:test conf:0.85 src:ix_duck::inference::tests::divergence_scalars]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        invoke_binary(input, output, "ix_kl", kl_divergence)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        binary_sig()
+    }
+}
+
+/// `ix_js(p DOUBLE[], q DOUBLE[]) -> DOUBLE` — Jensen–Shannon divergence (nats).
+struct IxJs;
+impl VScalar for IxJs {
+    type State = ();
+    // @ai:invariant ix_js wraps ix_math::inference::js_divergence; symmetric and bounded in [0, ln 2], equal distributions -> 0 [T:test conf:0.85 src:ix_duck::inference::tests::divergence_scalars]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        invoke_binary(input, output, "ix_js", js_divergence)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        binary_sig()
+    }
+}
+
+// ── ix_two_sample (table fn: one row of statistic + p_value) ────────────────────
+
+#[repr(C)]
+struct TwoSampleBind {
+    result: TestResult,
+}
+#[repr(C)]
+struct TwoSampleInit {
+    cursor: AtomicUsize,
+}
+
+struct IxTwoSample;
+impl VTab for IxTwoSample {
+    type InitData = TwoSampleInit;
+    type BindData = TwoSampleBind;
+
+    // @ai:invariant ix_two_sample(a,b,kind) emits one (statistic,p_value) row from the ix_math::inference two-sample test named by kind (ks|mannwhitney|welch); a clearly-shifted pair gives a small p_value, an unknown kind or empty sample -> SQL error [T:test conf:0.85 src:ix_duck::inference::tests::two_sample_detects_shift]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let a: Vec<f64> = serde_json::from_str(&bind.get_parameter(0).to_string())
+            .map_err(|e| format!("sample a must be a JSON number array: {e}"))?;
+        let b: Vec<f64> = serde_json::from_str(&bind.get_parameter(1).to_string())
+            .map_err(|e| format!("sample b must be a JSON number array: {e}"))?;
+        let kind = bind.get_parameter(2).to_string().to_lowercase();
+        let result = match kind.as_str() {
+            "ks" => ks_two_sample(&a, &b),
+            "mannwhitney" | "mann_whitney" | "u" => mann_whitney_u(&a, &b),
+            "welch" | "t" => welch_t_test(&a, &b),
+            other => {
+                return Err(format!(
+                    "unknown test '{other}' (expected ks|mannwhitney|welch)"
+                )
+                .into())
+            }
+        }
+        .map_err(|e| format!("ix_two_sample: {e}"))?;
+        bind.add_result_column("statistic", LogicalTypeHandle::from(LogicalTypeId::Double));
+        bind.add_result_column("p_value", LogicalTypeHandle::from(LogicalTypeId::Double));
+        Ok(TwoSampleBind { result })
+    }
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(TwoSampleInit {
+            cursor: AtomicUsize::new(0),
+        })
+    }
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let init = func.get_init_data();
+        if init.cursor.swap(1, Ordering::Relaxed) != 0 {
+            output.set_len(0);
+            return Ok(());
+        }
+        let r = &func.get_bind_data().result;
+        {
+            let mut v = output.flat_vector(0);
+            let s = unsafe { v.as_mut_slice_with_len::<f64>(1) };
+            s[0] = r.statistic;
+        }
+        {
+            let mut v = output.flat_vector(1);
+            let s = unsafe { v.as_mut_slice_with_len::<f64>(1) };
+            s[0] = r.p_value;
+        }
+        output.set_len(1);
+        Ok(())
+    }
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+        ])
+    }
+}
+
+/// Register the statistical-inference UDFs.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxSkewness>("ix_skewness")?;
+    conn.register_scalar_function::<IxKurtosis>("ix_kurtosis")?;
+    conn.register_scalar_function::<IxMad>("ix_mad")?;
+    conn.register_scalar_function::<IxIqr>("ix_iqr")?;
+    conn.register_scalar_function::<IxEntropy>("ix_entropy")?;
+    conn.register_scalar_function::<IxQuantile>("ix_quantile")?;
+    conn.register_scalar_function::<IxKl>("ix_kl")?;
+    conn.register_scalar_function::<IxJs>("ix_js")?;
+    conn.register_table_function::<IxTwoSample>("ix_two_sample")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    #[test]
+    fn descriptive_scalars_match_ix_math() {
+        let conn = open_bench().unwrap();
+        // kurtosis([1,2,3,4,5]) = -1.3; skew = 0; mad = 1.0 (scipy).
+        let kurt: f64 = conn
+            .query_row(
+                "SELECT ix_kurtosis(list(v)::DOUBLE[]) FROM (VALUES (1.0),(2.0),(3.0),(4.0),(5.0)) t(v)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((kurt + 1.3).abs() < 1e-9, "excess kurtosis = -1.3, got {kurt}");
+        let mad: f64 = conn
+            .query_row(
+                "SELECT ix_mad(list(v)::DOUBLE[]) FROM (VALUES (1.0),(2.0),(3.0),(4.0),(5.0)) t(v)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((mad - 1.0).abs() < 1e-9, "mad = 1.0, got {mad}");
+        // zero-variance skewness is a SQL error, not a panic.
+        assert!(
+            conn.query_row("SELECT ix_skewness([2.0,2.0,2.0]::DOUBLE[])", [], |r| r
+                .get::<_, f64>(0))
+                .is_err(),
+            "zero-variance skewness must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn quantile_scalar() {
+        let conn = open_bench().unwrap();
+        let med: f64 = conn
+            .query_row("SELECT ix_quantile([1.0,2.0,3.0,4.0]::DOUBLE[], 0.5)", [], |r| r.get(0))
+            .unwrap();
+        assert!((med - 2.5).abs() < 1e-9, "median = 2.5, got {med}");
+        assert!(
+            conn.query_row("SELECT ix_quantile([1.0,2.0]::DOUBLE[], 1.5)", [], |r| r
+                .get::<_, f64>(0))
+                .is_err(),
+            "q out of [0,1] must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn divergence_scalars() {
+        let conn = open_bench().unwrap();
+        // KL([1,0] ‖ [0.5,0.5]) = ln 2.
+        let kl: f64 = conn
+            .query_row("SELECT ix_kl([1.0,0.0]::DOUBLE[], [0.5,0.5]::DOUBLE[])", [], |r| r.get(0))
+            .unwrap();
+        assert!((kl - 2.0_f64.ln()).abs() < 1e-9, "KL = ln2, got {kl}");
+        // JS is symmetric and zero for equal distributions.
+        let js: f64 = conn
+            .query_row("SELECT ix_js([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])", [], |r| r.get(0))
+            .unwrap();
+        assert!(js.abs() < 1e-9, "JS of equal distributions = 0, got {js}");
+    }
+
+    #[test]
+    fn two_sample_detects_shift() {
+        let conn = open_bench().unwrap();
+        // Disjoint ranges → KS D = 1, small p.
+        let (d, p): (f64, f64) = conn
+            .query_row(
+                "SELECT statistic, p_value FROM ix_two_sample('[0,1,2,3]', '[10,11,12,13]', 'ks')",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert!((d - 1.0).abs() < 1e-9, "KS D = 1 for disjoint samples, got {d}");
+        assert!(p < 0.2, "shifted distributions → small p, got {p}");
+
+        // Identical samples → Welch t = 0, p = 1.
+        let p_same: f64 = conn
+            .query_row(
+                "SELECT p_value FROM ix_two_sample('[1,2,3,4]', '[1,2,3,4]', 'welch')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((p_same - 1.0).abs() < 1e-3, "identical samples → p≈1, got {p_same}");
+
+        // Unknown test kind is a SQL error.
+        assert!(
+            conn.query_row(
+                "SELECT statistic FROM ix_two_sample('[1,2]', '[3,4]', 'chi2')",
+                [],
+                |r| r.get::<_, f64>(0)
+            )
+            .is_err(),
+            "unknown test kind must be a SQL error"
+        );
+    }
+}

--- a/crates/ix-duck/src/inference.rs
+++ b/crates/ix-duck/src/inference.rs
@@ -10,6 +10,7 @@
 //! | `ix_quantile(x, q)` | the `q`-quantile (numpy linear) |
 //! | `ix_entropy(p)` | Shannon entropy in nats |
 //! | `ix_kl(p, q)` / `ix_js(p, q)` | KL / Jensen–Shannon divergence |
+//! | `ix_pearson(a, b)` | Pearson correlation in [−1, 1] (the mesh's pairwise primitive) |
 //!
 //! And the regression-gate primitive, a table function over two JSON samples:
 //! `ix_two_sample(a_json, b_json, kind)` → `TABLE(statistic, p_value)`, `kind` ∈
@@ -29,7 +30,7 @@ use duckdb::Connection;
 use ix_math::error::MathError;
 use ix_math::inference::{
     iqr as _iqr, js_divergence, kl_divergence, ks_two_sample, kurtosis, mad, mann_whitney_u,
-    quantile, shannon_entropy, skewness, welch_t_test, TestResult,
+    pearson, quantile, shannon_entropy, skewness, welch_t_test, TestResult,
 };
 
 use crate::udf::read_list_col;
@@ -155,6 +156,20 @@ impl VScalar for IxKl {
     }
 }
 
+/// `ix_pearson(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — Pearson correlation in [−1, 1].
+/// The pairwise primitive for a correlation mesh over many streams.
+struct IxPearson;
+impl VScalar for IxPearson {
+    type State = ();
+    // @ai:invariant ix_pearson wraps ix_math::inference::pearson; perfectly correlated -> 1, anti-correlated -> -1, a constant or length-mismatched arg -> SQL error [T:test conf:0.85 src:ix_duck::inference::tests::pearson_scalar]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        invoke_binary(input, output, "ix_pearson", pearson)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        binary_sig()
+    }
+}
+
 /// `ix_js(p DOUBLE[], q DOUBLE[]) -> DOUBLE` — Jensen–Shannon divergence (nats).
 struct IxJs;
 impl VScalar for IxJs {
@@ -254,6 +269,7 @@ pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxQuantile>("ix_quantile")?;
     conn.register_scalar_function::<IxKl>("ix_kl")?;
     conn.register_scalar_function::<IxJs>("ix_js")?;
+    conn.register_scalar_function::<IxPearson>("ix_pearson")?;
     conn.register_table_function::<IxTwoSample>("ix_two_sample")?;
     Ok(())
 }
@@ -319,6 +335,28 @@ mod tests {
             .query_row("SELECT ix_js([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])", [], |r| r.get(0))
             .unwrap();
         assert!(js.abs() < 1e-9, "JS of equal distributions = 0, got {js}");
+    }
+
+    #[test]
+    fn pearson_scalar() {
+        let conn = open_bench().unwrap();
+        let r: f64 = conn
+            .query_row(
+                "SELECT ix_pearson([1.0,2.0,3.0,4.0]::DOUBLE[], [2.0,4.0,6.0,8.0]::DOUBLE[])",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!((r - 1.0).abs() < 1e-9, "perfectly correlated → 1, got {r}");
+        assert!(
+            conn.query_row(
+                "SELECT ix_pearson([1.0,1.0,1.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])",
+                [],
+                |row| row.get::<_, f64>(0)
+            )
+            .is_err(),
+            "constant arg must be a SQL error"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -294,6 +294,38 @@ mod tests {
     }
 
     #[test]
+    fn ix_minkowski_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        // p=1 → manhattan (|3|+|4| = 7)
+        let m1: f64 = conn
+            .query_row(
+                "SELECT ix_minkowski([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[], 1.0)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((m1 - 7.0).abs() < 1e-12, "p=1 → manhattan 7.0, got {m1}");
+
+        // p=2 → euclidean (3-4-5 → 5)
+        let m2: f64 = conn
+            .query_row(
+                "SELECT ix_minkowski([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[], 2.0)",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((m2 - 5.0).abs() < 1e-12, "p=2 → euclidean 5.0, got {m2}");
+
+        // Dimension mismatch surfaces as a SQL error, not a panic.
+        let err = conn.query_row(
+            "SELECT ix_minkowski([1.0,0.0]::DOUBLE[], [1.0]::DOUBLE[], 2.0)",
+            [],
+            |r| r.get::<_, f64>(0),
+        );
+        assert!(err.is_err(), "dimension mismatch should be a SQL error");
+    }
+
+    #[test]
     fn ix_cosine_passes_null_through() {
         let conn = open_bench().unwrap();
         // A NULL list argument yields SQL NULL, not a spurious number.

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -69,6 +69,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Statistical-inference UDFs over `ix-math::inference` — distribution-shape
+/// scalars (ix_skewness/ix_kurtosis/ix_mad/ix_quantile/ix_entropy/ix_kl/ix_js)
+/// and the two-sample test table fn ix_two_sample. Registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod inference;
+
 /// Artifact source — the deep module every lens reads through: safe materialization of
 /// a GA-emitted JSON artifact set into a bench table (file selection + read_json_auto
 /// flags + the json_extract projection + empty-fallback). See `CONTEXT.md` → "Artifact source".

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -69,6 +69,12 @@ mod sketch;
 #[cfg(feature = "udf")]
 mod code;
 
+/// Supervised fit/predict UDFs over `ix-supervised` — `ix_linreg_fit`/`_predict`
+/// and `ix_logistic_fit`/`_predict`, models round-tripped as JSON `VARCHAR` blobs.
+/// Registered by [`udf::register_all`].
+#[cfg(feature = "udf")]
+mod supervised;
+
 /// Artifact source — the deep module every lens reads through: safe materialization of
 /// a GA-emitted JSON artifact set into a bench table (file selection + read_json_auto
 /// flags + the json_extract projection + empty-fallback). See `CONTEXT.md` → "Artifact source".

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -113,6 +113,12 @@ pub mod ood;
 #[cfg(feature = "duck")]
 pub mod maintain;
 
+/// Pipeline mesh — compose N IX pipelines over many streams and correlate them
+/// (smooth → ix_pearson → ix_connected_components → ix_centrality). The substrate
+/// decided in `docs/adr/0004-duckdb-sql-pipeline-mesh.md`.
+#[cfg(feature = "duck")]
+pub mod mesh;
+
 #[cfg(feature = "duck")]
 pub use duckdb::{Connection, Result};
 

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -236,6 +236,64 @@ mod tests {
     }
 
     #[test]
+    fn ix_manhattan_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        let d: f64 = conn
+            .query_row(
+                "SELECT ix_manhattan([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((d - 7.0).abs() < 1e-12, "|3|+|4| → 7.0, got {d}");
+
+        // Dimension mismatch surfaces as a SQL error, not a panic.
+        let err = conn.query_row(
+            "SELECT ix_manhattan([1.0,0.0]::DOUBLE[], [1.0]::DOUBLE[])",
+            [],
+            |r| r.get::<_, f64>(0),
+        );
+        assert!(err.is_err(), "dimension mismatch should be a SQL error");
+    }
+
+    #[test]
+    fn ix_chebyshev_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        let d: f64 = conn
+            .query_row(
+                "SELECT ix_chebyshev([0.0,0.0]::DOUBLE[], [3.0,4.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((d - 4.0).abs() < 1e-12, "max(|3|,|4|) → 4.0, got {d}");
+    }
+
+    #[test]
+    fn ix_cosine_distance_matches_ix_math() {
+        let conn = open_bench().unwrap();
+        // identical → 0.0
+        let same: f64 = conn
+            .query_row(
+                "SELECT ix_cosine_distance([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(same.abs() < 1e-12, "identical → 0.0, got {same}");
+
+        // orthogonal → 1.0
+        let orth: f64 = conn
+            .query_row(
+                "SELECT ix_cosine_distance([1.0,0.0]::DOUBLE[], [0.0,1.0]::DOUBLE[])",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((orth - 1.0).abs() < 1e-12, "orthogonal → 1.0, got {orth}");
+    }
+
+    #[test]
     fn ix_cosine_passes_null_through() {
         let conn = open_bench().unwrap();
         // A NULL list argument yields SQL NULL, not a spurious number.

--- a/crates/ix-duck/src/mesh.rs
+++ b/crates/ix-duck/src/mesh.rs
@@ -1,0 +1,299 @@
+//! Pipeline mesh — compose N IX "pipelines" over many streams and correlate them
+//! on the DuckDB analyst bench. The substrate decided in
+//! [ADR-0004](../../docs/adr/0004-duckdb-sql-pipeline-mesh.md).
+//!
+//! A *pipeline* is a named SQL view/macro over a JSON-on-disk stream composing IX
+//! UDFs; the *mesh* is the N×N correlation across their outputs. [`correlate`] runs
+//! the canonical shape end-to-end:
+//!
+//! ```text
+//!   N streams → ix_wavelet_denoise (condition) → ix_pearson (pairwise)
+//!             → threshold → ix_connected_components (clusters)
+//!             → ix_centrality (lead / hub indicator)
+//! ```
+//!
+//! and returns a structured [`MeshResult`]. [`install_pipeline_catalog`] registers
+//! a few reusable table macros as the SQL-native declaration layer.
+//!
+//! Advisory analysis only — never a binding gate or source of truth (`docs/DUCKDB.md`).
+
+use std::collections::BTreeMap;
+
+use duckdb::Connection;
+
+/// Which `ix_centrality` measure ranks the mesh's lead/hub stream.
+///
+/// **Note:** a hub-and-spoke correlation graph is *bipartite*, on which
+/// [`Eigenvector`](CentralityKind::Eigenvector) oscillates and mislabels every node
+/// equal; [`Betweenness`](CentralityKind::Betweenness) (the default) and
+/// [`Degree`](CentralityKind::Degree) are the correct hub lenses. Eigenvector suits
+/// dense, mutually-correlated clusters. See ADR-0004.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CentralityKind {
+    Degree,
+    Closeness,
+    Eigenvector,
+    Betweenness,
+}
+
+impl CentralityKind {
+    fn as_sql(self) -> &'static str {
+        match self {
+            CentralityKind::Degree => "degree",
+            CentralityKind::Closeness => "closeness",
+            CentralityKind::Eigenvector => "eigenvector",
+            CentralityKind::Betweenness => "betweenness",
+        }
+    }
+}
+
+/// How a mesh is built: smoothing, the correlation-edge threshold, and the
+/// lead-indicator centrality.
+#[derive(Debug, Clone, Copy)]
+pub struct MeshConfig {
+    /// `|r|` threshold above which two streams get a correlation edge.
+    pub threshold: f64,
+    /// Optional per-stream wavelet smoothing `(levels, threshold)`; `None` = raw.
+    pub smooth: Option<(i64, f64)>,
+    /// Centrality measure used to pick the lead/hub stream.
+    pub centrality: CentralityKind,
+}
+
+impl Default for MeshConfig {
+    fn default() -> Self {
+        // Betweenness is the robust hub lens (bipartite-safe); 0.4 separates
+        // orthogonal pairs (≈0) from a shared latent driver (≈0.58). See ADR-0004.
+        Self {
+            threshold: 0.4,
+            smooth: Some((2, 0.05)),
+            centrality: CentralityKind::Betweenness,
+        }
+    }
+}
+
+/// The correlated structure of a stream mesh.
+#[derive(Debug, Clone)]
+pub struct MeshResult {
+    /// Stream names, indexed as everything else is.
+    pub names: Vec<String>,
+    /// `correlation[i][j]` = Pearson r between streams i and j (1.0 on the diagonal;
+    /// 0.0 for pairs where r is undefined, e.g. a constant stream).
+    pub correlation: Vec<Vec<f64>>,
+    /// Incident clusters (weakly-connected components of the `|r| ≥ threshold` graph),
+    /// each a sorted list of stream indices.
+    pub clusters: Vec<Vec<usize>>,
+    /// `(stream index, centrality score)` sorted by score descending.
+    pub centrality: Vec<(usize, f64)>,
+    /// The lead/hub stream index (highest centrality), or `None` for an empty mesh.
+    pub lead: Option<usize>,
+}
+
+impl MeshResult {
+    /// The name of the lead/hub stream, if any.
+    pub fn lead_name(&self) -> Option<&str> {
+        self.lead.map(|i| self.names[i].as_str())
+    }
+}
+
+fn arr(v: &[f64]) -> String {
+    let body: Vec<String> = v.iter().map(|x| format!("{x:.6}")).collect();
+    format!("[{}]", body.join(","))
+}
+
+/// Run the canonical correlation mesh over `streams` (each `(name, series)`).
+///
+/// Returns the correlation matrix, incident clusters, centrality ranking, and the
+/// lead stream. Streams shorter than 2 samples, or whose Pearson pair is undefined
+/// (a constant stream), simply yield no edge rather than aborting.
+// @ai:invariant mesh::correlate composes ix_wavelet_denoise → ix_pearson → ix_connected_components → ix_centrality; a hub-and-spoke input (one stream correlated with several mutually-uncorrelated others) yields one cluster containing all of them and ranks the hub highest under betweenness [T:test conf:0.85 src:ix_duck::mesh::tests::hub_and_spoke_mesh]
+pub fn correlate(
+    conn: &Connection,
+    streams: &[(String, Vec<f64>)],
+    cfg: &MeshConfig,
+) -> duckdb::Result<MeshResult> {
+    let n = streams.len();
+    let names: Vec<String> = streams.iter().map(|(name, _)| name.clone()).collect();
+
+    // 1. Condition each stream (optional wavelet smoothing).
+    let mut series: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for (_, raw) in streams {
+        if let Some((levels, threshold)) = cfg.smooth {
+            let sql = format!(
+                "SELECT value FROM ix_wavelet_denoise('{}', {levels}, {threshold}) ORDER BY i",
+                arr(raw)
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| row.get::<_, f64>(0))?;
+            series.push(rows.collect::<Result<Vec<f64>, _>>()?);
+        } else {
+            series.push(raw.clone());
+        }
+    }
+
+    // 2. Pairwise Pearson correlation matrix (upper triangle, mirrored).
+    let mut correlation = vec![vec![0.0f64; n]; n];
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for i in 0..n {
+        correlation[i][i] = 1.0;
+        for j in (i + 1)..n {
+            // A constant stream makes Pearson undefined → SQL error → treat as r = 0
+            // (no edge) so one degenerate stream can't sink the whole mesh.
+            let rij: f64 = conn
+                .query_row(
+                    &format!(
+                        "SELECT ix_pearson({}::DOUBLE[], {}::DOUBLE[])",
+                        arr(&series[i]),
+                        arr(&series[j])
+                    ),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0.0);
+            correlation[i][j] = rij;
+            correlation[j][i] = rij;
+            if rij.abs() >= cfg.threshold {
+                edges.push((i, j));
+            }
+        }
+    }
+
+    // 3. Edge list (self-loops keep every stream a node even with no strong edge).
+    let mut edge_json: Vec<String> = (0..n).map(|i| format!("[{i},{i}]")).collect();
+    edge_json.extend(edges.iter().map(|(i, j)| format!("[{i},{j}]")));
+    let edge_list = format!("[{}]", edge_json.join(","));
+
+    // 4. Incident clusters via ix_connected_components.
+    let mut by_comp: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    if n > 0 {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, component FROM ix_connected_components('{edge_list}') ORDER BY node"
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
+        for row in rows {
+            let (node, comp) = row?;
+            by_comp.entry(comp).or_default().push(node as usize);
+        }
+    }
+    let clusters: Vec<Vec<usize>> = by_comp.into_values().collect();
+
+    // 5. Lead/hub via ix_centrality.
+    let mut centrality: Vec<(usize, f64)> = Vec::with_capacity(n);
+    if n > 0 {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, score FROM ix_centrality('{edge_list}', '{}') ORDER BY score DESC, node",
+            cfg.centrality.as_sql()
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?)))?;
+        for row in rows {
+            let (node, score) = row?;
+            centrality.push((node as usize, score));
+        }
+    }
+    let lead = centrality.first().map(|&(i, _)| i);
+
+    Ok(MeshResult {
+        names,
+        correlation,
+        clusters,
+        centrality,
+        lead,
+    })
+}
+
+/// Install the reusable **pipeline catalog** — table macros that name a conditioning
+/// pipeline so callers can `SELECT … FROM ix_smooth('[…]', 2, 0.05)` declaratively.
+/// This is the SQL-native declaration layer of ADR-0004; the 100+ mesh is a catalog
+/// of such macros over different sources.
+pub fn install_pipeline_catalog(conn: &Connection) -> duckdb::Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE MACRO ix_smooth(series, levels, threshold) AS TABLE
+            SELECT i, value FROM ix_wavelet_denoise(series, levels, threshold);
+         CREATE OR REPLACE MACRO ix_kalman_pipeline(series, process_noise, measurement_noise) AS TABLE
+            SELECT i, value FROM ix_kalman_smooth(series, process_noise, measurement_noise);",
+    )
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+    use crate::open_bench;
+
+    /// Deterministic ±0.05 pseudo-noise (no RNG → reproducible).
+    fn noise(t: usize, seed: u64) -> f64 {
+        let mut x = (t as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
+        x ^= x >> 33;
+        x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+        x ^= x >> 33;
+        (x as f64 / u64::MAX as f64 - 0.5) * 0.1
+    }
+    fn tone(f: f64, seed: u64, n: usize) -> Vec<f64> {
+        (0..n)
+            .map(|t| (2.0 * std::f64::consts::PI * f * t as f64 / n as f64).sin() + noise(t, seed))
+            .collect()
+    }
+
+    #[test]
+    fn hub_and_spoke_mesh() {
+        let conn = open_bench().unwrap();
+        let n = 64;
+        let p = tone(1.0, 11, n);
+        let q = tone(2.0, 22, n);
+        let r = tone(3.0, 33, n);
+        let h: Vec<f64> = (0..n).map(|t| (p[t] + q[t] + r[t]) / 3.0 + noise(t, 99)).collect();
+        let d1 = tone(5.0, 44, n);
+        let d2 = tone(6.0, 55, n);
+        let streams = vec![
+            ("H".into(), h),
+            ("P".into(), p),
+            ("Q".into(), q),
+            ("R".into(), r),
+            ("D1".into(), d1),
+            ("D2".into(), d2),
+        ];
+
+        let res = correlate(&conn, &streams, &MeshConfig::default()).unwrap();
+
+        // H correlates with each spoke; spokes are mutually orthogonal.
+        assert!(res.correlation[0][1] > 0.4, "H↔P correlated, got {}", res.correlation[0][1]);
+        assert!(res.correlation[1][2].abs() < 0.3, "P↔Q orthogonal, got {}", res.correlation[1][2]);
+
+        // One cluster holds {H,P,Q,R}; D1 and D2 are isolated → 3 clusters total.
+        assert_eq!(res.clusters.len(), 3, "expected {{H,P,Q,R}}, {{D1}}, {{D2}}");
+        let hub_cluster = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
+        assert_eq!(hub_cluster.len(), 4, "H,P,Q,R cluster together");
+        assert!(hub_cluster.contains(&1) && hub_cluster.contains(&2) && hub_cluster.contains(&3));
+
+        // Betweenness ranks the hub H (index 0) as the lead.
+        assert_eq!(res.lead, Some(0), "H is the lead/hub");
+        assert_eq!(res.lead_name(), Some("H"));
+    }
+
+    #[test]
+    fn constant_stream_yields_no_edge_not_error() {
+        let conn = open_bench().unwrap();
+        // A flat (constant) stream makes Pearson undefined; the mesh must treat it as
+        // uncorrelated rather than erroring out.
+        let streams = vec![
+            ("flat".into(), vec![5.0; 16]),
+            ("ramp".into(), (0..16).map(|t| t as f64).collect()),
+        ];
+        let res = correlate(&conn, &streams, &MeshConfig { smooth: None, ..Default::default() })
+            .unwrap();
+        assert!(res.correlation[0][1].abs() < 1e-9, "constant↔ramp → r treated as 0");
+        assert_eq!(res.clusters.len(), 2, "two isolated streams");
+    }
+
+    #[test]
+    fn pipeline_catalog_macro_runs() {
+        let conn = open_bench().unwrap();
+        install_pipeline_catalog(&conn).unwrap();
+        // The declared ix_smooth pipeline macro composes like any table function.
+        let n: i64 = conn
+            .query_row("SELECT count(*) FROM ix_smooth('[1,2,3,4,5,6,7,8]', 2, 0.05)", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(n, 8, "ix_smooth macro returns the conditioned series");
+    }
+}

--- a/crates/ix-duck/src/supervised.rs
+++ b/crates/ix-duck/src/supervised.rs
@@ -1,0 +1,284 @@
+//! Supervised fit/predict UDFs over `ix-supervised`.
+//!
+//! DuckDB has `regr_slope`/`regr_intercept` (simple OLS aggregates) but nothing
+//! that fits a *multivariate* model you can persist and re-apply. These UDFs do,
+//! following the same **fit → blob → predict** shape as the `sketch` module: fit
+//! returns the trained model as a JSON `VARCHAR` you store in a column, then
+//! `predict` re-applies it to a feature vector.
+//!
+//! | model | fit | predict |
+//! |---|---|---|
+//! | linear   | `ix_linreg_fit(x_json, y_json)`   | `ix_linreg_predict(model, x_json)` → DOUBLE |
+//! | logistic | `ix_logistic_fit(x_json, y_json)` | `ix_logistic_predict(model, x_json)` → BIGINT (class) |
+//!
+//! `x_json` for **fit** is a JSON 2-D array `[[…features…], …]` (one row per
+//! sample); `y_json` is a 1-D array (`DOUBLE`s for linear, integer class ids for
+//! logistic). `x_json` for **predict** is a single 1-D feature vector. The whole
+//! training set enters as one scalar string, so a typical call is
+//! `SELECT ix_linreg_fit('[[1],[2],[3]]', '[2,4,6]')`.
+//!
+//! Pure wraps of `ix-supervised` — linear round-trips through its own
+//! `LinearRegressionState`; logistic serializes its public `(weights, bias)`.
+//! No model math here.
+
+use duckdb::core::{DataChunkHandle, Inserter, LogicalTypeHandle, LogicalTypeId};
+use duckdb::ffi::duckdb_string_t;
+use duckdb::types::DuckString;
+use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
+use duckdb::vtab::arrow::WritableVector;
+use duckdb::Connection;
+use ix_supervised::linear_regression::{LinearRegression, LinearRegressionState};
+use ix_supervised::logistic_regression::LogisticRegression;
+use ix_supervised::traits::{Classifier, Regressor};
+use ndarray::{Array1, Array2};
+use std::error::Error;
+use std::ffi::CString;
+
+use crate::tablefn::parse_matrix;
+
+type Res = Result<(), Box<dyn Error>>;
+
+fn ty(id: LogicalTypeId) -> LogicalTypeHandle {
+    LogicalTypeHandle::from(id)
+}
+
+/// Read a `VARCHAR` column into owned `String`s (one per row).
+fn read_varchar(input: &mut DataChunkHandle, col: usize, n: usize) -> Vec<String> {
+    let v = input.flat_vector(col);
+    let slice = unsafe { v.as_slice_with_len::<duckdb_string_t>(n) };
+    slice
+        .iter()
+        .map(|ptr| DuckString::new(&mut { *ptr }).as_str().to_string())
+        .collect()
+}
+
+fn write_varchar(output: &mut dyn WritableVector, vals: &[String]) -> Res {
+    let out = output.flat_vector();
+    for (i, v) in vals.iter().enumerate() {
+        out.insert(i, CString::new(v.as_str())?);
+    }
+    Ok(())
+}
+
+fn write_f64(output: &mut dyn WritableVector, vals: &[f64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<f64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+fn write_i64(output: &mut dyn WritableVector, vals: &[i64]) {
+    let mut out = output.flat_vector();
+    let slice = unsafe { out.as_mut_slice_with_len::<i64>(vals.len()) };
+    slice.copy_from_slice(vals);
+}
+
+/// Parse a single 1-D JSON feature vector into a `(1, n_features)` matrix (the
+/// `predict` input shape).
+fn parse_feature_row(json: &str) -> Result<Array2<f64>, Box<dyn Error>> {
+    let feat: Vec<f64> =
+        serde_json::from_str(json).map_err(|e| format!("expected a JSON number array: {e}"))?;
+    if feat.is_empty() {
+        return Err("feature vector is empty".into());
+    }
+    let n = feat.len();
+    Ok(Array2::from_shape_vec((1, n), feat)?)
+}
+
+// ── linear regression ──────────────────────────────────────────────────────────
+
+struct IxLinregFit;
+impl VScalar for IxLinregFit {
+    type State = ();
+    // @ai:invariant ix_linreg_fit fits ix_supervised LinearRegression over the JSON (x 2-D, y 1-D) and returns its LinearRegressionState as a JSON blob; mismatched row counts -> SQL error (no panic) [T:test conf:0.85 src:ix_duck::supervised::tests::linreg_fit_predict_recovers_slope]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let xs = read_varchar(input, 0, n);
+        let ys = read_varchar(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = parse_matrix(&xs[i])?;
+            let y: Vec<f64> = serde_json::from_str(&ys[i])
+                .map_err(|e| format!("ix_linreg_fit: y must be a JSON number array: {e}"))?;
+            if y.len() != x.nrows() {
+                return Err(format!(
+                    "ix_linreg_fit: y length ({}) != number of samples ({})",
+                    y.len(),
+                    x.nrows()
+                )
+                .into());
+            }
+            let mut model = LinearRegression::new();
+            model.fit(&x, &Array1::from_vec(y));
+            let state = model
+                .save_state()
+                .ok_or("ix_linreg_fit: model did not fit")?;
+            out.push(serde_json::to_string(&state)?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxLinregPredict;
+impl VScalar for IxLinregPredict {
+    type State = ();
+    // @ai:invariant ix_linreg_predict reloads a LinearRegressionState blob and returns the model's prediction for the JSON feature vector; a model fit on y=2x predicts ~2*x [T:test conf:0.85 src:ix_duck::supervised::tests::linreg_fit_predict_recovers_slope]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let models = read_varchar(input, 0, n);
+        let xs = read_varchar(input, 1, n);
+        let mut out = vec![0.0f64; n];
+        for i in 0..n {
+            let state: LinearRegressionState = serde_json::from_str(&models[i])
+                .map_err(|e| format!("ix_linreg_predict: invalid model blob: {e}"))?;
+            let model = LinearRegression::load_state(&state);
+            let x = parse_feature_row(&xs[i])?;
+            out[i] = model.predict(&x)[0];
+        }
+        write_f64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Double),
+        )]
+    }
+}
+
+// ── logistic regression ────────────────────────────────────────────────────────
+
+struct IxLogisticFit;
+impl VScalar for IxLogisticFit {
+    type State = ();
+    // @ai:invariant ix_logistic_fit fits ix_supervised LogisticRegression over the JSON (x 2-D, y 1-D class ids) and returns its (weights, bias) as a JSON blob; mismatched row counts -> SQL error (no panic) [T:test conf:0.85 src:ix_duck::supervised::tests::logistic_fit_predict_separates_classes]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let xs = read_varchar(input, 0, n);
+        let ys = read_varchar(input, 1, n);
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            let x = parse_matrix(&xs[i])?;
+            let y: Vec<usize> = serde_json::from_str(&ys[i])
+                .map_err(|e| format!("ix_logistic_fit: y must be a JSON int array: {e}"))?;
+            if y.len() != x.nrows() {
+                return Err(format!(
+                    "ix_logistic_fit: y length ({}) != number of samples ({})",
+                    y.len(),
+                    x.nrows()
+                )
+                .into());
+            }
+            let mut model = LogisticRegression::new();
+            model.fit(&x, &Array1::from_vec(y));
+            let weights = model
+                .weights
+                .as_ref()
+                .ok_or("ix_logistic_fit: model did not fit")?
+                .to_vec();
+            // LogisticRegression has no save_state; its (weights, bias) fully
+            // determine predictions, so serialize that tuple directly.
+            out.push(serde_json::to_string(&(weights, model.bias))?);
+        }
+        write_varchar(output, &out)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Varchar),
+        )]
+    }
+}
+
+struct IxLogisticPredict;
+impl VScalar for IxLogisticPredict {
+    type State = ();
+    // @ai:invariant ix_logistic_predict reloads a (weights, bias) blob and returns the predicted class id for the JSON feature vector; points on opposite sides of a fitted boundary get different classes [T:test conf:0.85 src:ix_duck::supervised::tests::logistic_fit_predict_separates_classes]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        let n = input.len();
+        let models = read_varchar(input, 0, n);
+        let xs = read_varchar(input, 1, n);
+        let mut out = vec![0i64; n];
+        for i in 0..n {
+            let (weights, bias): (Vec<f64>, f64) = serde_json::from_str(&models[i])
+                .map_err(|e| format!("ix_logistic_predict: invalid model blob: {e}"))?;
+            let mut model = LogisticRegression::new();
+            model.weights = Some(Array1::from_vec(weights));
+            model.bias = bias;
+            let x = parse_feature_row(&xs[i])?;
+            out[i] = model.predict(&x)[0] as i64;
+        }
+        write_i64(output, &out);
+        Ok(())
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![ty(LogicalTypeId::Varchar), ty(LogicalTypeId::Varchar)],
+            ty(LogicalTypeId::Bigint),
+        )]
+    }
+}
+
+/// Register the supervised fit/predict UDFs.
+pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
+    conn.register_scalar_function::<IxLinregFit>("ix_linreg_fit")?;
+    conn.register_scalar_function::<IxLinregPredict>("ix_linreg_predict")?;
+    conn.register_scalar_function::<IxLogisticFit>("ix_logistic_fit")?;
+    conn.register_scalar_function::<IxLogisticPredict>("ix_logistic_predict")?;
+    Ok(())
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use crate::open_bench;
+
+    #[test]
+    fn linreg_fit_predict_recovers_slope() {
+        let conn = open_bench().unwrap();
+        // Fit y = 2x on a perfect line, then predict at x=6 → ~12.
+        let pred: f64 = conn
+            .query_row(
+                "SELECT ix_linreg_predict(\
+                    ix_linreg_fit('[[1],[2],[3],[4],[5]]', '[2,4,6,8,10]'), '[6]')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((pred - 12.0).abs() < 1e-6, "y=2x model predicts ~12 at x=6, got {pred}");
+    }
+
+    #[test]
+    fn linreg_fit_rejects_mismatched_lengths() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT ix_linreg_fit('[[1],[2],[3]]', '[2,4]')",
+                [],
+                |r| r.get::<_, String>(0)
+            )
+            .is_err(),
+            "y shorter than x must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn logistic_fit_predict_separates_classes() {
+        let conn = open_bench().unwrap();
+        // 1-D, linearly separable: class 0 below ~2.5, class 1 above. A point at
+        // x=0 should predict class 0; x=5 should predict class 1.
+        let model = "ix_logistic_fit('[[0],[1],[2],[3],[4],[5]]', '[0,0,0,1,1,1]')";
+        let lo: i64 = conn
+            .query_row(&format!("SELECT ix_logistic_predict({model}, '[0]')"), [], |r| r.get(0))
+            .unwrap();
+        let hi: i64 = conn
+            .query_row(&format!("SELECT ix_logistic_predict({model}, '[5]')"), [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(lo, 0, "x=0 is in the low class");
+        assert_eq!(hi, 1, "x=5 is in the high class");
+    }
+}

--- a/crates/ix-duck/src/tablefn.rs
+++ b/crates/ix-duck/src/tablefn.rs
@@ -28,6 +28,11 @@
 //!     cluster labels `0..k-1`. `k` is capped at the sample count; deterministic
 //!     (seed 42). The centroid/mixture complement to `ix_dbscan`'s density labels —
 //!     all three feed `ix_silhouette`. Wrap `ix_unsupervised::{kmeans,gmm}`.
+//! - `ix_tsne_project(json_vectors VARCHAR, n_components BIGINT, perplexity DOUBLE)` /
+//!   `ix_mds_project(json_vectors VARCHAR, n_components BIGINT)`
+//!     → `TABLE(row BIGINT, coords DOUBLE[])`, the non-linear (t-SNE, seed 42) and
+//!     distance-preserving (classical MDS) companions to `ix_pca_project`. Wrap
+//!     `ix_unsupervised::{tsne::TSNE, mds::classical_mds}` — no reimplementation.
 //!
 //! A whole set enters in one SQL call as JSON scalar params (a 2-D number array
 //! for vectors, a 1-D int array for labels):
@@ -47,8 +52,10 @@ use ix_math::distance::euclidean;
 use ix_unsupervised::dbscan::DBSCAN;
 use ix_unsupervised::gmm::GMM;
 use ix_unsupervised::kmeans::KMeans;
+use ix_unsupervised::mds::{classical_mds, pairwise_euclidean};
 use ix_unsupervised::pca::PCA;
 use ix_unsupervised::traits::{Clusterer, DimensionReducer};
+use ix_unsupervised::tsne::TSNE;
 use ndarray::{Array1, Array2};
 
 /// Register every IX table function on `conn`.
@@ -59,6 +66,8 @@ pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_table_function::<IxDbscan>("ix_dbscan")?;
     conn.register_table_function::<IxKmeans>("ix_kmeans")?;
     conn.register_table_function::<IxGmm>("ix_gmm")?;
+    conn.register_table_function::<IxTsneProject>("ix_tsne_project")?;
+    conn.register_table_function::<IxMdsProject>("ix_mds_project")?;
     Ok(())
 }
 
@@ -176,6 +185,173 @@ impl VTab for IxPcaProject {
         output.set_len(rows);
         init.cursor.store(start + rows, Ordering::Relaxed);
         Ok(())
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+        ])
+    }
+}
+
+// ── ix_tsne_project / ix_mds_project (DimensionReducer companions to PCA) ──────
+//
+// All three project a (json_vectors, k[, …]) call to TABLE(row BIGINT, coords DOUBLE[]),
+// so they share the streaming `func` (row index + a length-`k` coords list per row).
+// Only the projection differs: PCA (linear, above), t-SNE (non-linear, perplexity),
+// classical MDS (distance-preserving). Both new estimators are seeded for determinism.
+
+#[repr(C)]
+struct ProjectBind {
+    /// Projected coordinates: one inner Vec (length `k`) per input row.
+    projected: Vec<Vec<f64>>,
+    k: usize,
+}
+#[repr(C)]
+struct ProjectInit {
+    cursor: AtomicUsize,
+}
+
+/// Shared streaming `func` for projection table functions: emit `row` (BIGINT) and
+/// `coords` (LIST<DOUBLE>, length `k`) in output-vector-sized chunks via the cursor.
+fn emit_coord_rows(
+    projected: &[Vec<f64>],
+    k: usize,
+    cursor: &AtomicUsize,
+    output: &mut DataChunkHandle,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let n = projected.len();
+    let start = cursor.load(Ordering::Relaxed);
+    if start >= n {
+        output.set_len(0);
+        return Ok(());
+    }
+    let cap = output.flat_vector(0).capacity();
+    let rows = (n - start).min(cap);
+
+    // col 0: row index (BIGINT)
+    {
+        let mut idx_vec = output.flat_vector(0);
+        let slice = unsafe { idx_vec.as_mut_slice_with_len::<i64>(rows) };
+        for (i, s) in slice.iter_mut().enumerate().take(rows) {
+            *s = (start + i) as i64;
+        }
+    }
+    // col 1: coords (LIST<DOUBLE>)
+    {
+        let total = rows * k;
+        let flat: Vec<f64> = (0..rows)
+            .flat_map(|i| projected[start + i].iter().copied())
+            .collect();
+        let mut lv = output.list_vector(1);
+        {
+            let mut child = lv.child(total);
+            let cslice = unsafe { child.as_mut_slice_with_len::<f64>(total) };
+            cslice[..total].copy_from_slice(&flat);
+        }
+        lv.set_len(total);
+        for i in 0..rows {
+            lv.set_entry(i, i * k, k);
+        }
+    }
+    output.set_len(rows);
+    cursor.store(start + rows, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Declare the shared (row, coords) result columns and turn an `(n_samples, k)`
+/// coordinate matrix into the row-wise `ProjectBind`.
+fn project_bind(bind: &BindInfo, projected_mat: Array2<f64>, k: usize) -> ProjectBind {
+    let projected: Vec<Vec<f64>> = (0..projected_mat.nrows())
+        .map(|r| projected_mat.row(r).to_vec())
+        .collect();
+    bind.add_result_column("row", LogicalTypeHandle::from(LogicalTypeId::Bigint));
+    bind.add_result_column(
+        "coords",
+        LogicalTypeHandle::list(&LogicalTypeHandle::from(LogicalTypeId::Double)),
+    );
+    ProjectBind { projected, k }
+}
+
+struct IxTsneProject;
+
+impl VTab for IxTsneProject {
+    type InitData = ProjectInit;
+    type BindData = ProjectBind;
+
+    // @ai:invariant ix_tsne_project fits ix_unsupervised TSNE (seed 42, given perplexity) over the JSON input vectors and emits one row per input with its min(n_components, n_features)-D embedding; deterministic for fixed seed [T:test conf:0.8 src:ix_duck::tablefn::tests::tsne_project_shape_and_deterministic]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let x = parse_matrix(&bind.get_parameter(0).to_string())?;
+        let k_req = bind.get_parameter(1).to_int64();
+        if k_req < 1 {
+            return Err("n_components must be >= 1".into());
+        }
+        let perplexity = bind.get_parameter(2).to_string().parse::<f64>().ok();
+        let perplexity = match perplexity {
+            Some(p) if p.is_finite() && p > 0.0 => p,
+            _ => return Err("perplexity must be a finite number > 0".into()),
+        };
+        // t-SNE's perplexity must stay below the sample count (it is a soft neighbour
+        // count); cap it so tiny analyst-bench inputs don't blow up the affinities.
+        let perplexity = perplexity.min((x.nrows() as f64 - 1.0).max(1.0));
+        let k = (k_req as usize).min(x.ncols());
+        let mut tsne = TSNE::new(k).with_perplexity(perplexity).with_seed(42);
+        let projected_mat = tsne.fit_transform(&x);
+        Ok(project_bind(bind, projected_mat, k))
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(ProjectInit { cursor: AtomicUsize::new(0) })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        emit_coord_rows(&bind.projected, bind.k, &func.get_init_data().cursor, output)
+    }
+
+    fn parameters() -> Option<Vec<LogicalTypeHandle>> {
+        Some(vec![
+            LogicalTypeHandle::from(LogicalTypeId::Varchar),
+            LogicalTypeHandle::from(LogicalTypeId::Bigint),
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        ])
+    }
+}
+
+struct IxMdsProject;
+
+impl VTab for IxMdsProject {
+    type InitData = ProjectInit;
+    type BindData = ProjectBind;
+
+    // @ai:invariant ix_mds_project runs classical (distance-preserving) MDS over the pairwise Euclidean distances of the JSON input vectors and emits one row per input with its min(n_components, n_features)-D embedding; well-separated points stay separated [T:test conf:0.8 src:ix_duck::tablefn::tests::mds_project_preserves_separation]
+    fn bind(bind: &BindInfo) -> Result<Self::BindData, Box<dyn std::error::Error>> {
+        let x = parse_matrix(&bind.get_parameter(0).to_string())?;
+        let k_req = bind.get_parameter(1).to_int64();
+        if k_req < 1 {
+            return Err("n_components must be >= 1".into());
+        }
+        let k = (k_req as usize).min(x.ncols());
+        let distances = pairwise_euclidean(&x);
+        let projected_mat =
+            classical_mds(&distances, k).map_err(|e| format!("ix_mds_project: {e}"))?;
+        Ok(project_bind(bind, projected_mat, k))
+    }
+
+    fn init(_: &InitInfo) -> Result<Self::InitData, Box<dyn std::error::Error>> {
+        Ok(ProjectInit { cursor: AtomicUsize::new(0) })
+    }
+
+    fn func(
+        func: &TableFunctionInfo<Self>,
+        output: &mut DataChunkHandle,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bind = func.get_bind_data();
+        emit_coord_rows(&bind.projected, bind.k, &func.get_init_data().cursor, output)
     }
 
     fn parameters() -> Option<Vec<LogicalTypeHandle>> {
@@ -689,6 +865,101 @@ mod tests {
             )
             .unwrap();
         assert_eq!(dim, 2, "n_components capped at n_features");
+    }
+
+    #[test]
+    fn tsne_project_shape_and_deterministic() {
+        let conn = open_bench().unwrap();
+        let pts = "[[0,0],[0,1],[1,0],[10,10],[10,11],[11,10]]";
+        // one row per input; coords length == n_components.
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_tsne_project('{pts}', 1, 2.0)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 6, "one row per input vector");
+        let dim: i64 = conn
+            .query_row(
+                &format!("SELECT len(coords) FROM ix_tsne_project('{pts}', 1, 2.0) LIMIT 1"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(dim, 1, "coords length == n_components");
+
+        // Seeded (42) → deterministic: row 0's coord is identical across two runs.
+        let a: f64 = conn
+            .query_row(
+                &format!("SELECT coords[1] FROM ix_tsne_project('{pts}', 1, 2.0) WHERE row=0"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let b: f64 = conn
+            .query_row(
+                &format!("SELECT coords[1] FROM ix_tsne_project('{pts}', 1, 2.0) WHERE row=0"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!((a - b).abs() < 1e-12, "seed 42 → deterministic embedding");
+    }
+
+    #[test]
+    fn tsne_project_rejects_bad_perplexity() {
+        let conn = open_bench().unwrap();
+        assert!(
+            conn.query_row(
+                "SELECT coords[1] FROM ix_tsne_project('[[0,0],[1,1]]', 1, 0.0)",
+                [],
+                |r| r.get::<_, f64>(0)
+            )
+            .is_err(),
+            "perplexity=0 must be a SQL error"
+        );
+    }
+
+    #[test]
+    fn mds_project_preserves_separation() {
+        let conn = open_bench().unwrap();
+        // Two tight clusters far apart; 1-D classical MDS must keep them apart.
+        let pts = "[[0,0],[0,1],[10,10],[10,11]]";
+        let n: i64 = conn
+            .query_row(
+                &format!("SELECT count(*) FROM ix_mds_project('{pts}', 1)"),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 4, "one row per input vector");
+
+        // |coord(row0) − coord(row2)| (cross-cluster) ≫ |coord(row0) − coord(row1)| (within).
+        let cross: f64 = conn
+            .query_row(
+                &format!(
+                    "SELECT abs((SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=0) \
+                              - (SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=2))"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let within: f64 = conn
+            .query_row(
+                &format!(
+                    "SELECT abs((SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=0) \
+                              - (SELECT coords[1] FROM ix_mds_project('{pts}',1) WHERE row=1))"
+                ),
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            cross > within * 3.0,
+            "cross-cluster MDS distance dominates within-cluster (cross={cross}, within={within})"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -291,5 +291,6 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     crate::eval::register(conn)?;
     crate::sketch::register(conn)?;
     crate::code::register(conn)?;
+    crate::supervised::register(conn)?;
     Ok(())
 }

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -1,9 +1,11 @@
 //! IX algorithms exposed as DuckDB scalar UDFs (via the `VScalar` trait).
 //!
-//! `ix_cosine(a, b)` and `ix_euclidean(a, b)` take two `DOUBLE[]` (LIST<DOUBLE>)
+//! The pairwise distance UDFs (`ix_cosine`, `ix_euclidean`, `ix_manhattan`,
+//! `ix_chebyshev`, `ix_cosine_distance`) each take two `DOUBLE[]` (LIST<DOUBLE>)
 //! and return a `DOUBLE`, wrapping the real `ix_math::distance` functions (no
 //! reimplementation). `ix_euclidean` is the primitive for the kNN-distance / OOD
-//! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`).
+//! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`); `ix_cosine_distance`
+//! (= 1 − cosine_similarity) is the metric-space companion for the same recipe.
 //!
 //! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions
 //! in the sibling `tablefn` module; [`register_all`] registers both surfaces.
@@ -12,7 +14,7 @@ use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use duckdb::Connection;
-use ix_math::distance::{cosine_similarity, euclidean};
+use ix_math::distance::{chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan};
 use ix_math::error::MathError;
 use ndarray::Array1;
 
@@ -137,11 +139,85 @@ impl VScalar for IxEuclidean {
     }
 }
 
-/// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`) and
-/// table (`ix_pca_project`, `ix_silhouette`) functions.
+/// `ix_manhattan(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — L1 (city-block) distance.
+struct IxManhattan;
+
+impl VScalar for IxManhattan {
+    type State = ();
+
+    // @ai:invariant ix_manhattan returns ix_math manhattan L1 distance of its two DOUBLE[] args; equal vectors -> 0.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_manhattan_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_manhattan", manhattan)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// `ix_chebyshev(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — L∞ (max-coordinate) distance.
+struct IxChebyshev;
+
+impl VScalar for IxChebyshev {
+    type State = ();
+
+    // @ai:invariant ix_chebyshev returns ix_math chebyshev L∞ distance of its two DOUBLE[] args; equal vectors -> 0.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_chebyshev_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_chebyshev", chebyshev)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// `ix_cosine_distance(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — `1 − cosine_similarity`,
+/// in `[0, 2]`. The metric-space companion to `ix_cosine` for kNN-distance / OOD.
+struct IxCosineDistance;
+
+impl VScalar for IxCosineDistance {
+    type State = ();
+
+    // @ai:invariant ix_cosine_distance returns ix_math cosine_distance (1 − cosine_similarity) of its two DOUBLE[] args; identical vectors -> 0.0, orthogonal -> 1.0, dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_cosine_distance_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        invoke_pairwise(input, output, "ix_cosine_distance", cosine_distance)
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![list_double(), list_double()],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
+/// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`,
+/// `ix_manhattan`, `ix_chebyshev`, `ix_cosine_distance`) and table
+/// (`ix_pca_project`, `ix_silhouette`) functions.
 pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxCosine>("ix_cosine")?;
     conn.register_scalar_function::<IxEuclidean>("ix_euclidean")?;
+    conn.register_scalar_function::<IxManhattan>("ix_manhattan")?;
+    conn.register_scalar_function::<IxChebyshev>("ix_chebyshev")?;
+    conn.register_scalar_function::<IxCosineDistance>("ix_cosine_distance")?;
     crate::tablefn::register(conn)?;
     crate::bracelet::register(conn)?;
     crate::serial::register(conn)?;

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -150,5 +150,6 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     crate::eval::register(conn)?;
     crate::sketch::register(conn)?;
     crate::code::register(conn)?;
+    crate::inference::register(conn)?;
     Ok(())
 }

--- a/crates/ix-duck/src/udf.rs
+++ b/crates/ix-duck/src/udf.rs
@@ -6,6 +6,8 @@
 //! reimplementation). `ix_euclidean` is the primitive for the kNN-distance / OOD
 //! SQL recipe (`ORDER BY ix_euclidean(q, r) LIMIT k`); `ix_cosine_distance`
 //! (= 1 − cosine_similarity) is the metric-space companion for the same recipe.
+//! `ix_minkowski(a, b, p)` adds a third scalar exponent (p=1 → manhattan, p=2 →
+//! euclidean) and so has its own invoke path.
 //!
 //! Set-relative operations (`ix_pca_project`, `ix_silhouette`) are table functions
 //! in the sibling `tablefn` module; [`register_all`] registers both surfaces.
@@ -14,7 +16,9 @@ use duckdb::core::{DataChunkHandle, LogicalTypeHandle, LogicalTypeId};
 use duckdb::vscalar::{ScalarFunctionSignature, VScalar};
 use duckdb::vtab::arrow::WritableVector;
 use duckdb::Connection;
-use ix_math::distance::{chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan};
+use ix_math::distance::{
+    chebyshev, cosine_distance, cosine_similarity, euclidean, manhattan, minkowski,
+};
 use ix_math::error::MathError;
 use ndarray::Array1;
 
@@ -209,6 +213,66 @@ impl VScalar for IxCosineDistance {
     }
 }
 
+/// `ix_minkowski(a DOUBLE[], b DOUBLE[], p DOUBLE) -> DOUBLE` — the Lᵖ family.
+/// `p = 1` reduces to manhattan, `p = 2` to euclidean. Unlike the 2-arg metrics
+/// this reads a third (scalar `DOUBLE`) argument, so it has its own invoke path.
+struct IxMinkowski;
+
+impl VScalar for IxMinkowski {
+    type State = ();
+
+    // @ai:invariant ix_minkowski(a,b,p) returns ix_math minkowski Lᵖ distance; p=1 equals ix_manhattan, p=2 equals ix_euclidean; a NULL list or NULL p yields SQL NULL; dimension mismatch -> SQL error (no panic) [T:test conf:0.9 src:ix_duck::tests::ix_minkowski_matches_ix_math]
+    unsafe fn invoke(
+        _: &Self::State,
+        input: &mut DataChunkHandle,
+        output: &mut dyn WritableVector,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let n = input.len();
+        let a_null = null_mask(input, 0, n);
+        let b_null = null_mask(input, 1, n);
+        let p_null = null_mask(input, 2, n);
+        let a = read_list_col(input, 0, n);
+        let b = read_list_col(input, 1, n);
+        // The `p` exponent is a flat DOUBLE column (one value per row).
+        let p_vals: Vec<f64> = {
+            let pv = input.flat_vector(2);
+            let s = pv.as_slice_with_len::<f64>(n);
+            s[..n].to_vec()
+        };
+        let mut out = output.flat_vector();
+        {
+            let out_slice = out.as_mut_slice_with_len::<f64>(n);
+            for i in 0..n {
+                if a_null[i] || b_null[i] || p_null[i] {
+                    out_slice[i] = 0.0; // placeholder; row flagged NULL below
+                    continue;
+                }
+                let av = Array1::from_vec(a[i].clone());
+                let bv = Array1::from_vec(b[i].clone());
+                out_slice[i] =
+                    minkowski(&av, &bv, p_vals[i]).map_err(|e| format!("ix_minkowski: {e}"))?;
+            }
+        }
+        for i in 0..n {
+            if a_null[i] || b_null[i] || p_null[i] {
+                out.set_null(i);
+            }
+        }
+        Ok(())
+    }
+
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        vec![ScalarFunctionSignature::exact(
+            vec![
+                list_double(),
+                list_double(),
+                LogicalTypeHandle::from(LogicalTypeId::Double),
+            ],
+            LogicalTypeHandle::from(LogicalTypeId::Double),
+        )]
+    }
+}
+
 /// Register every IX UDF on `conn` — scalar (`ix_cosine`, `ix_euclidean`,
 /// `ix_manhattan`, `ix_chebyshev`, `ix_cosine_distance`) and table
 /// (`ix_pca_project`, `ix_silhouette`) functions.
@@ -218,6 +282,7 @@ pub fn register_all(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxManhattan>("ix_manhattan")?;
     conn.register_scalar_function::<IxChebyshev>("ix_chebyshev")?;
     conn.register_scalar_function::<IxCosineDistance>("ix_cosine_distance")?;
+    conn.register_scalar_function::<IxMinkowski>("ix_minkowski")?;
     crate::tablefn::register(conn)?;
     crate::bracelet::register(conn)?;
     crate::serial::register(conn)?;

--- a/crates/ix-graph/src/graph.rs
+++ b/crates/ix-graph/src/graph.rs
@@ -215,6 +215,48 @@ impl Graph {
 
         rank
     }
+
+    /// Weakly-connected components: returns each node's component id, indexed by
+    /// node (`result[node]`). Edge direction is ignored, so two nodes share an id
+    /// iff one is reachable from the other along edges in either direction. Ids are
+    /// assigned `0, 1, …` in increasing node order (the smallest node in a component
+    /// fixes its id), so the count of distinct ids is the number of components.
+    pub fn connected_components(&self) -> Vec<usize> {
+        let n = self.node_count;
+        // Undirected adjacency view built from the directed adjacency list.
+        let mut undirected: Vec<Vec<usize>> = vec![Vec::new(); n];
+        for (&u, edges) in &self.adjacency {
+            if u >= n {
+                continue;
+            }
+            for &(v, _) in edges {
+                if v >= n {
+                    continue;
+                }
+                undirected[u].push(v);
+                undirected[v].push(u);
+            }
+        }
+        let mut comp = vec![usize::MAX; n];
+        let mut next_id = 0;
+        for start in 0..n {
+            if comp[start] != usize::MAX {
+                continue;
+            }
+            comp[start] = next_id;
+            let mut queue = VecDeque::from([start]);
+            while let Some(node) = queue.pop_front() {
+                for &nb in &undirected[node] {
+                    if comp[nb] == usize::MAX {
+                        comp[nb] = next_id;
+                        queue.push_back(nb);
+                    }
+                }
+            }
+            next_id += 1;
+        }
+        comp
+    }
 }
 
 impl Default for Graph {
@@ -262,6 +304,30 @@ mod tests {
         assert_eq!(dist[&0], 0);
         assert_eq!(dist[&1], 1);
         assert_eq!(dist[&3], 2);
+    }
+
+    #[test]
+    fn test_connected_components() {
+        // Two components: {0,1,2} (a directed chain — direction ignored) and {3,4}.
+        // Node 5 is isolated → its own component. Three components total.
+        let mut g = Graph::with_nodes(6);
+        g.add_edge(0, 1, 1.0);
+        g.add_edge(1, 2, 1.0);
+        g.add_edge(3, 4, 1.0);
+
+        let comp = g.connected_components();
+        assert_eq!(comp.len(), 6, "one id per node");
+        // Same component within {0,1,2} and within {3,4}.
+        assert_eq!(comp[0], comp[1]);
+        assert_eq!(comp[1], comp[2]);
+        assert_eq!(comp[3], comp[4]);
+        // Different components across the three groups.
+        assert_ne!(comp[0], comp[3]);
+        assert_ne!(comp[0], comp[5]);
+        assert_ne!(comp[3], comp[5]);
+
+        let distinct: std::collections::HashSet<_> = comp.iter().collect();
+        assert_eq!(distinct.len(), 3, "exactly three weakly-connected components");
     }
 
     #[test]

--- a/crates/ix-graph/src/graph.rs
+++ b/crates/ix-graph/src/graph.rs
@@ -257,6 +257,142 @@ impl Graph {
         }
         comp
     }
+
+    /// Undirected adjacency view (deduplicated neighbour sets), built from the
+    /// directed adjacency list. Shared by the centrality measures, which treat the
+    /// graph as undirected.
+    fn undirected_adjacency(&self) -> Vec<Vec<usize>> {
+        let n = self.node_count;
+        let mut sets: Vec<HashSet<usize>> = vec![HashSet::new(); n];
+        for (&u, edges) in &self.adjacency {
+            if u >= n {
+                continue;
+            }
+            for &(v, _) in edges {
+                if v >= n || v == u {
+                    continue;
+                }
+                sets[u].insert(v);
+                sets[v].insert(u);
+            }
+        }
+        sets.into_iter().map(|s| s.into_iter().collect()).collect()
+    }
+
+    /// Degree centrality (undirected): each node's neighbour count normalized by the
+    /// maximum possible (`n − 1`). Indexed by node.
+    pub fn degree_centrality(&self) -> Vec<f64> {
+        let n = self.node_count;
+        let adj = self.undirected_adjacency();
+        let denom = (n as f64 - 1.0).max(1.0);
+        adj.iter().map(|nb| nb.len() as f64 / denom).collect()
+    }
+
+    /// Closeness centrality (undirected, unweighted, Wasserman–Faust form for
+    /// possibly-disconnected graphs): for node `v` with `r` other reachable nodes at
+    /// total hop-distance `d`, `C(v) = r² / ((n − 1) · d)`. Indexed by node.
+    pub fn closeness_centrality(&self) -> Vec<f64> {
+        let n = self.node_count;
+        let adj = self.undirected_adjacency();
+        let denom = (n as f64 - 1.0).max(1.0);
+        let mut out = vec![0.0; n];
+        for s in 0..n {
+            // BFS hop distances from s over the undirected view.
+            let mut dist = vec![-1i64; n];
+            dist[s] = 0;
+            let mut q = VecDeque::from([s]);
+            while let Some(v) = q.pop_front() {
+                for &w in &adj[v] {
+                    if dist[w] < 0 {
+                        dist[w] = dist[v] + 1;
+                        q.push_back(w);
+                    }
+                }
+            }
+            let (mut r, mut sumd) = (0.0, 0.0);
+            for (i, &d) in dist.iter().enumerate() {
+                if i != s && d > 0 {
+                    r += 1.0;
+                    sumd += d as f64;
+                }
+            }
+            out[s] = if sumd > 0.0 { (r * r) / (denom * sumd) } else { 0.0 };
+        }
+        out
+    }
+
+    /// Eigenvector centrality (undirected) by power iteration on the adjacency
+    /// matrix, L2-normalized. Indexed by node.
+    pub fn eigenvector_centrality(&self, iterations: usize) -> Vec<f64> {
+        let n = self.node_count;
+        if n == 0 {
+            return Vec::new();
+        }
+        let adj = self.undirected_adjacency();
+        let mut x = vec![1.0 / (n as f64).sqrt(); n];
+        for _ in 0..iterations {
+            let mut next = vec![0.0; n];
+            for (v, nb) in adj.iter().enumerate() {
+                for &w in nb {
+                    next[v] += x[w];
+                }
+            }
+            let norm: f64 = next.iter().map(|v| v * v).sum::<f64>().sqrt();
+            if norm <= f64::EPSILON {
+                break; // no edges → leave the previous estimate
+            }
+            for v in &mut next {
+                *v /= norm;
+            }
+            x = next;
+        }
+        x
+    }
+
+    /// Betweenness centrality (undirected, unweighted) via Brandes' algorithm: the
+    /// fraction of shortest paths through each node, halved to undo the
+    /// each-pair-counted-twice double count. Indexed by node.
+    pub fn betweenness_centrality(&self) -> Vec<f64> {
+        let n = self.node_count;
+        let adj = self.undirected_adjacency();
+        let mut bc = vec![0.0; n];
+        for s in 0..n {
+            let mut stack: Vec<usize> = Vec::new();
+            let mut preds: Vec<Vec<usize>> = vec![Vec::new(); n];
+            let mut sigma = vec![0.0; n];
+            sigma[s] = 1.0;
+            let mut dist = vec![-1i64; n];
+            dist[s] = 0;
+            let mut q = VecDeque::from([s]);
+            while let Some(v) = q.pop_front() {
+                stack.push(v);
+                for &w in &adj[v] {
+                    if dist[w] < 0 {
+                        dist[w] = dist[v] + 1;
+                        q.push_back(w);
+                    }
+                    if dist[w] == dist[v] + 1 {
+                        sigma[w] += sigma[v];
+                        preds[w].push(v);
+                    }
+                }
+            }
+            let mut delta = vec![0.0; n];
+            while let Some(w) = stack.pop() {
+                for &v in &preds[w] {
+                    delta[v] += (sigma[v] / sigma[w]) * (1.0 + delta[w]);
+                }
+                if w != s {
+                    bc[w] += delta[w];
+                }
+            }
+        }
+        // Undirected: each shortest path is counted from both endpoints.
+        for v in &mut bc {
+            *v /= 2.0;
+        }
+        bc
+    }
 }
 
 impl Default for Graph {
@@ -328,6 +464,43 @@ mod tests {
 
         let distinct: std::collections::HashSet<_> = comp.iter().collect();
         assert_eq!(distinct.len(), 3, "exactly three weakly-connected components");
+    }
+
+    #[test]
+    fn test_centrality_star_center_dominates() {
+        // Star: center 0 joined to leaves 1,2,3 (undirected). The hub must score
+        // strictly highest on every centrality measure; leaves tie.
+        let mut g = Graph::with_nodes(4);
+        g.add_undirected_edge(0, 1, 1.0);
+        g.add_undirected_edge(0, 2, 1.0);
+        g.add_undirected_edge(0, 3, 1.0);
+
+        let deg = g.degree_centrality();
+        assert!((deg[0] - 1.0).abs() < 1e-12, "hub degree centrality = 3/3 = 1");
+        assert!(deg[0] > deg[1] && (deg[1] - deg[2]).abs() < 1e-12);
+
+        let clo = g.closeness_centrality();
+        assert!(clo[0] > clo[1], "hub is closest to everything");
+
+        let eig = g.eigenvector_centrality(100);
+        assert!(eig[0] > eig[1], "hub has the highest eigenvector centrality");
+
+        let bc = g.betweenness_centrality();
+        // Every shortest path between two leaves passes through the hub → bc[0] > 0,
+        // leaves lie on no one else's path → 0.
+        assert!(bc[0] > 0.0, "hub has positive betweenness, got {}", bc[0]);
+        assert!(bc[1].abs() < 1e-12, "a leaf has zero betweenness, got {}", bc[1]);
+    }
+
+    #[test]
+    fn test_betweenness_path_middle_dominates() {
+        // Path 0-1-2: only the middle node 1 lies on the 0↔2 shortest path.
+        let mut g = Graph::with_nodes(3);
+        g.add_undirected_edge(0, 1, 1.0);
+        g.add_undirected_edge(1, 2, 1.0);
+        let bc = g.betweenness_centrality();
+        assert!((bc[1] - 1.0).abs() < 1e-12, "middle node betweenness = 1, got {}", bc[1]);
+        assert!(bc[0].abs() < 1e-12 && bc[2].abs() < 1e-12, "endpoints have zero betweenness");
     }
 
     #[test]

--- a/crates/ix-math/src/inference.rs
+++ b/crates/ix-math/src/inference.rs
@@ -121,6 +121,36 @@ pub fn zscore(x: &[f64]) -> Result<Vec<f64>, MathError> {
     Ok(x.iter().map(|v| (v - mu) / sigma).collect())
 }
 
+/// Pearson product-moment correlation `r ∈ [−1, 1]` between two equal-length,
+/// non-constant samples. `r = Σ(aᵢ−ā)(bᵢ−b̄) / √(Σ(aᵢ−ā)² · Σ(bᵢ−b̄)²)`. The
+/// pairwise primitive for a correlation mesh over many streams.
+pub fn pearson(a: &[f64], b: &[f64]) -> Result<f64, MathError> {
+    if a.len() != b.len() {
+        return Err(MathError::DimensionMismatch {
+            expected: a.len(),
+            got: b.len(),
+        });
+    }
+    if a.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let (ma, mb) = (mean(a), mean(b));
+    let (mut cov, mut va, mut vb) = (0.0, 0.0, 0.0);
+    for (&ai, &bi) in a.iter().zip(b) {
+        let (da, db) = (ai - ma, bi - mb);
+        cov += da * db;
+        va += da * da;
+        vb += db * db;
+    }
+    let denom = (va * vb).sqrt();
+    if denom <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "Pearson correlation is undefined when a sample is constant".into(),
+        ));
+    }
+    Ok((cov / denom).clamp(-1.0, 1.0))
+}
+
 // ── divergences over probability vectors ───────────────────────────────────────
 
 /// Normalize a non-negative vector to sum 1. Errors on negatives or all-zero.
@@ -495,6 +525,18 @@ mod tests {
         assert!((z[0] + 2.0_f64.sqrt()).abs() < TOL);
         assert!(z[2].abs() < TOL);
         assert!((z.iter().sum::<f64>()).abs() < TOL, "z-scores sum to 0");
+    }
+
+    #[test]
+    fn pearson_correlation() {
+        // Perfect positive / negative / independent.
+        assert!((pearson(&[1., 2., 3., 4.], &[2., 4., 6., 8.]).unwrap() - 1.0).abs() < TOL);
+        assert!((pearson(&[1., 2., 3., 4.], &[8., 6., 4., 2.]).unwrap() + 1.0).abs() < TOL);
+        // numpy.corrcoef([1,2,3,4,5],[2,1,4,3,6])[0,1] = 10/√148 ≈ 0.821995
+        let expected = 10.0 / 148.0_f64.sqrt();
+        assert!((pearson(&[1., 2., 3., 4., 5.], &[2., 1., 4., 3., 6.]).unwrap() - expected).abs() < TOL);
+        assert!(pearson(&[1., 1., 1.], &[1., 2., 3.]).is_err(), "constant sample is undefined");
+        assert!(pearson(&[1., 2.], &[1.]).is_err(), "length mismatch errors");
     }
 
     #[test]

--- a/crates/ix-math/src/inference.rs
+++ b/crates/ix-math/src/inference.rs
@@ -1,0 +1,546 @@
+//! Statistical inference: distribution-shape moments, divergences, and two-sample
+//! hypothesis tests — the layer both `ix-math::stats` and DuckDB built-ins lack.
+//!
+//! The motivating question is *"did this metric's **distribution** shift versus
+//! baseline?"* — the core of any regression / RSI gate. A mean can hold steady
+//! while the distribution degrades (variance blow-up, bimodality, tail shift), so
+//! a principled gate needs two-sample tests, not mean thresholds.
+//!
+//! Conventions match SciPy defaults so results are checkable against a reference:
+//! [`skewness`]/[`kurtosis`] are the biased (population) Fisher–Pearson forms,
+//! [`kurtosis`] is *excess*, [`zscore`] uses population σ (ddof=0), [`quantile`]
+//! is numpy's linear interpolation, [`welch_t_test`] is `ttest_ind(equal_var=False)`,
+//! and [`shannon_entropy`]/[`kl_divergence`] use natural log (nats). Test values
+//! are pinned to SciPy in the unit tests — **do not** change a formula without a
+//! reference value.
+
+use crate::error::MathError;
+
+/// Outcome of a two-sample hypothesis test: the test statistic and its two-sided
+/// p-value (the probability, under the null of equal distributions, of a statistic
+/// at least this extreme).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TestResult {
+    pub statistic: f64,
+    pub p_value: f64,
+}
+
+// ── descriptive: distribution shape over one sample ────────────────────────────
+
+/// The `q`-quantile (`q ∈ [0, 1]`) by linear interpolation between order statistics
+/// — numpy's default method. `q = 0.5` is the median.
+pub fn quantile(x: &[f64], q: f64) -> Result<f64, MathError> {
+    if x.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    if q.is_nan() || !(0.0..=1.0).contains(&q) {
+        return Err(MathError::InvalidParameter(format!(
+            "quantile q must be in [0, 1], got {q}"
+        )));
+    }
+    let mut s = x.to_vec();
+    s.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let n = s.len();
+    if n == 1 {
+        return Ok(s[0]);
+    }
+    let pos = q * (n as f64 - 1.0);
+    let lo = pos.floor() as usize;
+    let frac = pos - lo as f64;
+    if lo + 1 < n {
+        Ok(s[lo] + frac * (s[lo + 1] - s[lo]))
+    } else {
+        Ok(s[lo])
+    }
+}
+
+/// Interquartile range: `quantile(0.75) − quantile(0.25)`.
+pub fn iqr(x: &[f64]) -> Result<f64, MathError> {
+    Ok(quantile(x, 0.75)? - quantile(x, 0.25)?)
+}
+
+/// Median absolute deviation: `median(|xᵢ − median(x)|)`. A robust spread estimate.
+pub fn mad(x: &[f64]) -> Result<f64, MathError> {
+    let med = quantile(x, 0.5)?;
+    let dev: Vec<f64> = x.iter().map(|v| (v - med).abs()).collect();
+    quantile(&dev, 0.5)
+}
+
+fn mean(x: &[f64]) -> f64 {
+    x.iter().sum::<f64>() / x.len() as f64
+}
+
+/// `n`-th central moment `(1/N) Σ (xᵢ − μ)ⁿ`.
+fn central_moment(x: &[f64], n: i32) -> f64 {
+    let mu = mean(x);
+    x.iter().map(|v| (v - mu).powi(n)).sum::<f64>() / x.len() as f64
+}
+
+/// Biased (population) Fisher–Pearson skewness `g₁ = m₃ / m₂^{3/2}` — SciPy's
+/// `skew` default. Symmetric data → 0; a long right tail → positive.
+pub fn skewness(x: &[f64]) -> Result<f64, MathError> {
+    if x.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let m2 = central_moment(x, 2);
+    if m2 <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "skewness is undefined for zero-variance data".into(),
+        ));
+    }
+    Ok(central_moment(x, 3) / m2.powf(1.5))
+}
+
+/// Biased excess kurtosis `g₂ = m₄ / m₂² − 3` — SciPy's `kurtosis` default
+/// (`fisher=True`). A normal distribution → 0.
+pub fn kurtosis(x: &[f64]) -> Result<f64, MathError> {
+    if x.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let m2 = central_moment(x, 2);
+    if m2 <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "kurtosis is undefined for zero-variance data".into(),
+        ));
+    }
+    Ok(central_moment(x, 4) / (m2 * m2) - 3.0)
+}
+
+/// Standard score `(xᵢ − μ) / σ` with population σ (ddof = 0) — SciPy's `zscore`.
+pub fn zscore(x: &[f64]) -> Result<Vec<f64>, MathError> {
+    if x.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let mu = mean(x);
+    let sigma = central_moment(x, 2).sqrt();
+    if sigma <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "zscore is undefined for zero-variance data".into(),
+        ));
+    }
+    Ok(x.iter().map(|v| (v - mu) / sigma).collect())
+}
+
+// ── divergences over probability vectors ───────────────────────────────────────
+
+/// Normalize a non-negative vector to sum 1. Errors on negatives or all-zero.
+fn normalize(p: &[f64]) -> Result<Vec<f64>, MathError> {
+    if p.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    if p.iter().any(|&v| v < 0.0 || v.is_nan()) {
+        return Err(MathError::InvalidParameter(
+            "probability vector must be non-negative".into(),
+        ));
+    }
+    let total: f64 = p.iter().sum();
+    if total <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "probability vector sums to zero".into(),
+        ));
+    }
+    Ok(p.iter().map(|v| v / total).collect())
+}
+
+/// Shannon entropy `−Σ pᵢ ln pᵢ` in nats over the normalized distribution.
+pub fn shannon_entropy(p: &[f64]) -> Result<f64, MathError> {
+    let p = normalize(p)?;
+    Ok(-p
+        .iter()
+        .filter(|&&v| v > 0.0)
+        .map(|&v| v * v.ln())
+        .sum::<f64>())
+}
+
+/// Kullback–Leibler divergence `Σ pᵢ ln(pᵢ / qᵢ)` in nats (asymmetric). Both
+/// vectors are normalized first; `qᵢ = 0` where `pᵢ > 0` is `+∞`-undefined → error.
+pub fn kl_divergence(p: &[f64], q: &[f64]) -> Result<f64, MathError> {
+    if p.len() != q.len() {
+        return Err(MathError::DimensionMismatch {
+            expected: p.len(),
+            got: q.len(),
+        });
+    }
+    let p = normalize(p)?;
+    let q = normalize(q)?;
+    let mut sum = 0.0;
+    for (&pi, &qi) in p.iter().zip(&q) {
+        if pi > 0.0 {
+            if qi <= 0.0 {
+                return Err(MathError::InvalidParameter(
+                    "KL divergence diverges: q is zero where p is positive".into(),
+                ));
+            }
+            sum += pi * (pi / qi).ln();
+        }
+    }
+    Ok(sum)
+}
+
+/// Jensen–Shannon divergence `½KL(p‖m) + ½KL(q‖m)` with `m = (p+q)/2`. Symmetric
+/// and bounded in `[0, ln 2]`; `0` iff the distributions are equal.
+pub fn js_divergence(p: &[f64], q: &[f64]) -> Result<f64, MathError> {
+    if p.len() != q.len() {
+        return Err(MathError::DimensionMismatch {
+            expected: p.len(),
+            got: q.len(),
+        });
+    }
+    let p = normalize(p)?;
+    let q = normalize(q)?;
+    let m: Vec<f64> = p.iter().zip(&q).map(|(&a, &b)| 0.5 * (a + b)).collect();
+    Ok(0.5 * kl_divergence(&p, &m)? + 0.5 * kl_divergence(&q, &m)?)
+}
+
+// ── two-sample tests ───────────────────────────────────────────────────────────
+
+/// Two-sample Kolmogorov–Smirnov test. Statistic `D = supₓ |F_a(x) − F_b(x)|`;
+/// p-value from the asymptotic Kolmogorov distribution with the Stephens
+/// small-sample correction (SciPy's `method='asymp'`).
+pub fn ks_two_sample(a: &[f64], b: &[f64]) -> Result<TestResult, MathError> {
+    if a.is_empty() || b.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let mut sa = a.to_vec();
+    let mut sb = b.to_vec();
+    sa.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    sb.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
+    let (na, nb) = (sa.len() as f64, sb.len() as f64);
+    // Walk the merged order, tracking the two empirical CDFs and their max gap. At
+    // each distinct value, advance *both* CDFs past all of its copies before
+    // measuring the gap — otherwise a shared (tied) value spuriously inflates D.
+    let (mut i, mut j) = (0usize, 0usize);
+    let mut d = 0.0_f64;
+    while i < sa.len() || j < sb.len() {
+        let v = if i < sa.len() && (j >= sb.len() || sa[i] <= sb[j]) {
+            sa[i]
+        } else {
+            sb[j]
+        };
+        while i < sa.len() && sa[i] == v {
+            i += 1;
+        }
+        while j < sb.len() && sb[j] == v {
+            j += 1;
+        }
+        d = d.max((i as f64 / na - j as f64 / nb).abs());
+    }
+    let en = (na * nb / (na + nb)).sqrt();
+    let p = kolmogorov_sf((en + 0.12 + 0.11 / en) * d);
+    Ok(TestResult {
+        statistic: d,
+        p_value: p.clamp(0.0, 1.0),
+    })
+}
+
+/// Mann–Whitney U test (rank-sum) with the normal approximation, tie correction,
+/// and continuity correction — SciPy's `mannwhitneyu(method='asymptotic')`. The
+/// reported statistic is `U₁` for the first sample; the p-value is two-sided.
+pub fn mann_whitney_u(a: &[f64], b: &[f64]) -> Result<TestResult, MathError> {
+    if a.is_empty() || b.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let (n1, n2) = (a.len() as f64, b.len() as f64);
+    // Average ranks over the pooled sample, recording tie-group sizes.
+    let mut pooled: Vec<(f64, bool)> = a.iter().map(|&v| (v, true)).collect();
+    pooled.extend(b.iter().map(|&v| (v, false)));
+    pooled.sort_by(|x, y| x.0.partial_cmp(&y.0).unwrap_or(std::cmp::Ordering::Equal));
+    let n = pooled.len();
+    let mut ranks = vec![0.0f64; n];
+    let mut tie_term = 0.0;
+    let mut k = 0;
+    while k < n {
+        let mut m = k + 1;
+        while m < n && pooled[m].0 == pooled[k].0 {
+            m += 1;
+        }
+        let group = m - k;
+        let avg_rank = (k + 1 + m) as f64 / 2.0; // mean of ranks k+1..=m
+        for r in ranks.iter_mut().take(m).skip(k) {
+            *r = avg_rank;
+        }
+        let t = group as f64;
+        tie_term += t * t * t - t;
+        k = m;
+    }
+    let r1: f64 = ranks
+        .iter()
+        .zip(&pooled)
+        .filter(|(_, &(_, first))| first)
+        .map(|(&r, _)| r)
+        .sum();
+    let u1 = r1 - n1 * (n1 + 1.0) / 2.0;
+    let mu = n1 * n2 / 2.0;
+    let big_n = n1 + n2;
+    let sigma =
+        (n1 * n2 / 12.0 * ((big_n + 1.0) - tie_term / (big_n * (big_n - 1.0)))).sqrt();
+    if sigma <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "Mann–Whitney variance is zero (all values tied)".into(),
+        ));
+    }
+    // Continuity correction of 0.5 toward the mean.
+    let z = (u1 - mu).abs().max(0.0);
+    let z = (z - 0.5).max(0.0) / sigma;
+    let p = (2.0 * normal_sf(z)).clamp(0.0, 1.0);
+    Ok(TestResult {
+        statistic: u1,
+        p_value: p,
+    })
+}
+
+/// Welch's unequal-variance two-sample t-test — SciPy's
+/// `ttest_ind(equal_var=False)`. Statistic `t`, two-sided p-value from the
+/// Student-t distribution with Welch–Satterthwaite degrees of freedom.
+pub fn welch_t_test(a: &[f64], b: &[f64]) -> Result<TestResult, MathError> {
+    if a.len() < 2 || b.len() < 2 {
+        return Err(MathError::InvalidParameter(
+            "Welch's t-test needs at least 2 observations per sample".into(),
+        ));
+    }
+    let (na, nb) = (a.len() as f64, b.len() as f64);
+    let (ma, mb) = (mean(a), mean(b));
+    // Sample variance (ddof = 1).
+    let va = a.iter().map(|v| (v - ma).powi(2)).sum::<f64>() / (na - 1.0);
+    let vb = b.iter().map(|v| (v - mb).powi(2)).sum::<f64>() / (nb - 1.0);
+    let sa = va / na;
+    let sb = vb / nb;
+    let se = (sa + sb).sqrt();
+    if se <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "Welch's t-test is undefined: both samples are constant".into(),
+        ));
+    }
+    let t = (ma - mb) / se;
+    let df = (sa + sb).powi(2) / (sa * sa / (na - 1.0) + sb * sb / (nb - 1.0));
+    // Two-sided p = I_x(df/2, 1/2) with x = df/(df + t²).
+    let x = df / (df + t * t);
+    let p = reg_incomplete_beta(df / 2.0, 0.5, x).clamp(0.0, 1.0);
+    Ok(TestResult {
+        statistic: t,
+        p_value: p,
+    })
+}
+
+// ── special functions (self-contained; ix-math has none of these) ──────────────
+
+/// Error function via Abramowitz & Stegun 7.1.26 (|error| ≤ 1.5e-7).
+fn erf(x: f64) -> f64 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * x);
+    let y = 1.0
+        - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t
+            + 0.254829592)
+            * t
+            * (-x * x).exp();
+    sign * y
+}
+
+/// Upper tail of the standard normal: `P(Z > z)`.
+fn normal_sf(z: f64) -> f64 {
+    0.5 * (1.0 - erf(z / std::f64::consts::SQRT_2))
+}
+
+/// Survival function of the Kolmogorov distribution:
+/// `Q(t) = 2 Σ_{k≥1} (−1)^{k−1} e^{−2k²t²}`.
+fn kolmogorov_sf(t: f64) -> f64 {
+    if t <= 0.0 {
+        return 1.0;
+    }
+    let mut sum = 0.0;
+    let mut sign = 1.0;
+    for k in 1..=100 {
+        let term = sign * (-2.0 * (k * k) as f64 * t * t).exp();
+        sum += term;
+        if term.abs() < 1e-12 {
+            break;
+        }
+        sign = -sign;
+    }
+    (2.0 * sum).clamp(0.0, 1.0)
+}
+
+/// Natural log of the gamma function (Lanczos approximation, g = 7).
+fn ln_gamma(x: f64) -> f64 {
+    const C: [f64; 9] = [
+        0.999_999_999_999_809_9,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+    if x < 0.5 {
+        // Reflection: Γ(x)Γ(1−x) = π / sin(πx).
+        (std::f64::consts::PI / (std::f64::consts::PI * x).sin()).ln() - ln_gamma(1.0 - x)
+    } else {
+        let x = x - 1.0;
+        let mut a = C[0];
+        let tval = x + 7.5;
+        for (i, &c) in C.iter().enumerate().skip(1) {
+            a += c / (x + i as f64);
+        }
+        0.5 * (2.0 * std::f64::consts::PI).ln() + (x + 0.5) * tval.ln() - tval + a.ln()
+    }
+}
+
+/// Regularized incomplete beta `I_x(a, b)` via the Lentz continued fraction
+/// (Numerical Recipes `betai`).
+fn reg_incomplete_beta(a: f64, b: f64, x: f64) -> f64 {
+    if x <= 0.0 {
+        return 0.0;
+    }
+    if x >= 1.0 {
+        return 1.0;
+    }
+    let bt = (ln_gamma(a + b) - ln_gamma(a) - ln_gamma(b)
+        + a * x.ln()
+        + b * (1.0 - x).ln())
+    .exp();
+    if x < (a + 1.0) / (a + b + 2.0) {
+        bt * betacf(a, b, x) / a
+    } else {
+        1.0 - bt * betacf(b, a, 1.0 - x) / b
+    }
+}
+
+/// Continued-fraction core of the incomplete beta (Numerical Recipes `betacf`).
+fn betacf(a: f64, b: f64, x: f64) -> f64 {
+    const EPS: f64 = 3.0e-12;
+    const FPMIN: f64 = 1.0e-300;
+    let qab = a + b;
+    let qap = a + 1.0;
+    let qam = a - 1.0;
+    let mut c = 1.0;
+    let mut d = 1.0 - qab * x / qap;
+    if d.abs() < FPMIN {
+        d = FPMIN;
+    }
+    d = 1.0 / d;
+    let mut h = d;
+    for m in 1..=200 {
+        let m = m as f64;
+        let m2 = 2.0 * m;
+        let aa = m * (b - m) * x / ((qam + m2) * (a + m2));
+        d = 1.0 + aa * d;
+        if d.abs() < FPMIN {
+            d = FPMIN;
+        }
+        c = 1.0 + aa / c;
+        if c.abs() < FPMIN {
+            c = FPMIN;
+        }
+        d = 1.0 / d;
+        h *= d * c;
+        let aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
+        d = 1.0 + aa * d;
+        if d.abs() < FPMIN {
+            d = FPMIN;
+        }
+        c = 1.0 + aa / c;
+        if c.abs() < FPMIN {
+            c = FPMIN;
+        }
+        d = 1.0 / d;
+        let del = d * c;
+        h *= del;
+        if (del - 1.0).abs() < EPS {
+            break;
+        }
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TOL: f64 = 1e-9;
+    /// Looser tolerance for p-values from approximate special functions.
+    const PTOL: f64 = 2e-3;
+
+    #[test]
+    fn quantile_linear_interpolation() {
+        // numpy.quantile([1,2,3,4], q, method='linear')
+        assert!((quantile(&[1., 2., 3., 4.], 0.5).unwrap() - 2.5).abs() < TOL);
+        assert!((quantile(&[1., 2., 3., 4.], 0.25).unwrap() - 1.75).abs() < TOL);
+        assert!((quantile(&[1., 2., 3., 4.], 0.75).unwrap() - 3.25).abs() < TOL);
+        assert!(quantile(&[1.0], 1.5).is_err());
+    }
+
+    #[test]
+    fn mad_robust_spread() {
+        // scipy.stats.median_abs_deviation([1,2,3,4,5]) = 1.0
+        assert!((mad(&[1., 2., 3., 4., 5.]).unwrap() - 1.0).abs() < TOL);
+    }
+
+    #[test]
+    fn skewness_kurtosis_match_scipy() {
+        // scipy.stats.skew([1,2,3,4,5]) = 0; .kurtosis(...) = -1.3
+        assert!(skewness(&[1., 2., 3., 4., 5.]).unwrap().abs() < TOL);
+        assert!((kurtosis(&[1., 2., 3., 4., 5.]).unwrap() + 1.3).abs() < TOL);
+        // scipy.stats.skew([0,0,0,0,5]) = 1.5 (right-skewed)
+        assert!((skewness(&[0., 0., 0., 0., 5.]).unwrap() - 1.5).abs() < TOL);
+        assert!(skewness(&[2., 2., 2.]).is_err(), "zero variance is undefined");
+    }
+
+    #[test]
+    fn zscore_population_sigma() {
+        let z = zscore(&[1., 2., 3., 4., 5.]).unwrap();
+        // mean 3, population sigma sqrt(2); endpoints ±2/sqrt(2) = ±sqrt(2)
+        assert!((z[0] + 2.0_f64.sqrt()).abs() < TOL);
+        assert!(z[2].abs() < TOL);
+        assert!((z.iter().sum::<f64>()).abs() < TOL, "z-scores sum to 0");
+    }
+
+    #[test]
+    fn entropy_and_divergences() {
+        // uniform over 4 → ln 4
+        assert!((shannon_entropy(&[1., 1., 1., 1.]).unwrap() - 4.0_f64.ln()).abs() < TOL);
+        assert!(shannon_entropy(&[1., 0., 0., 0.]).unwrap().abs() < TOL);
+        // KL([1,0] ‖ [0.5,0.5]) = ln 2
+        assert!((kl_divergence(&[1., 0.], &[0.5, 0.5]).unwrap() - 2.0_f64.ln()).abs() < TOL);
+        assert!(kl_divergence(&[0.5, 0.5], &[0.5, 0.5]).unwrap().abs() < TOL);
+        // JS of disjoint supports = ln 2 (the max)
+        assert!((js_divergence(&[1., 0.], &[0., 1.]).unwrap() - 2.0_f64.ln()).abs() < TOL);
+        assert!(js_divergence(&[1., 2., 3.], &[1., 2., 3.]).unwrap().abs() < TOL);
+        // KL diverges when q is zero where p is positive.
+        assert!(kl_divergence(&[1., 1.], &[1., 0.]).is_err());
+    }
+
+    #[test]
+    fn ks_two_sample_separates_distributions() {
+        // Identical samples → D = 0, p = 1.
+        let same = ks_two_sample(&[1., 2., 3., 4.], &[1., 2., 3., 4.]).unwrap();
+        assert!(same.statistic.abs() < TOL);
+        assert!(same.p_value > 0.99);
+        // Disjoint ranges → D = 1, tiny p.
+        let diff = ks_two_sample(&[0., 1., 2.], &[10., 11., 12.]).unwrap();
+        assert!((diff.statistic - 1.0).abs() < TOL);
+        assert!(diff.p_value < 0.2, "clearly different → small p, got {}", diff.p_value);
+    }
+
+    #[test]
+    fn mann_whitney_complete_separation() {
+        // x entirely below y → U1 = 0.
+        let r = mann_whitney_u(&[1., 2., 3.], &[4., 5., 6.]).unwrap();
+        assert!((r.statistic - 0.0).abs() < TOL, "U1 = 0, got {}", r.statistic);
+        assert!(r.p_value < 0.2, "separation → small p, got {}", r.p_value);
+    }
+
+    #[test]
+    fn welch_t_test_matches_scipy() {
+        // ttest_ind([1,2,3,4,5],[2,3,4,5,6], equal_var=False): t = -1.0, df = 8, p ≈ 0.34659
+        let r = welch_t_test(&[1., 2., 3., 4., 5.], &[2., 3., 4., 5., 6.]).unwrap();
+        assert!((r.statistic + 1.0).abs() < TOL, "t = -1.0, got {}", r.statistic);
+        assert!((r.p_value - 0.346_598).abs() < PTOL, "p ≈ 0.3466, got {}", r.p_value);
+        // Identical samples → t = 0, p = 1.
+        let same = welch_t_test(&[1., 2., 3.], &[1., 2., 3.]).unwrap();
+        assert!(same.statistic.abs() < TOL);
+        assert!((same.p_value - 1.0).abs() < PTOL);
+    }
+}

--- a/crates/ix-math/src/lib.rs
+++ b/crates/ix-math/src/lib.rs
@@ -12,6 +12,7 @@ pub mod eigen;
 pub mod error;
 pub mod geometric_space;
 pub mod hyperbolic;
+pub mod inference;
 pub mod linalg;
 pub mod plucker;
 pub mod poincare_hierarchy;

--- a/docs/adr/0004-duckdb-sql-pipeline-mesh.md
+++ b/docs/adr/0004-duckdb-sql-pipeline-mesh.md
@@ -1,0 +1,82 @@
+# DuckDB-SQL + IX UDFs is the IX pipeline-mesh correlation substrate (complementary to IXQL)
+
+Status: accepted (2026-06-21)
+
+## Context
+
+We want to **declare many IX "pipelines" and compose them into a mesh** that correlates
+real-world data scenarios (sensors, market ticks, log-rates, ecosystem telemetry) — on the
+order of 100+ pipelines — to answer "which streams move together, and which one leads?".
+
+The instinct is to reach for **IXQL** (Demerzel's governance pipeline-spec DSL). But per
+[ADR-0001](0001-ixql-duckdb-integration-via-mcp-seam.md), IXQL is **spec-only** (no executor
+ships; `ix-cli` #103 is a draft) and the grammar is a governed artifact — adding DuckDB
+source/sink nodes is forbidden until the executor lands *and* a grammar change gets
+Galactic-Protocol sign-off. So IXQL cannot run a mesh today.
+
+Meanwhile `ix-duck` (the analyst bench, `docs/DUCKDB.md`) now exposes ~80 IX algorithm UDFs,
+including the exact correlation primitives a mesh needs: `ix_pearson`, `ix_two_sample`,
+`ix_kl`/`ix_js`, `ix_connected_components`, `ix_centrality`, and the per-stream conditioners
+`ix_wavelet_denoise`/`ix_kalman_smooth`.
+
+## Decision
+
+**The pipeline-mesh correlation substrate is DuckDB SQL as the composition language with IX
+UDFs as the stages — *not* IXQL, and *not* a new execution engine.** Concretely:
+
+1. **A "pipeline" is a named DuckDB `VIEW` / table `MACRO`** over a JSON-on-disk stream,
+   composing IX UDFs. The "catalog" is a set of such macros; the "mesh" is the N×N
+   correlation across their outputs. This is pure analyst-bench analysis (read-only,
+   no source-of-truth), so it crosses **no** governed boundary — ADR-0001 stands untouched
+   (we add no IXQL grammar nodes).
+2. **The canonical mesh pipeline shape** is:
+   `N streams → ix_wavelet_denoise/ix_kalman_smooth (condition) → ix_pearson / ix_two_sample
+   (pairwise) → threshold → edge list → ix_connected_components (incident clusters) →
+   ix_centrality (lead/hub indicator)`.
+3. **A thin reusable driver** (`ix-duck::mesh`) orchestrates that shape over an arbitrary set
+   of named streams and returns a structured `MeshResult` (correlation matrix + clusters +
+   centrality ranking + lead). It also installs a small **pipeline catalog** of reusable
+   table macros (`ix_smooth`, `ix_zsmooth`) as the SQL-native declaration layer.
+
+## Why (the trade-off)
+
+- **Runnable today, zero new governed surface.** SQL views/macros + existing UDFs run on the
+  bundled-DuckDB (`duck`) feature now; IXQL would run *nothing*. The mesh is useful immediately
+  and remains forward-compatible: when the IXQL executor ships, its `mcp_tool_output(…)` /
+  `database(…)` productions can target an ix-duck mesh query as a data source (ADR-0001 path #1).
+- **SQL *is* a declarative composition language.** CTEs, views, and table macros already give
+  naming, parameterization, and composition — re-deriving that in a bespoke engine is the
+  "build the whole thing" failure mode the repo's tracer-bullet discipline warns against.
+- **The primitives already exist and are tested.** The mesh is *assembly*, not new math.
+
+## Consequences
+
+- `ix-duck::mesh` is **`duck`-feature-gated** (it runs SQL on a bundled engine), like the other
+  lenses; the default/`--workspace` build never compiles it.
+- The mesh is **advisory analysis**, never a binding gate or source of truth (`docs/DUCKDB.md`).
+  Binding verdicts still go through the governed `maintain-gate` (ADR-0002), not raw mesh SQL.
+- **Centrality choice is load-bearing.** A hub-and-spoke correlation graph is **bipartite**, on
+  which `eigenvector` centrality oscillates (power iteration does not converge) and mislabels
+  every node equal. `betweenness` (or `degree`) is the correct lead/hub lens for hub-and-spoke;
+  `eigenvector` suits *dense, mutually-correlated* clusters. The driver defaults to `betweenness`.
+- Pearson over **constant** streams is undefined → a SQL error; the driver treats such a pair as
+  uncorrelated (no edge) rather than aborting the whole mesh.
+
+## Use-case catalog (good scenarios)
+
+1. **Ecosystem regression radar** — one drift pipeline per `state/quality/*.json` metric;
+   `ix_two_sample` vs each metric's 30-day baseline; `ix_centrality` ranks which regressing
+   metric is *causally central* vs a downstream symptom.
+2. **Cross-repo correlation** — ix/tars/ga emit JSONL; the mesh joins them to test "does a tars
+   grammar-weight change correlate with a ga routing-F1 drop?".
+3. **Sensor / IoT / market correlation** — N raw streams → `ix_kalman_smooth` → pairwise
+   `ix_pearson` → `ix_connected_components` (incident clusters) → `ix_centrality` (lead indicator).
+4. **Telemetry anomaly mesh** — per-intent query streams; `ix_kdist`/`ix_dbscan` flag OOD,
+   `ix_connected_components` groups co-failing intents into incident clusters.
+5. **A/B & experiment fleet** — 100 arms as macros; `ix_two_sample` (distribution-free) gates each.
+
+## Revisit trigger
+
+When the IXQL executor (`ix-cli` #103) ships: a first-class `duckdb(…)` source could then declare
+a mesh query *inside* an IXQL pipeline (with grammar sign-off, per ADR-0001's revisit trigger).
+Until then the mesh lives entirely in ix-duck.

--- a/docs/plans/2026-06-21-001-feat-ix-math-inference-primitive-plan.md
+++ b/docs/plans/2026-06-21-001-feat-ix-math-inference-primitive-plan.md
@@ -1,0 +1,113 @@
+---
+title: ix-math::inference — the statistical-inference primitive (two-sample tests, divergences, moments)
+type: feat
+status: draft
+date: 2026-06-21
+origin: investigation "are we missing any ML/math tool in DuckDB/IX?" (2026-06-21)
+reversibility: one-way (new public ix-math surface + new ix-duck UDFs) — see "One-way door" below
+revisit-trigger: first telemetry regression-gate that needs distribution-shift detection, or any consumer importing ix_math::inference
+---
+
+# ix-math::inference — the missing statistical layer
+
+> One-page design produced from the 2026-06-21 gap analysis of the DuckDB/IX surface.
+> Of six gaps found, five are *exposure* gaps (wire an existing IX algorithm through a
+> UDF). **This is the only *algorithm* gap** — the primitive is absent from `ix-math`
+> *and* from DuckDB built-ins. It is therefore the highest-leverage piece and the one
+> that needs design before code.
+
+## Problem / why
+
+`ix-duck` is an analyst bench over **JSONL time-series telemetry** (routing, OOD, loop,
+chatbot, quality lenses). The single most-used analyst question over such data is
+*"did this metric's distribution shift versus baseline?"* — the core of any RSI /
+regression gate. Today neither side can answer it:
+
+- **`ix-math::stats`** has only `mean / variance / std_dev / median / covariance_matrix /
+  correlation_matrix / min_max`. No higher moments, no quantiles, no divergences, no tests.
+- **DuckDB built-ins** give `quantile`, `stddev`, `corr`, `regr_*` — but **no** two-sample
+  test (KS, Mann–Whitney, t-test), **no** divergence (KL, JS), **no** skew/kurtosis/MAD,
+  **no** entropy / mutual-information.
+
+So the `maintain` gate currently compares distributions with hand-rolled thresholds on
+means. That is exactly the Goodhart-prone shortcut the RSI work warned against: a mean can
+hold steady while the *distribution* degrades (variance blow-up, bimodality, tail shift).
+
+Who is in pain: the maintain-gate / RSI loop (and any future telemetry gate) — it cannot
+make a principled "distributions differ" call. What changes: a fail-closed gate can assert
+"today's `coverage_max` distribution differs from the 30-day baseline at p<0.01 (KS)" as a
+**bound, testable** verdict instead of a tuned threshold.
+
+## What we're building
+
+A new pure-Rust module `ix-math::inference` (no new deps — built on `ndarray` + the
+existing `stats` primitives), then a thin UDF layer in `ix-duck`. Two tiers:
+
+### Tier 1 — descriptive (distribution shape over one column)
+| fn | signature | notes |
+|----|-----------|-------|
+| `quantile` | `(x, q) -> f64` | linear interpolation; `q∈[0,1]` |
+| `iqr`, `mad` | `(x) -> f64` | robust spread (MAD = median abs deviation) |
+| `skewness`, `kurtosis` | `(x) -> f64` | 3rd/4th standardized moments (excess kurtosis) |
+| `zscore` | `(x) -> Array1` | `(xᵢ − mean)/std`; the normalize the bench keeps re-deriving |
+| `shannon_entropy` | `(p) -> f64` | over a normalized histogram / probability vector |
+
+### Tier 2 — inferential (two-sample: today vs baseline)
+| fn | signature | returns | notes |
+|----|-----------|---------|-------|
+| `ks_two_sample` | `(a, b) -> TestResult` | `{statistic, p_value}` | **the primary gate primitive** — distribution-free, no normality assumption |
+| `mann_whitney_u` | `(a, b) -> TestResult` | `{u, p_value}` | rank-based location shift |
+| `welch_t_test` | `(a, b) -> TestResult` | `{t, df, p_value}` | unequal-variance means |
+| `kl_divergence` | `(p, q) -> f64` | nats | over aligned histograms; asymmetric |
+| `js_divergence` | `(p, q) -> f64` | nats | symmetric, bounded — safer default than KL |
+
+`TestResult { statistic: f64, p_value: f64 }` — one small public struct.
+
+### UDF layer (`ix-duck`, after the module lands)
+- Scalars over `DOUBLE[]`: `ix_quantile(x, q)`, `ix_skewness(x)`, `ix_kurtosis(x)`,
+  `ix_mad(x)`, `ix_entropy(p)`, `ix_kl(p,q)`, `ix_js(p,q)`.
+- Table fn `ix_two_sample(a DOUBLE[], b DOUBLE[], test VARCHAR) -> (statistic, p_value)`
+  so SQL can pick KS / Mann–Whitney / Welch by name in one call.
+
+## Tracer-bullet slice (Karpathy r2 / aihero)
+
+Smallest end-to-end cut, **all layers**: `ks_two_sample` only →
+`ix_two_sample(..., 'ks')` UDF → one `maintain`-gate query that compares today's
+`coverage_max` vs the baseline window → assert a known-shifted fixture trips p<0.01 and a
+same-distribution fixture does not. Ship that, get feedback, *then* fan out the rest of the
+table. Do **not** build all 10 functions before the first SQL call works.
+
+## Instrumentation (CLAUDE.md "instrument before you ship")
+
+- **Baseline**: the current maintain-gate verdict series in
+  `state/thinking-machine/maintain-gate.jsonl`.
+- **Expected direction**: false-flip rate of the gate should *drop* (mean-threshold
+  flapping replaced by a distribution test); detection of a genuine seeded regression
+  should *fire*.
+- **Guardrail**: KS must not flag two samples drawn from the same fixture (TNR check) —
+  the asymmetric fail-closed discipline from `feedback_llm_judge_panel_failclosed`. A test
+  primitive that cries wolf is worse than none.
+
+## One-way door — sign-off required
+
+New **public `ix-math` API** (a stable-tier crate) + new public `TestResult` type. Per
+CLAUDE.md the stable-surface gate (`pub `-line hash) will trip on the added `pub fn`s →
+this needs the version-bump / beta-demote dance and operator sign-off before merge. The
+**p-value implementations** are the risk: KS/Mann–Whitney asymptotic tails and the
+t-distribution CDF must be validated against a reference (SciPy values pinned in tests),
+or the gate is "green but wrong." No LLM may stand in as the correctness oracle here —
+pin numeric fixtures.
+
+Two-way (cheap to revert): the `ix-duck` UDF names — internal-tier, no downstream contract.
+
+## Out of scope
+
+- Multiple-comparison correction, bootstrap CIs, Bayesian tests — add only if a consumer asks.
+- Replacing DuckDB's native `quantile`/`stddev`/`corr` — we *complement*, never shadow them.
+
+## Links
+
+- Gap analysis: this investigation (2026-06-21).
+- RSI guardrail discipline: `docs/solutions/**` + the maintain-gate ledger.
+- Sibling exposure-gaps (separate issues): ix-signal time-series UDFs, t-SNE/MDS projection,
+  supervised fit/predict, graph centrality.

--- a/scripts/confidence_calibrator.py
+++ b/scripts/confidence_calibrator.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+ix confidence_calibrator — the analytical (producer) half of Demerzel's
+ML-governance feedback loop, leg 3a of pipelines/ml-feedback-loop.ixql.
+
+Role split (per Demerzel CLAUDE.md "Cross-repo contracts" + policies/
+ml-governance-feedback-policy.yaml): **ix is the analytical/ML substrate.**
+Demerzel produces governance data (belief states); ix consumes it and returns
+a calibration recommendation. Demerzel (the governor) decides whether to apply
+it — that is the *separate* applier, scripts/apply_ml_feedback.py in Demerzel.
+
+This is a deliberately minimal *tracer-bullet*: it closes ONE real leg of the
+loop end-to-end on REAL data rather than simulating it. It computes an
+overconfidence signal from Demerzel's actual belief files (current vs the
+archived prior versions that prove a belief was revised), and — only if the
+signal clears the policy trigger — emits ONE schema-valid
+`ml-feedback-recommendation` into Demerzel's oversight inbox.
+
+What it reads  (Demerzel repo):
+  state/beliefs/*.belief.json            current beliefs (confidence assignments)
+  state/beliefs/archived/*.belief.json   prior versions = evidence of revision
+
+What it writes (Demerzel repo):
+  state/oversight/ml-recommendations/<message_id>.json
+      conforms to schemas/contracts/ml-feedback-recommendation.schema.json
+      (+ integrity-fields.schema.json: message_id, content_hash, ...)
+
+Overconfidence metric (real, auditable):
+  high-confidence beliefs  = every belief (current + archived) with confidence
+                             >= HIGH_CONF (0.85)
+  revised-and-overconfident = archived prior versions with confidence >= HIGH_CONF
+                             (an archived prior is, by definition, a belief that
+                              was later revised)
+  overconfidence_rate      = revised-and-overconfident / high-confidence beliefs
+
+Per pipelines/ml-feedback-loop.ixql §3a the recommendation is only emitted when
+overconfidence_rate > 0.15, and the proposed nudge is capped by policy at
++/- 0.1 per cycle (max(-0.1, -overconfidence_rate * 0.5)).
+
+NOTE on a real contract drift this script intentionally resolves in favour of
+the *schema*: ml-feedback-loop.ixql §3a filters `recommendation_type ==
+"calibration_report"`, but the validated schema enum has no such value — it is
+`recommendation_type: "threshold_adjustment"` with `pipeline_id:
+"confidence_calibrator"`. A schema-valid document therefore never matches the
+pipeline's filter. We emit the schema-valid shape and flag the drift on stderr.
+
+Usage:
+  python scripts/confidence_calibrator.py                 # auto-find ../Demerzel
+  python scripts/confidence_calibrator.py --demerzel-root /path/to/Demerzel
+  python scripts/confidence_calibrator.py --dry-run       # print, do not write
+
+Exit codes:
+  0  recommendation emitted (or, with --dry-run, would be emitted)
+  1  usage / IO error
+  4  no recommendation warranted (overconfidence_rate <= trigger) — loop is a no-op
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+HIGH_CONF = 0.85          # threshold for "high-confidence belief"
+TRIGGER = 0.15            # ml-feedback-loop.ixql §3a: emit only if rate > 0.15
+NUDGE_CAP = 0.10          # policy guardrail: +/- 0.1 per cycle
+MODEL_VERSION = "confidence-calibrator-tracer-0.1.0"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _load_beliefs(folder: Path) -> list[dict]:
+    out = []
+    if not folder.is_dir():
+        return out
+    for p in sorted(folder.glob("*.belief.json")):
+        try:
+            with p.open(encoding="utf-8") as fh:
+                data = json.load(fh)
+            data["__file"] = str(p)
+            out.append(data)
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"  warn: skipping unreadable belief {p}: {exc}", file=sys.stderr)
+    return out
+
+
+def compute_calibration(demerzel_root: Path) -> dict:
+    beliefs_dir = demerzel_root / "state" / "beliefs"
+    current = _load_beliefs(beliefs_dir)
+    archived = _load_beliefs(beliefs_dir / "archived")  # prior, revised versions
+
+    all_beliefs = current + archived
+    high_conf = [b for b in all_beliefs if isinstance(b.get("confidence"), (int, float))
+                 and b["confidence"] >= HIGH_CONF]
+    # An archived prior version IS a belief that was revised.
+    revised_overconfident = [b for b in archived
+                             if isinstance(b.get("confidence"), (int, float))
+                             and b["confidence"] >= HIGH_CONF]
+
+    rate = (len(revised_overconfident) / len(high_conf)) if high_conf else 0.0
+    return {
+        "data_points": len(all_beliefs),
+        "current_count": len(current),
+        "archived_count": len(archived),
+        "high_conf_count": len(high_conf),
+        "revised_overconfident_count": len(revised_overconfident),
+        "overconfidence_rate": round(rate, 4),
+        "worst_examples": [Path(b["__file"]).name for b in revised_overconfident][:5],
+    }
+
+
+def build_recommendation(calib: dict) -> dict:
+    rate = calib["overconfidence_rate"]
+    # ml-feedback-loop.ixql §3a formula, clamped to the policy guardrail.
+    nudge = max(-NUDGE_CAP, round(-rate * 0.5, 4))
+
+    # Producer confidence: the *direction* (reduce threshold) is well supported
+    # even at small N, and the magnitude is hard-capped at +/-0.1, so confidence
+    # is bounded but meaningful. Grows modestly with data points.
+    confidence = round(min(0.92, 0.70 + 0.02 * calib["data_points"]), 3)
+
+    payload = {
+        "pipeline_id": "confidence_calibrator",
+        "recommendation_type": "threshold_adjustment",
+        "recommendation": {
+            "action": "Nudge the global confidence-calibration threshold by "
+                      f"{nudge} (reduce, to counter detected overconfidence).",
+            "rationale": (
+                f"{calib['revised_overconfident_count']} of {calib['high_conf_count']} "
+                f"high-confidence beliefs (>= {HIGH_CONF}) were later revised "
+                f"(overconfidence_rate={rate}). Revisions evidenced by archived prior "
+                f"versions: {', '.join(calib['worst_examples']) or 'none'}. Nudge magnitude "
+                f"capped at +/-{NUDGE_CAP}/cycle per ml-governance-feedback-policy."
+            ),
+            "expected_impact": (
+                "Future high-confidence assignments require marginally stronger evidence, "
+                "reducing the overconfidence-then-revision pattern over subsequent cycles."
+            ),
+            "parameters": {
+                "threshold_nudge": nudge,
+                "target": "state/beliefs/confidence-calibration.belief.json",
+                "cap": NUDGE_CAP,
+            },
+        },
+        "confidence": confidence,
+        "evidence": {
+            "data_points": calib["data_points"],
+            "model_version": MODEL_VERSION,
+            "training_window": "all on-disk belief states (current + archived)",
+            "key_features": [
+                "belief.confidence", "archived prior version (revision marker)",
+                f"high_conf_count={calib['high_conf_count']}",
+                f"revised_overconfident_count={calib['revised_overconfident_count']}",
+            ],
+        },
+        "constitutional_check": {
+            "passed": True,
+            "articles_checked": [
+                "Article 3 - Reversibility",
+                "Article 7 - Auditability",
+                "Article 9 - Bounded Autonomy",
+            ],
+            "concerns": [],
+        },
+        "timestamp": _now_iso(),
+    }
+    return payload
+
+
+def _attach_integrity(payload: dict) -> dict:
+    """Add Galactic-Protocol integrity fields. content_hash is the sha256 of the
+    payload BEFORE integrity fields are added (per integrity-fields.schema.json)."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    content_hash = hashlib.sha256(canonical).hexdigest()
+    doc = dict(payload)
+    doc.update({
+        "message_id": str(uuid.uuid4()),
+        "origin_repo": "ix",
+        "origin_agent": "ix-confidence-calibrator",
+        "content_hash": content_hash,
+        "hash_algorithm": "sha256",
+        # integrity 'timestamp' mirrors payload timestamp (same generation moment)
+        "timestamp": payload["timestamp"],
+    })
+    return doc
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="ix confidence_calibrator (producer)")
+    here = Path(__file__).resolve()
+    default_demerzel = here.parents[2] / "Demerzel"  # repos/ix/scripts/x.py -> repos/Demerzel
+    ap.add_argument("--demerzel-root", type=Path, default=default_demerzel)
+    ap.add_argument("--dry-run", action="store_true", help="print, do not write")
+    args = ap.parse_args(argv)
+
+    root = args.demerzel_root.resolve()
+    if not (root / "state" / "beliefs").is_dir():
+        print(f"error: no state/beliefs under {root}", file=sys.stderr)
+        return 1
+
+    calib = compute_calibration(root)
+    print(f"calibration: {json.dumps(calib, indent=2)}", file=sys.stderr)
+
+    if calib["overconfidence_rate"] <= TRIGGER:
+        print(f"overconfidence_rate {calib['overconfidence_rate']} <= trigger {TRIGGER} "
+              "-> no recommendation warranted (loop no-op).", file=sys.stderr)
+        return 4
+
+    print("note: pipeline §3a filters recommendation_type=='calibration_report' but the "
+          "schema enum is 'threshold_adjustment'; emitting the schema-valid shape.",
+          file=sys.stderr)
+
+    doc = _attach_integrity(build_recommendation(calib))
+    out = root / "state" / "oversight" / "ml-recommendations" / f"{doc['message_id']}.json"
+
+    if args.dry_run:
+        print(json.dumps(doc, indent=2))
+        print(f"\n[dry-run] would write -> {out}", file=sys.stderr)
+        return 0
+
+    try:
+        _atomic_write(out, doc)
+    except OSError as exc:
+        print(f"error: could not write recommendation: {exc}", file=sys.stderr)
+        return 1
+    print(f"wrote recommendation -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/staleness_predictor.py
+++ b/scripts/staleness_predictor.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+ix staleness_predictor — analytical (producer) half of leg 3b of Demerzel's
+ML-governance feedback loop (pipelines/ml-feedback-loop.ixql §3b).
+
+Second green leg of the loop, sibling to scripts/confidence_calibrator.py. Same
+role split: ix is the analytical substrate; it reads Demerzel's belief states,
+predicts which are about to go stale, and — only when at least one belief is at
+risk — emits ONE schema-valid `proactive_recon` recommendation into Demerzel's
+oversight inbox. The Demerzel governor (scripts/apply_ml_feedback.py) gates it
+and schedules the recons.
+
+Staleness model (real, measured — not inferred):
+  age_days       = now - belief.last_updated
+  STALE_DAYS     = 7   (framework staleness threshold)
+  HORIZON_DAYS   = 3   (policy: "predicted to become stale within 3 days")
+  at_risk        = age_days >= STALE_DAYS - HORIZON_DAYS  (i.e. >= 4 days old:
+                   within the horizon of, or already past, the 7-day threshold)
+  staleness_velocity = age_days / STALE_DAYS  (threshold-multiples overdue;
+                       higher = more urgent)
+
+Per policy guardrail and ml-feedback-loop.ixql §3b (`head(3)`), at most 3
+proactive recons are proposed per cycle — the top 3 by staleness_velocity.
+
+What it reads  (Demerzel repo):  state/beliefs/*.belief.json  (current only;
+  archived versions are superseded, so staleness of *live* beliefs is the signal)
+What it writes (Demerzel repo):  state/oversight/ml-recommendations/<message_id>.json
+  conforms to schemas/contracts/ml-feedback-recommendation.schema.json
+
+Usage:
+  python scripts/staleness_predictor.py                 # auto-find ../Demerzel
+  python scripts/staleness_predictor.py --demerzel-root /path/to/Demerzel
+  python scripts/staleness_predictor.py --dry-run
+
+Exit codes:
+  0  recommendation emitted (or, with --dry-run, would be)
+  1  usage / IO error
+  4  no recommendation warranted (no at-risk beliefs) — loop no-op
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+STALE_DAYS = 7
+HORIZON_DAYS = 3
+AT_RISK_AGE = STALE_DAYS - HORIZON_DAYS   # >= 4 days old = at risk
+MAX_RECONS = 3                            # policy guardrail / §3b head(3)
+MODEL_VERSION = "staleness-predictor-tracer-0.1.0"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_ts(value: str) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def compute_staleness(demerzel_root: Path) -> dict:
+    beliefs_dir = demerzel_root / "state" / "beliefs"
+    now = _now()
+    assessed, at_risk = 0, []
+    if beliefs_dir.is_dir():
+        for p in sorted(beliefs_dir.glob("*.belief.json")):
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            ts = _parse_ts(data.get("last_updated", ""))
+            if ts is None:
+                continue                      # can't assess without a timestamp
+            assessed += 1
+            age_days = (now - ts).total_seconds() / 86400.0
+            if age_days >= AT_RISK_AGE:
+                at_risk.append({
+                    "belief": p.name,
+                    "proposition": (data.get("proposition") or "")[:120],
+                    "age_days": round(age_days, 1),
+                    "staleness_velocity": round(age_days / STALE_DAYS, 3),
+                    "already_stale": age_days >= STALE_DAYS,
+                })
+    at_risk.sort(key=lambda r: r["staleness_velocity"], reverse=True)
+    return {"assessed": assessed, "at_risk_count": len(at_risk),
+            "targets": at_risk[:MAX_RECONS]}
+
+
+def build_recommendation(st: dict) -> dict:
+    targets = st["targets"]
+    names = ", ".join(t["belief"] for t in targets)
+    confidence = round(min(0.95, 0.80 + 0.02 * st["assessed"]), 3)  # measured -> confident
+    payload = {
+        "pipeline_id": "staleness_predictor",
+        "recommendation_type": "proactive_recon",
+        "recommendation": {
+            "action": f"Schedule proactive reconnaissance for {len(targets)} at-risk "
+                      f"belief(s) (top {MAX_RECONS} by staleness velocity).",
+            "rationale": (
+                f"{st['at_risk_count']} of {st['assessed']} timestamped beliefs are within "
+                f"{HORIZON_DAYS}d of (or past) the {STALE_DAYS}d staleness threshold. "
+                f"Most overdue: {names}. Capped at {MAX_RECONS} recons/cycle per "
+                f"ml-governance-feedback-policy."
+            ),
+            "expected_impact": (
+                "Stale beliefs are refreshed before they silently misinform governance "
+                "decisions; reduces the count of beliefs acting on expired evidence."
+            ),
+            "parameters": {
+                "recon_targets": [t["belief"] for t in targets],
+                "target_detail": targets,
+                "max_per_day": MAX_RECONS,
+            },
+        },
+        "confidence": confidence,
+        "evidence": {
+            "data_points": st["assessed"],
+            "model_version": MODEL_VERSION,
+            "training_window": "current belief states, last_updated timestamps",
+            "key_features": ["belief.last_updated", "age_days", "staleness_velocity",
+                             f"at_risk_count={st['at_risk_count']}"],
+        },
+        "constitutional_check": {
+            "passed": True,
+            "articles_checked": [
+                "Article 7 - Auditability",
+                "Article 8 - Observability",
+                "Article 9 - Bounded Autonomy",
+            ],
+            "concerns": [],
+        },
+        "timestamp": _now_iso(),
+    }
+    return payload
+
+
+def _attach_integrity(payload: dict) -> dict:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    doc = dict(payload)
+    doc.update({
+        "message_id": str(uuid.uuid4()),
+        "origin_repo": "ix",
+        "origin_agent": "ix-staleness-predictor",
+        "content_hash": hashlib.sha256(canonical).hexdigest(),
+        "hash_algorithm": "sha256",
+        "timestamp": payload["timestamp"],
+    })
+    return doc
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, path)
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="ix staleness_predictor (producer)")
+    here = Path(__file__).resolve()
+    ap.add_argument("--demerzel-root", type=Path, default=here.parents[2] / "Demerzel")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    root = args.demerzel_root.resolve()
+    if not (root / "state" / "beliefs").is_dir():
+        print(f"error: no state/beliefs under {root}", file=sys.stderr)
+        return 1
+
+    st = compute_staleness(root)
+    print(f"staleness: assessed={st['assessed']} at_risk={st['at_risk_count']} "
+          f"targets={[t['belief'] for t in st['targets']]}", file=sys.stderr)
+
+    if st["at_risk_count"] == 0:
+        print("no at-risk beliefs -> no recommendation (loop no-op).", file=sys.stderr)
+        return 4
+
+    doc = _attach_integrity(build_recommendation(st))
+    out = root / "state" / "oversight" / "ml-recommendations" / f"{doc['message_id']}.json"
+
+    if args.dry_run:
+        print(json.dumps(doc, indent=2))
+        print(f"\n[dry-run] would write -> {out}", file=sys.stderr)
+        return 0
+    try:
+        _atomic_write(out, doc)
+    except OSError as exc:
+        print(f"error: could not write recommendation: {exc}", file=sys.stderr)
+        return 1
+    print(f"wrote recommendation -> {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
**DRAFT — depends on #164, #165, #166. Merge those first, then rebase/merge this; it will collapse to just the mesh + ADR-0004 delta.**

Answers "can we declare + compose IX pipelines in DuckDB to correlate real-world data?" — yes, with DuckDB SQL as the composition language and IX UDFs as stages (no IXQL grammar change; stays inside the analyst-bench role per ADR-0001).

- **ADR-0004** (`docs/adr/0004-duckdb-sql-pipeline-mesh.md`): DuckDB SQL + IX UDFs is THE pipeline-mesh correlation substrate, complementary to IXQL. Canonical shape + bipartite-centrality caveat + use-case catalog. CONTEXT.md gains the **pipeline mesh** term.
- **ix-math::inference::pearson** + **ix_pearson** UDF (SciPy-pinned) — the mesh's pairwise primitive.
- **ix_duck::mesh** — `correlate(conn, streams, MeshConfig) -> MeshResult` runs `ix_wavelet_denoise → ix_pearson → ix_connected_components → ix_centrality` and returns correlation matrix + clusters + centrality ranking + lead. `install_pipeline_catalog()` registers reusable table macros (the SQL-native "declare a pipeline" layer).
- **examples/ix_mesh_correlate.rs** — runnable; verifiable hub-and-spoke fixture (cluster {H,P,Q,R}, D1/D2 isolated, lead = H). `cargo run -p ix-duck --example ix_mesh_correlate --features duck`.

**Finding baked in:** eigenvector centrality oscillates on a bipartite hub-and-spoke → betweenness/degree are the correct hub lens (documented in ADR + module).

**Note for the author:** this branch was cut from `main` after two concurrent ml-feedback commits (`confidence_calibrator`, `staleness_predictor`, authored by @Stephane during the same session) landed there; they ride along here. They should land via their own path — this draft is the mesh+ADR work only.

**Verification:** 158 ix-duck tests green (incl. 3 mesh + 1 pearson); clippy clean on `ix-math --all-targets` and `ix-duck --features duck --all-targets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)