### PR TITLE
feat(ix-duck): ADR-0004 pipeline-mesh substrate + ix_pearson (replaces #167)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,25 @@ contracts (see `docs/contracts/`), not runtime coupling.
 - **Lens** — a read-only analyst module on the bench (`ix_duck::{chatbot, routing,
   loops, ood, maintain}`) that turns a GA artifact set into a queryable signal. A lens
   owns *analytics*, not ingest.
+- **Topological fingerprint** — the *static* per-instrument Betti numbers (β₀ = connected
+  components, β₁ = loops) of an embedding sample at a fixed filtration radius, computed daily
+  by `ix-embedding-diagnostics` (via `ix_topo::pointcloud::betti_at_radius`) and retained in
+  `state/quality-snapshots/embeddings/*.json`. Answers *"what shape does the embedding space
+  have today?"* — one snapshot, no time axis.
+- **Topological drift** — the *change* in an embedding space's shape between two points in time,
+  measured as the `bottleneck_distance` / `wasserstein_distance` between their persistence
+  diagrams (both in `ix-topo`, neither yet called by the diagnostic). Distinct from a
+  **topological fingerprint** (static) and from **distributional drift** (the OOD lens /
+  `ix_two_sample`, which sees a moment/quantile shift but not a shape change — a hole closing or
+  clusters merging). An unproven signal: whether β₀-drift carries information the existing
+  `leak_detection` metric misses is a measure-first question against the retained β₀ history.
+- **Pipeline mesh** (`ix_duck::mesh`) — composing **N IX "pipelines"** (each a named
+  SQL view/macro over a stream, built from IX UDFs) and correlating their outputs N×N
+  to find which streams move together (clusters) and which one leads (centrality). The
+  canonical shape is `condition → ix_pearson → ix_connected_components → ix_centrality`.
+  DuckDB SQL is the composition language, **not** IXQL (which is spec-only and stays
+  complementary — see `docs/adr/0004-duckdb-sql-pipeline-mesh.md` + ADR-0001). Advisory
+  analysis only; betweenness/degree (not eigenvector) is the hub lens on bipartite meshes.
 - **Artifact source** (`ix_duck::source`) — the deep module a **lens** reads through:
   given a file selector + a flat **column spec**, it materializes a GA-emitted JSON
   artifact set into a bench table, owning file selection, the `read_json_auto` flags,

--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -92,5 +92,9 @@ required-features = ["duck"]
 name = "ix_grothendieck_lens"
 required-features = ["duck"]
 
+[[example]]
+name = "ix_mesh_correlate"
+required-features = ["duck"]
+
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/ix-duck/examples/ix_mesh_correlate.rs
+++ b/crates/ix-duck/examples/ix_mesh_correlate.rs
@@ -1,0 +1,100 @@
+//! `ix_mesh_correlate` — a runnable demo of the **pipeline mesh** correlation
+//! substrate (ADR-0004): N real-world-style streams composed on the DuckDB analyst
+//! bench with IX UDFs as stages, via the reusable [`ix_duck::mesh`] driver:
+//!
+//! ```text
+//!   N streams ─▶ ix_wavelet_denoise (condition) ─▶ ix_pearson (N×N correlation)
+//!             ─▶ threshold ─▶ ix_connected_components (incident clusters)
+//!             ─▶ ix_centrality betweenness (lead / hub indicator)
+//! ```
+//!
+//! Run: `cargo run -p ix-duck --example ix_mesh_correlate --features duck`
+//!
+//! The synthetic streams have a KNOWN hub-and-spoke structure so the result is
+//! verifiable: P, Q, R are orthogonal (distinct-frequency) signals; H = mean(P,Q,R)
+//! is a latent hub correlated with each spoke (but the spokes are mutually
+//! uncorrelated); D1, D2 are independent distractors. Expected mesh outcome:
+//! **cluster {H,P,Q,R}**, D1/D2 isolated, **H the lead** (betweenness).
+
+use ix_duck::mesh::{correlate, MeshConfig};
+use ix_duck::open_bench;
+
+const N: usize = 64; // samples per stream (power of two → clean wavelet levels)
+
+/// Deterministic ±0.05 pseudo-noise, so the demo is reproducible without an RNG.
+fn noise(t: usize, seed: u64) -> f64 {
+    let mut x = (t as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    x ^= x >> 33;
+    (x as f64 / u64::MAX as f64 - 0.5) * 0.1
+}
+
+/// A pure tone of integer frequency `f` over the window, plus a little noise.
+fn tone(f: f64, seed: u64) -> Vec<f64> {
+    (0..N)
+        .map(|t| (2.0 * std::f64::consts::PI * f * t as f64 / N as f64).sin() + noise(t, seed))
+        .collect()
+}
+
+fn main() -> ix_duck::Result<()> {
+    let conn = open_bench()?;
+
+    // Build the streams (the "real-world data scenarios").
+    let p = tone(1.0, 11);
+    let q = tone(2.0, 22);
+    let r = tone(3.0, 33);
+    let h: Vec<f64> = (0..N).map(|t| (p[t] + q[t] + r[t]) / 3.0 + noise(t, 99)).collect();
+    let streams = vec![
+        ("H".to_string(), h),
+        ("P".to_string(), p),
+        ("Q".to_string(), q),
+        ("R".to_string(), r),
+        ("D1".to_string(), tone(5.0, 44)),
+        ("D2".to_string(), tone(6.0, 55)),
+    ];
+
+    let cfg = MeshConfig::default();
+    println!(
+        "ix pipeline mesh — {} streams × {N} samples, |r| threshold τ = {}, lead lens = {:?}\n",
+        streams.len(),
+        cfg.threshold,
+        cfg.centrality
+    );
+
+    let mesh = correlate(&conn, &streams, &cfg)?;
+
+    // Correlation matrix.
+    print!("ix_pearson correlation matrix\n     ");
+    for n in &mesh.names {
+        print!("{n:>6}");
+    }
+    println!();
+    for (i, name) in mesh.names.iter().enumerate() {
+        print!("{name:>4} ");
+        for j in 0..mesh.names.len() {
+            print!("{:>6.2}", mesh.correlation[i][j]);
+        }
+        println!();
+    }
+
+    // Clusters.
+    println!("\nix_connected_components → {} incident clusters:", mesh.clusters.len());
+    for (c, members) in mesh.clusters.iter().enumerate() {
+        let labels: Vec<&str> = members.iter().map(|&i| mesh.names[i].as_str()).collect();
+        println!("   cluster {c}: {{ {} }}", labels.join(", "));
+    }
+
+    // Lead indicator.
+    println!("\nix_centrality ({:?}) — lead indicator ranking:", cfg.centrality);
+    for &(i, score) in &mesh.centrality {
+        println!("   {:>3}: {score:.3}", mesh.names[i]);
+    }
+
+    println!(
+        "\n▶ mesh verdict: {{H,P,Q,R}} correlated; D1/D2 independent; lead (hub) = {}",
+        mesh.lead_name().unwrap_or("?")
+    );
+    Ok(())
+}

--- a/crates/ix-duck/src/inference.rs
+++ b/crates/ix-duck/src/inference.rs
@@ -10,6 +10,7 @@
 //! | `ix_quantile(x, q)` | the `q`-quantile (numpy linear) |
 //! | `ix_entropy(p)` | Shannon entropy in nats |
 //! | `ix_kl(p, q)` / `ix_js(p, q)` | KL / Jensen–Shannon divergence |
+//! | `ix_pearson(a, b)` | Pearson correlation in [−1, 1] (the mesh's pairwise primitive) |
 //!
 //! And the regression-gate primitive, a table function over two JSON samples:
 //! `ix_two_sample(a_json, b_json, kind)` → `TABLE(statistic, p_value)`, `kind` ∈
@@ -29,7 +30,7 @@ use duckdb::Connection;
 use ix_math::error::MathError;
 use ix_math::inference::{
     iqr as _iqr, js_divergence, kl_divergence, ks_two_sample, kurtosis, mad, mann_whitney_u,
-    quantile, shannon_entropy, skewness, welch_t_test, TestResult,
+    pearson, quantile, shannon_entropy, skewness, welch_t_test, TestResult,
 };
 
 use crate::udf::{null_mask, read_list_col};
@@ -208,6 +209,20 @@ impl VScalar for IxJs {
     }
 }
 
+/// `ix_pearson(a DOUBLE[], b DOUBLE[]) -> DOUBLE` — Pearson correlation in [−1, 1].
+/// The pairwise primitive for a correlation mesh over many streams.
+struct IxPearson;
+impl VScalar for IxPearson {
+    type State = ();
+    // @ai:invariant ix_pearson wraps ix_math::inference::pearson; perfectly correlated -> 1, anti-correlated -> -1, a constant or length-mismatched arg -> SQL error [T:test conf:0.85 src:ix_duck::inference::tests::pearson_scalar]
+    unsafe fn invoke(_: &(), input: &mut DataChunkHandle, output: &mut dyn WritableVector) -> Res {
+        invoke_binary(input, output, "ix_pearson", pearson)
+    }
+    fn signatures() -> Vec<ScalarFunctionSignature> {
+        binary_sig()
+    }
+}
+
 // ── ix_two_sample (table fn: one row of statistic + p_value) ────────────────────
 
 #[repr(C)]
@@ -294,6 +309,7 @@ pub(crate) fn register(conn: &Connection) -> duckdb::Result<()> {
     conn.register_scalar_function::<IxQuantile>("ix_quantile")?;
     conn.register_scalar_function::<IxKl>("ix_kl")?;
     conn.register_scalar_function::<IxJs>("ix_js")?;
+    conn.register_scalar_function::<IxPearson>("ix_pearson")?;
     conn.register_table_function::<IxTwoSample>("ix_two_sample")?;
     Ok(())
 }
@@ -375,6 +391,28 @@ mod tests {
             .query_row("SELECT ix_js([1.0,2.0,3.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])", [], |r| r.get(0))
             .unwrap();
         assert!(js.abs() < 1e-9, "JS of equal distributions = 0, got {js}");
+    }
+
+    #[test]
+    fn pearson_scalar() {
+        let conn = open_bench().unwrap();
+        let r: f64 = conn
+            .query_row(
+                "SELECT ix_pearson([1.0,2.0,3.0,4.0]::DOUBLE[], [2.0,4.0,6.0,8.0]::DOUBLE[])",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!((r - 1.0).abs() < 1e-9, "perfectly correlated → 1, got {r}");
+        assert!(
+            conn.query_row(
+                "SELECT ix_pearson([1.0,1.0,1.0]::DOUBLE[], [1.0,2.0,3.0]::DOUBLE[])",
+                [],
+                |row| row.get::<_, f64>(0)
+            )
+            .is_err(),
+            "constant arg must be a SQL error"
+        );
     }
 
     #[test]

--- a/crates/ix-duck/src/lib.rs
+++ b/crates/ix-duck/src/lib.rs
@@ -113,6 +113,12 @@ pub mod ood;
 #[cfg(feature = "duck")]
 pub mod maintain;
 
+/// Pipeline mesh — compose N IX pipelines over many streams and correlate them
+/// (smooth → ix_pearson → ix_connected_components → ix_centrality). The substrate
+/// decided in `docs/adr/0004-duckdb-sql-pipeline-mesh.md`.
+#[cfg(feature = "duck")]
+pub mod mesh;
+
 #[cfg(feature = "duck")]
 pub use duckdb::{Connection, Result};
 

--- a/crates/ix-duck/src/mesh.rs
+++ b/crates/ix-duck/src/mesh.rs
@@ -1,0 +1,302 @@
+//! Pipeline mesh — compose N IX "pipelines" over many streams and correlate them
+//! on the DuckDB analyst bench. The substrate decided in
+//! [ADR-0004](../../docs/adr/0004-duckdb-sql-pipeline-mesh.md).
+//!
+//! A *pipeline* is a named SQL view/macro over a JSON-on-disk stream composing IX
+//! UDFs; the *mesh* is the N×N correlation across their outputs. [`correlate`] runs
+//! the canonical shape end-to-end:
+//!
+//! ```text
+//!   N streams → ix_wavelet_denoise (condition) → ix_pearson (pairwise)
+//!             → threshold → ix_connected_components (clusters)
+//!             → ix_centrality (lead / hub indicator)
+//! ```
+//!
+//! and returns a structured [`MeshResult`]. [`install_pipeline_catalog`] registers
+//! a few reusable table macros as the SQL-native declaration layer.
+//!
+//! Advisory analysis only — never a binding gate or source of truth (`docs/DUCKDB.md`).
+
+use std::collections::BTreeMap;
+
+use duckdb::Connection;
+
+/// Which `ix_centrality` measure ranks the mesh's lead/hub stream.
+///
+/// **Note:** on a hub-and-spoke (near-*bipartite*) correlation graph,
+/// [`Eigenvector`](CentralityKind::Eigenvector) is the wrong hub lens — it favours dense
+/// mutually-correlated clusters over a structural hub whose spokes don't correlate with
+/// each other. ([`ix-graph`'s power iteration no longer *diverges* on bipartite graphs as
+/// of #165 (the `A + I` self-loop shift) — it just doesn't rank the hub.]) Use
+/// [`Betweenness`](CentralityKind::Betweenness) (the default) or
+/// [`Degree`](CentralityKind::Degree) for hub-and-spoke; eigenvector suits dense,
+/// mutually-correlated clusters. See ADR-0004.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CentralityKind {
+    Degree,
+    Closeness,
+    Eigenvector,
+    Betweenness,
+}
+
+impl CentralityKind {
+    fn as_sql(self) -> &'static str {
+        match self {
+            CentralityKind::Degree => "degree",
+            CentralityKind::Closeness => "closeness",
+            CentralityKind::Eigenvector => "eigenvector",
+            CentralityKind::Betweenness => "betweenness",
+        }
+    }
+}
+
+/// How a mesh is built: smoothing, the correlation-edge threshold, and the
+/// lead-indicator centrality.
+#[derive(Debug, Clone, Copy)]
+pub struct MeshConfig {
+    /// `|r|` threshold above which two streams get a correlation edge.
+    pub threshold: f64,
+    /// Optional per-stream wavelet smoothing `(levels, threshold)`; `None` = raw.
+    pub smooth: Option<(i64, f64)>,
+    /// Centrality measure used to pick the lead/hub stream.
+    pub centrality: CentralityKind,
+}
+
+impl Default for MeshConfig {
+    fn default() -> Self {
+        // Betweenness is the robust hub lens (bipartite-safe); 0.4 separates
+        // orthogonal pairs (≈0) from a shared latent driver (≈0.58). See ADR-0004.
+        Self {
+            threshold: 0.4,
+            smooth: Some((2, 0.05)),
+            centrality: CentralityKind::Betweenness,
+        }
+    }
+}
+
+/// The correlated structure of a stream mesh.
+#[derive(Debug, Clone)]
+pub struct MeshResult {
+    /// Stream names, indexed as everything else is.
+    pub names: Vec<String>,
+    /// `correlation[i][j]` = Pearson r between streams i and j (1.0 on the diagonal;
+    /// 0.0 for pairs where r is undefined, e.g. a constant stream).
+    pub correlation: Vec<Vec<f64>>,
+    /// Incident clusters (weakly-connected components of the `|r| ≥ threshold` graph),
+    /// each a sorted list of stream indices.
+    pub clusters: Vec<Vec<usize>>,
+    /// `(stream index, centrality score)` sorted by score descending.
+    pub centrality: Vec<(usize, f64)>,
+    /// The lead/hub stream index (highest centrality), or `None` for an empty mesh.
+    pub lead: Option<usize>,
+}
+
+impl MeshResult {
+    /// The name of the lead/hub stream, if any.
+    pub fn lead_name(&self) -> Option<&str> {
+        self.lead.map(|i| self.names[i].as_str())
+    }
+}
+
+fn arr(v: &[f64]) -> String {
+    let body: Vec<String> = v.iter().map(|x| format!("{x:.6}")).collect();
+    format!("[{}]", body.join(","))
+}
+
+/// Run the canonical correlation mesh over `streams` (each `(name, series)`).
+///
+/// Returns the correlation matrix, incident clusters, centrality ranking, and the
+/// lead stream. Streams shorter than 2 samples, or whose Pearson pair is undefined
+/// (a constant stream), simply yield no edge rather than aborting.
+// @ai:invariant mesh::correlate composes ix_wavelet_denoise → ix_pearson → ix_connected_components → ix_centrality; a hub-and-spoke input (one stream correlated with several mutually-uncorrelated others) yields one cluster containing all of them and ranks the hub highest under betweenness [T:test conf:0.85 src:ix_duck::mesh::tests::hub_and_spoke_mesh]
+pub fn correlate(
+    conn: &Connection,
+    streams: &[(String, Vec<f64>)],
+    cfg: &MeshConfig,
+) -> duckdb::Result<MeshResult> {
+    let n = streams.len();
+    let names: Vec<String> = streams.iter().map(|(name, _)| name.clone()).collect();
+
+    // 1. Condition each stream (optional wavelet smoothing).
+    let mut series: Vec<Vec<f64>> = Vec::with_capacity(n);
+    for (_, raw) in streams {
+        if let Some((levels, threshold)) = cfg.smooth {
+            let sql = format!(
+                "SELECT value FROM ix_wavelet_denoise('{}', {levels}, {threshold}) ORDER BY i",
+                arr(raw)
+            );
+            let mut stmt = conn.prepare(&sql)?;
+            let rows = stmt.query_map([], |row| row.get::<_, f64>(0))?;
+            series.push(rows.collect::<Result<Vec<f64>, _>>()?);
+        } else {
+            series.push(raw.clone());
+        }
+    }
+
+    // 2. Pairwise Pearson correlation matrix (upper triangle, mirrored).
+    let mut correlation = vec![vec![0.0f64; n]; n];
+    let mut edges: Vec<(usize, usize)> = Vec::new();
+    for i in 0..n {
+        correlation[i][i] = 1.0;
+        for j in (i + 1)..n {
+            // A constant stream makes Pearson undefined → SQL error → treat as r = 0
+            // (no edge) so one degenerate stream can't sink the whole mesh.
+            let rij: f64 = conn
+                .query_row(
+                    &format!(
+                        "SELECT ix_pearson({}::DOUBLE[], {}::DOUBLE[])",
+                        arr(&series[i]),
+                        arr(&series[j])
+                    ),
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap_or(0.0);
+            correlation[i][j] = rij;
+            correlation[j][i] = rij;
+            if rij.abs() >= cfg.threshold {
+                edges.push((i, j));
+            }
+        }
+    }
+
+    // 3. Edge list (self-loops keep every stream a node even with no strong edge).
+    let mut edge_json: Vec<String> = (0..n).map(|i| format!("[{i},{i}]")).collect();
+    edge_json.extend(edges.iter().map(|(i, j)| format!("[{i},{j}]")));
+    let edge_list = format!("[{}]", edge_json.join(","));
+
+    // 4. Incident clusters via ix_connected_components.
+    let mut by_comp: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    if n > 0 {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, component FROM ix_connected_components('{edge_list}') ORDER BY node"
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)))?;
+        for row in rows {
+            let (node, comp) = row?;
+            by_comp.entry(comp).or_default().push(node as usize);
+        }
+    }
+    let clusters: Vec<Vec<usize>> = by_comp.into_values().collect();
+
+    // 5. Lead/hub via ix_centrality.
+    let mut centrality: Vec<(usize, f64)> = Vec::with_capacity(n);
+    if n > 0 {
+        let mut stmt = conn.prepare(&format!(
+            "SELECT node, score FROM ix_centrality('{edge_list}', '{}') ORDER BY score DESC, node",
+            cfg.centrality.as_sql()
+        ))?;
+        let rows = stmt.query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, f64>(1)?)))?;
+        for row in rows {
+            let (node, score) = row?;
+            centrality.push((node as usize, score));
+        }
+    }
+    let lead = centrality.first().map(|&(i, _)| i);
+
+    Ok(MeshResult {
+        names,
+        correlation,
+        clusters,
+        centrality,
+        lead,
+    })
+}
+
+/// Install the reusable **pipeline catalog** — table macros that name a conditioning
+/// pipeline so callers can `SELECT … FROM ix_smooth('[…]', 2, 0.05)` declaratively.
+/// This is the SQL-native declaration layer of ADR-0004; the 100+ mesh is a catalog
+/// of such macros over different sources.
+pub fn install_pipeline_catalog(conn: &Connection) -> duckdb::Result<()> {
+    conn.execute_batch(
+        "CREATE OR REPLACE MACRO ix_smooth(series, levels, threshold) AS TABLE
+            SELECT i, value FROM ix_wavelet_denoise(series, levels, threshold);
+         CREATE OR REPLACE MACRO ix_kalman_pipeline(series, process_noise, measurement_noise) AS TABLE
+            SELECT i, value FROM ix_kalman_smooth(series, process_noise, measurement_noise);",
+    )
+}
+
+#[cfg(all(test, feature = "duck"))]
+mod tests {
+    use super::*;
+    use crate::open_bench;
+
+    /// Deterministic ±0.05 pseudo-noise (no RNG → reproducible).
+    fn noise(t: usize, seed: u64) -> f64 {
+        let mut x = (t as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
+        x ^= x >> 33;
+        x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+        x ^= x >> 33;
+        (x as f64 / u64::MAX as f64 - 0.5) * 0.1
+    }
+    fn tone(f: f64, seed: u64, n: usize) -> Vec<f64> {
+        (0..n)
+            .map(|t| (2.0 * std::f64::consts::PI * f * t as f64 / n as f64).sin() + noise(t, seed))
+            .collect()
+    }
+
+    #[test]
+    fn hub_and_spoke_mesh() {
+        let conn = open_bench().unwrap();
+        let n = 64;
+        let p = tone(1.0, 11, n);
+        let q = tone(2.0, 22, n);
+        let r = tone(3.0, 33, n);
+        let h: Vec<f64> = (0..n).map(|t| (p[t] + q[t] + r[t]) / 3.0 + noise(t, 99)).collect();
+        let d1 = tone(5.0, 44, n);
+        let d2 = tone(6.0, 55, n);
+        let streams = vec![
+            ("H".into(), h),
+            ("P".into(), p),
+            ("Q".into(), q),
+            ("R".into(), r),
+            ("D1".into(), d1),
+            ("D2".into(), d2),
+        ];
+
+        let res = correlate(&conn, &streams, &MeshConfig::default()).unwrap();
+
+        // H correlates with each spoke; spokes are mutually orthogonal.
+        assert!(res.correlation[0][1] > 0.4, "H↔P correlated, got {}", res.correlation[0][1]);
+        assert!(res.correlation[1][2].abs() < 0.3, "P↔Q orthogonal, got {}", res.correlation[1][2]);
+
+        // One cluster holds {H,P,Q,R}; D1 and D2 are isolated → 3 clusters total.
+        assert_eq!(res.clusters.len(), 3, "expected {{H,P,Q,R}}, {{D1}}, {{D2}}");
+        let hub_cluster = res.clusters.iter().find(|c| c.contains(&0)).unwrap();
+        assert_eq!(hub_cluster.len(), 4, "H,P,Q,R cluster together");
+        assert!(hub_cluster.contains(&1) && hub_cluster.contains(&2) && hub_cluster.contains(&3));
+
+        // Betweenness ranks the hub H (index 0) as the lead.
+        assert_eq!(res.lead, Some(0), "H is the lead/hub");
+        assert_eq!(res.lead_name(), Some("H"));
+    }
+
+    #[test]
+    fn constant_stream_yields_no_edge_not_error() {
+        let conn = open_bench().unwrap();
+        // A flat (constant) stream makes Pearson undefined; the mesh must treat it as
+        // uncorrelated rather than erroring out.
+        let streams = vec![
+            ("flat".into(), vec![5.0; 16]),
+            ("ramp".into(), (0..16).map(|t| t as f64).collect()),
+        ];
+        let res = correlate(&conn, &streams, &MeshConfig { smooth: None, ..Default::default() })
+            .unwrap();
+        assert!(res.correlation[0][1].abs() < 1e-9, "constant↔ramp → r treated as 0");
+        assert_eq!(res.clusters.len(), 2, "two isolated streams");
+    }
+
+    #[test]
+    fn pipeline_catalog_macro_runs() {
+        let conn = open_bench().unwrap();
+        install_pipeline_catalog(&conn).unwrap();
+        // The declared ix_smooth pipeline macro composes like any table function.
+        let n: i64 = conn
+            .query_row("SELECT count(*) FROM ix_smooth('[1,2,3,4,5,6,7,8]', 2, 0.05)", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(n, 8, "ix_smooth macro returns the conditioned series");
+    }
+}

--- a/crates/ix-math/src/inference.rs
+++ b/crates/ix-math/src/inference.rs
@@ -121,6 +121,36 @@ pub fn zscore(x: &[f64]) -> Result<Vec<f64>, MathError> {
     Ok(x.iter().map(|v| (v - mu) / sigma).collect())
 }
 
+/// Pearson product-moment correlation `r ∈ [−1, 1]` between two equal-length,
+/// non-constant samples. `r = Σ(aᵢ−ā)(bᵢ−b̄) / √(Σ(aᵢ−ā)² · Σ(bᵢ−b̄)²)`. The
+/// pairwise primitive for a correlation mesh over many streams.
+pub fn pearson(a: &[f64], b: &[f64]) -> Result<f64, MathError> {
+    if a.len() != b.len() {
+        return Err(MathError::DimensionMismatch {
+            expected: a.len(),
+            got: b.len(),
+        });
+    }
+    if a.is_empty() {
+        return Err(MathError::EmptyInput);
+    }
+    let (ma, mb) = (mean(a), mean(b));
+    let (mut cov, mut va, mut vb) = (0.0, 0.0, 0.0);
+    for (&ai, &bi) in a.iter().zip(b) {
+        let (da, db) = (ai - ma, bi - mb);
+        cov += da * db;
+        va += da * da;
+        vb += db * db;
+    }
+    let denom = (va * vb).sqrt();
+    if denom <= 0.0 {
+        return Err(MathError::InvalidParameter(
+            "Pearson correlation is undefined when a sample is constant".into(),
+        ));
+    }
+    Ok((cov / denom).clamp(-1.0, 1.0))
+}
+
 // ── divergences over probability vectors ───────────────────────────────────────
 
 /// Normalize a non-negative vector to sum 1. Errors on negatives or all-zero.
@@ -521,6 +551,18 @@ mod tests {
         assert!((z[0] + 2.0_f64.sqrt()).abs() < TOL);
         assert!(z[2].abs() < TOL);
         assert!((z.iter().sum::<f64>()).abs() < TOL, "z-scores sum to 0");
+    }
+
+    #[test]
+    fn pearson_correlation() {
+        // Perfect positive / negative / independent.
+        assert!((pearson(&[1., 2., 3., 4.], &[2., 4., 6., 8.]).unwrap() - 1.0).abs() < TOL);
+        assert!((pearson(&[1., 2., 3., 4.], &[8., 6., 4., 2.]).unwrap() + 1.0).abs() < TOL);
+        // numpy.corrcoef([1,2,3,4,5],[2,1,4,3,6])[0,1] = 10/√148 ≈ 0.821995
+        let expected = 10.0 / 148.0_f64.sqrt();
+        assert!((pearson(&[1., 2., 3., 4., 5.], &[2., 1., 4., 3., 6.]).unwrap() - expected).abs() < TOL);
+        assert!(pearson(&[1., 1., 1.], &[1., 2., 3.]).is_err(), "constant sample is undefined");
+        assert!(pearson(&[1., 2.], &[1.]).is_err(), "length mismatch errors");
     }
 
     #[test]

--- a/docs/adr/0004-duckdb-sql-pipeline-mesh.md
+++ b/docs/adr/0004-duckdb-sql-pipeline-mesh.md
@@ -1,0 +1,86 @@
+# DuckDB-SQL + IX UDFs is the IX pipeline-mesh correlation substrate (complementary to IXQL)
+
+Status: accepted (2026-06-21)
+
+## Context
+
+We want to **declare many IX "pipelines" and compose them into a mesh** that correlates
+real-world data scenarios (sensors, market ticks, log-rates, ecosystem telemetry) — on the
+order of 100+ pipelines — to answer "which streams move together, and which one leads?".
+
+The instinct is to reach for **IXQL** (Demerzel's governance pipeline-spec DSL). But per
+[ADR-0001](0001-ixql-duckdb-integration-via-mcp-seam.md), IXQL is **spec-only** (no executor
+ships; `ix-cli` #103 is a draft) and the grammar is a governed artifact — adding DuckDB
+source/sink nodes is forbidden until the executor lands *and* a grammar change gets
+Galactic-Protocol sign-off. So IXQL cannot run a mesh today.
+
+Meanwhile `ix-duck` (the analyst bench, `docs/DUCKDB.md`) now exposes ~80 IX algorithm UDFs,
+including the exact correlation primitives a mesh needs: `ix_pearson`, `ix_two_sample`,
+`ix_kl`/`ix_js`, `ix_connected_components`, `ix_centrality`, and the per-stream conditioners
+`ix_wavelet_denoise`/`ix_kalman_smooth`.
+
+## Decision
+
+**The pipeline-mesh correlation substrate is DuckDB SQL as the composition language with IX
+UDFs as the stages — *not* IXQL, and *not* a new execution engine.** Concretely:
+
+1. **A "pipeline" is a named DuckDB `VIEW` / table `MACRO`** over a JSON-on-disk stream,
+   composing IX UDFs. The "catalog" is a set of such macros; the "mesh" is the N×N
+   correlation across their outputs. This is pure analyst-bench analysis (read-only,
+   no source-of-truth), so it crosses **no** governed boundary — ADR-0001 stands untouched
+   (we add no IXQL grammar nodes).
+2. **The canonical mesh pipeline shape** is:
+   `N streams → ix_wavelet_denoise/ix_kalman_smooth (condition) → ix_pearson / ix_two_sample
+   (pairwise) → threshold → edge list → ix_connected_components (incident clusters) →
+   ix_centrality (lead/hub indicator)`.
+3. **A thin reusable driver** (`ix-duck::mesh`) orchestrates that shape over an arbitrary set
+   of named streams and returns a structured `MeshResult` (correlation matrix + clusters +
+   centrality ranking + lead). It also installs a small **pipeline catalog** of reusable
+   table macros (`ix_smooth`, `ix_zsmooth`) as the SQL-native declaration layer.
+
+## Why (the trade-off)
+
+- **Runnable today, zero new governed surface.** SQL views/macros + existing UDFs run on the
+  bundled-DuckDB (`duck`) feature now; IXQL would run *nothing*. The mesh is useful immediately
+  and remains forward-compatible: when the IXQL executor ships, its `mcp_tool_output(…)` /
+  `database(…)` productions can target an ix-duck mesh query as a data source (ADR-0001 path #1).
+- **SQL *is* a declarative composition language.** CTEs, views, and table macros already give
+  naming, parameterization, and composition — re-deriving that in a bespoke engine is the
+  "build the whole thing" failure mode the repo's tracer-bullet discipline warns against.
+- **The primitives already exist and are tested.** The mesh is *assembly*, not new math.
+
+## Consequences
+
+- `ix-duck::mesh` is **`duck`-feature-gated** (it runs SQL on a bundled engine), like the other
+  lenses; the default/`--workspace` build never compiles it.
+- The mesh is **advisory analysis**, never a binding gate or source of truth (`docs/DUCKDB.md`).
+  Binding verdicts still go through the governed `maintain-gate` (ADR-0002), not raw mesh SQL.
+- **Centrality choice is load-bearing.** On a hub-and-spoke (near-**bipartite**) correlation
+  graph, `eigenvector` centrality is still the wrong lens — it spreads weight toward dense
+  mutually-correlated clusters and under-weights a structural hub whose spokes don't correlate
+  with each other. (The earlier power-iteration *non-convergence* on exactly-bipartite graphs is
+  fixed in `ix-graph` as of #165 via the `A + I` self-loop shift, so eigenvector now returns a
+  stable vector — it's just not the hub lens we want here.) `betweenness` (or `degree`) is the
+  correct lead/hub lens for hub-and-spoke; `eigenvector` suits *dense, mutually-correlated*
+  clusters. The driver defaults to `betweenness`.
+- Pearson over **constant** streams is undefined → a SQL error; the driver treats such a pair as
+  uncorrelated (no edge) rather than aborting the whole mesh.
+
+## Use-case catalog (good scenarios)
+
+1. **Ecosystem regression radar** — one drift pipeline per `state/quality/*.json` metric;
+   `ix_two_sample` vs each metric's 30-day baseline; `ix_centrality` ranks which regressing
+   metric is *causally central* vs a downstream symptom.
+2. **Cross-repo correlation** — ix/tars/ga emit JSONL; the mesh joins them to test "does a tars
+   grammar-weight change correlate with a ga routing-F1 drop?".
+3. **Sensor / IoT / market correlation** — N raw streams → `ix_kalman_smooth` → pairwise
+   `ix_pearson` → `ix_connected_components` (incident clusters) → `ix_centrality` (lead indicator).
+4. **Telemetry anomaly mesh** — per-intent query streams; `ix_kdist`/`ix_dbscan` flag OOD,
+   `ix_connected_components` groups co-failing intents into incident clusters.
+5. **A/B & experiment fleet** — 100 arms as macros; `ix_two_sample` (distribution-free) gates each.
+
+## Revisit trigger
+
+When the IXQL executor (`ix-cli` #103) ships: a first-class `duckdb(…)` source could then declare
+a mesh query *inside* an IXQL pipeline (with grammar sign-off, per ADR-0001's revisit trigger).
+Until then the mesh lives entirely in ix-duck.


### PR DESCRIPTION
## What

The **pipeline-mesh substrate** (ADR-0004) for `ix-duck` — compose N IX "pipelines" over many streams on the DuckDB analyst bench and correlate their outputs N×N to find which streams move together (clusters) and which one leads (centrality).

Canonical shape, end-to-end in `ix_duck::mesh::correlate`:

```
N streams -> ix_wavelet_denoise (condition) -> ix_pearson (pairwise)
          -> threshold -> ix_connected_components (clusters)
          -> ix_centrality (lead/hub indicator) -> MeshResult
```

Advisory analysis only (ADR-0004) — never a binding gate or source of truth. Binding verdicts still go through the governed `maintain-gate` (ADR-0002).

## Changes

- `crates/ix-duck/src/mesh.rs` — the substrate (`MeshConfig`, `MeshResult`, `correlate`, `install_pipeline_catalog`).
- `crates/ix-duck/examples/ix_mesh_correlate.rs` — runnable end-to-end example.
- **`ix_pearson`** scalar UDF — `ix_math::inference::pearson` + the ix-duck `VScalar` wrap; the mesh's pairwise primitive. Constant / length-mismatch arg → SQL error (not a panic). Tests in both crates.
- `docs/adr/0004-duckdb-sql-pipeline-mesh.md` + `CONTEXT.md` glossary (**pipeline-mesh**, **topological fingerprint**, **topological drift**).

## Notes

- DuckDB SQL is the composition language here, **not** IXQL (which is spec-only and stays complementary — ADR-0001 + ADR-0004).
- Default hub lens is **betweenness** (correct on bipartite hub-and-spoke). The earlier "eigenvector oscillates / does not converge" note is **softened**: #165 fixed power-iteration convergence via the `A + I` self-loop shift, so eigenvector now returns a stable vector — it just isn't the right hub lens for hub-and-spoke.

## Provenance

Rebuilt cleanly off updated `main` (post #164 / #166 / #168), re-applying **only** the net-new mesh delta from the old `feat/ix-mesh-correlate` spike — the two `confidence_calibrator` / `staleness_predictor` commits there are not part of this (they landed separately as #168). **Replaces draft #167**, which is closed.

## Verification

- `cargo test -p ix-duck --features duck` → 162 pass (incl. `mesh::tests::hub_and_spoke_mesh`, `inference::tests::pearson_scalar`).
- `cargo test -p ix-math inference` → `pearson_correlation` ok.
- `cargo clippy -p ix-duck --features duck --all-targets` + `-p ix-math --all-targets` → clean.
- `cargo build -p ix-duck --features duck --example ix_mesh_correlate` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
