### PR TITLE
docs: reference AI-coding dictionary in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,10 @@ Canonical defaults (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-f
 ### Domain docs
 
 Single-context: `CONTEXT.md` + `docs/adr/` at the repo root (`/grill-with-docs` grows them lazily). See `docs/agents/domain.md`.
+
+## AI-coding vocabulary (shared ecosystem reference)
+
+<https://github.com/mattpocock/dictionary-of-ai-coding> — the plain-English
+glossary behind the aihero methodology adopted across the GuitarAlchemist
+ecosystem (smart-zone, tracer-bullets, context windows, handoffs, failure
+modes). Referenced, not vendored, so it tracks upstream.


### PR DESCRIPTION
Adds a one-line reference to [mattpocock/dictionary-of-ai-coding](https://github.com/mattpocock/dictionary-of-ai-coding) in `CLAUDE.md` — the plain-English glossary behind the aihero methodology this repo already adopted. Referenced, not vendored, so it tracks upstream with no license/maintenance burden. Part of the 5-core-repo rollout (ga merged first; this repo's hand-maintained AGENTS.md has no sync script and is left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)