### PR TITLE
feat(ix-duck): ix_voicing_mesh — second axis (fretSpan) + τ-sweep with named regions

### DIFF
--- a/crates/ix-duck/examples/ix_voicing_mesh.rs
+++ b/crates/ix-duck/examples/ix_voicing_mesh.rs
@@ -1,32 +1,33 @@
 //! `ix_voicing_mesh` — a **real-world** pipeline-mesh (ADR-0004) over the GA guitar
 //! voicing corpus (`state/voicings/raw/guitar.jsonl`, ~667 k fingerings).
 //!
-//! Analysis question:
-//!   *Which chord set-classes occupy the same fretboard regions, and which
-//!    set-class is the structural hub of the guitar's voicing geometry?*
+//! Analysis question (run for **two axes**):
+//!   *Which chord set-classes behave alike along the neck, and which set-class is the
+//!    structural hub of that geometry?* — once by **position** (`minFret`: where on the
+//!    neck a set-class lives) and once by **stretch** (`fretSpan`: how ergonomically
+//!    wide its shapes are).
 //!
-//! Each **stream** is one Forte set-class; the aligned axis is **fret position**
-//! (`minFret`), so a stream is that set-class's *fretboard-position profile*
-//! (#voicings per fret). One load-bearing pipeline stage — **common-mode removal** —
-//! makes the mesh informative: every set-class crowds the low frets, so raw profiles
-//! all correlate ~1 (one clique, no hub). Normalizing each profile to a distribution
-//! and subtracting the cross-set-class mean leaves each set-class's *distinctive*
-//! fret preference, which is what the mesh correlates.
+//! Each **stream** is one Forte set-class; the aligned axis is a histogram over the
+//! chosen bin column, so a stream is that set-class's *position profile* or *stretch
+//! profile*. One load-bearing pipeline stage — **common-mode removal** — makes the mesh
+//! informative: every set-class crowds the low frets / wide spans, so raw profiles all
+//! correlate ~1 (one clique, no hub). Normalizing each profile to a distribution and
+//! subtracting the cross-set-class mean leaves each set-class's *distinctive* preference,
+//! which is what the mesh correlates.
 //!
 //! **Both layered** (ADR-0004): the demo is a graph of ~460 *operators* (a 4-stage
 //! pipeline per stream, joined through a common-mode barrier, plus a shared head and
 //! mesh tail — reified as an `ix_pipeline::dag::Dag`) whose ~120 *stream* outputs feed
 //! the N×N correlation mesh. Every layer is an IX UDF on the DuckDB bench:
 //! ```text
-//!   read_json_auto ─▶ ix_forte_number (annotate) ─▶ GROUP BY minFret (bin)
+//!   read_json_auto ─▶ ix_forte_number (annotate) ─▶ GROUP BY <axis> (bin)
 //!     ─▶ per-set-class profile ─▶ normalize ─▶ subtract common-mode
 //!     ─▶ ix_wavelet_denoise (condition) ─▶ ix_pearson (N×N)
 //!     ─▶ ix_connected_components (regions) ─▶ ix_centrality betweenness (hub)
 //! ```
 //!
-//! Finding (τ = 0.8, 114 well-supported set-classes): guitar voicing set-classes form
-//! one connected fretboard-geometry web, with **5-29** its structural hub (betweenness
-//! ~112, 3.5× the runner-up). The lever is the `|r|` threshold τ (ADR-0004).
+//! The `|r|` threshold τ is the operating lever (ADR-0004): a τ-sweep shows the single
+//! web at τ = 0.8 fracturing into named fret-band regions as τ rises.
 //!
 //! Run: `cargo run -p ix-duck --example ix_voicing_mesh --features duck`
 
@@ -36,27 +37,68 @@ use ix_duck::mesh::{correlate, MeshConfig, MeshResult};
 use ix_duck::open_bench;
 use ix_pipeline::dag::Dag;
 
-/// Fret-position axis: `minFret` 0..FRETS-1 (the aligned vector index).
-const FRETS: usize = 18;
-/// `|r|` edge threshold. At 0.4 the de-trended mesh is one giant clique; a stricter
-/// operating point carves out distinct fretboard regions (ADR-0004: the lever is τ).
+/// Default `|r|` edge threshold (the mesh's headline operating point).
 const THRESHOLD: f64 = 0.8;
+/// τ values swept to show region structure emerging as the threshold tightens.
+const TAU_SWEEP: [f64; 4] = [0.8, 0.9, 0.95, 0.98];
 /// Print the full N×N matrix only for a small (tracer-bullet) mesh.
 const FULL_MATRIX_MAX: usize = 12;
 
 /// The full GA CLI dump (~667 k fingerings) — gitignored (110 MB), so present only on
-/// a machine that has run `ix-voicings`. Yields the headline 100+ stream / 5-29-hub run.
+/// a machine that has run `ix-voicings`. Yields the headline 100+ stream run.
 const CORPUS_FULL: &str = "state/voicings/raw/guitar.jsonl";
 /// A tracked 500-voicing sample (same schema) so the demo runs on a fresh checkout.
 /// Smaller N → the structure is real but the exact hub differs from the full corpus.
 const CORPUS_SAMPLE: &str = "state/voicings/guitar-corpus.json";
 
 /// Per-corpus parameters: a set-class needs `min_support` voicings to be a stream
-/// (so every fret bin is populated and a sparse profile can't fake a bridge), and the
-/// mesh keeps the top `top_k` by support. Scaled to the corpus so the sample still runs.
+/// (so every bin is populated and a sparse profile can't fake a bridge), and the mesh
+/// keeps the top `top_k` by support. Scaled to the corpus so the sample still runs.
 struct Params {
     min_support: f64,
     top_k: usize,
+}
+
+/// The aligned axis a stream's profile is binned over.
+#[derive(Clone, Copy)]
+enum Axis {
+    /// `minFret` — *where* on the neck a set-class's voicings sit (0..17).
+    Position,
+    /// `fretSpan` — *how wide* its shapes stretch (0..4); an ergonomic-difficulty lens.
+    Stretch,
+}
+
+impl Axis {
+    /// The voicing column binned over, and the inclusive bin count.
+    fn column(self) -> &'static str {
+        match self {
+            Axis::Position => "minFret",
+            Axis::Stretch => "fretSpan",
+        }
+    }
+    fn bins(self) -> usize {
+        match self {
+            Axis::Position => 18,
+            Axis::Stretch => 5,
+        }
+    }
+    fn title(self) -> &'static str {
+        match self {
+            Axis::Position => "POSITION (minFret — where on the neck)",
+            Axis::Stretch => "STRETCH (fretSpan — ergonomic width)",
+        }
+    }
+    /// Name the fret-band a peak bin falls in (used to label regions).
+    fn band(self, bin: usize) -> &'static str {
+        match self {
+            Axis::Position if bin <= 4 => "open",
+            Axis::Position if bin <= 11 => "mid-neck",
+            Axis::Position => "upper",
+            Axis::Stretch if bin == 0 => "no-stretch",
+            Axis::Stretch if bin <= 2 => "moderate",
+            Axis::Stretch => "wide",
+        }
+    }
 }
 
 fn main() -> ix_duck::Result<()> {
@@ -72,168 +114,221 @@ fn main() -> ix_duck::Result<()> {
         println!(
             "note: full corpus '{CORPUS_FULL}' not found (gitignored, 110 MB) — using the \
              tracked {CORPUS_SAMPLE} sample.\n      Run `cargo run -p ix-voicings` to dump the \
-             full corpus and reproduce the 100+ stream / 5-29-hub result.\n"
+             full corpus and reproduce the 100+ stream result.\n"
         );
     }
 
-    // ── annotate + bin: one pass over the corpus → (set-class, fret) → count ──────
-    // ix_forte_number(midiNotes) is the per-row annotate operator; GROUP BY is the bin.
-    let sql = format!(
-        "WITH annotated AS (
-            SELECT ix_forte_number(midiNotes) AS sc, minFret AS fret
-            FROM read_json_auto('{corpus}')
-         )
-         SELECT sc, fret, count(*) AS n
-         FROM annotated
-         WHERE sc IS NOT NULL AND fret >= 0 AND fret < {FRETS}
-         GROUP BY sc, fret"
-    );
-
-    let mut profiles: BTreeMap<String, Vec<f64>> = BTreeMap::new();
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, i64>(1)?,
-            row.get::<_, i64>(2)?,
-        ))
-    })?;
-    for row in rows {
-        let (sc, fret, n) = row?;
-        let v = profiles.entry(sc).or_insert_with(|| vec![0.0; FRETS]);
-        v[fret as usize] = n as f64;
+    for axis in [Axis::Position, Axis::Stretch] {
+        run_axis(&conn, corpus, &params, axis)?;
     }
-
-    // ── data-shape summary (calibration) ─────────────────────────────────────────
-    let total_voicings: f64 = profiles.values().flat_map(|v| v.iter()).sum();
-    println!(
-        "corpus: {} → {} distinct set-classes, {:.0} classifiable voicings over frets 0..{}\n",
-        corpus,
-        profiles.len(),
-        total_voicings,
-        FRETS - 1
-    );
-
-    // ── qualifying population: set-classes with enough support ───────────────────
-    let qualifying: Vec<(String, Vec<f64>, f64)> = profiles
-        .into_iter()
-        .map(|(sc, v)| {
-            let support: f64 = v.iter().sum();
-            (sc, v, support)
-        })
-        .filter(|(_, _, support)| *support >= params.min_support)
-        .collect();
-
-    // ── common-mode removal (the load-bearing pipeline stage) ────────────────────
-    // Raw fret profiles all share one dominant trend — *every* set-class crowds the
-    // low frets — so raw Pearson sees them as identical (one clique, no hub). We want
-    // each set-class's *distinctive* fret preference, so:
-    //   1. normalize each profile to a positional distribution (removes the
-    //      frequency confound: a common set-class shouldn't outweigh a rare one), then
-    //   2. subtract the cross-set-class mean distribution per fret, leaving the
-    //      *anomaly* — where this set-class over/under-indexes vs the typical one.
-    // Pearson on these residuals correlates distinctive co-location, not the shared trend.
-    let mut mean_dist = vec![0.0f64; FRETS];
-    let dists: Vec<Vec<f64>> = qualifying
-        .iter()
-        .map(|(_, raw, support)| raw.iter().map(|n| n / support).collect::<Vec<f64>>())
-        .collect();
-    for dist in &dists {
-        for (k, p) in dist.iter().enumerate() {
-            mean_dist[k] += p / dists.len() as f64;
-        }
-    }
-    let residual = |dist: &[f64]| -> Vec<f64> {
-        dist.iter().zip(&mean_dist).map(|(p, m)| p - m).collect()
-    };
-
-    // ── select streams: top-K set-classes by total support, as residual profiles ──
-    let mut ranked: Vec<(String, Vec<f64>, f64)> = qualifying
-        .iter()
-        .zip(&dists)
-        .map(|((sc, _, support), dist)| (sc.clone(), residual(dist), *support))
-        .collect();
-    ranked.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap());
-    ranked.truncate(params.top_k);
-
-    let streams: Vec<(String, Vec<f64>)> = ranked
-        .iter()
-        .map(|(sc, v, _)| (sc.clone(), v.clone()))
-        .collect();
-
-    println!(
-        "{} streams (top set-classes by support, ≥{:.0} voicings) over a {FRETS}-fret \
-         axis, common-mode removed:",
-        streams.len(),
-        params.min_support
-    );
-    for (sc, _, support) in &ranked {
-        println!("   {sc:>6}  ({support:.0} voicings)");
-    }
-    println!();
-
-    // ── reify the operator DAG (ADR-0004 "both layered") ─────────────────────────
-    // The mesh is *two layered*: a graph of 100+ operators (the per-stream pipelines
-    // + the shared head/tail) whose stream outputs feed the N×N correlation mesh.
-    let dag = build_operator_dag(&streams);
-    let levels = dag.parallel_levels();
-    let (crit, crit_len) = dag.critical_path(|_, _| 1.0);
-    println!("operator DAG (ix_pipeline::dag) — the \"both layered\" pipeline graph:");
-    println!(
-        "   {} operators, {} edges, depth {} (parallel levels), critical path {} ops",
-        dag.node_count(),
-        dag.edge_count(),
-        levels.len(),
-        crit_len as usize
-    );
-    println!(
-        "   widest level fans out to {} concurrent operators (one per stream)",
-        levels.iter().map(Vec::len).max().unwrap_or(0)
-    );
-    println!("   critical chain: {}\n", crit.iter().take(7).cloned().cloned().collect::<Vec<_>>().join(" → "));
-
-    // ── run the mesh ─────────────────────────────────────────────────────────────
-    let cfg = MeshConfig { threshold: THRESHOLD, ..MeshConfig::default() };
-    let mesh = correlate(&conn, &streams, &cfg)?;
-
-    if streams.len() <= FULL_MATRIX_MAX {
-        print!("ix_pearson fretboard-profile correlation\n        ");
-        for (sc, _) in &streams {
-            print!("{sc:>7}");
-        }
-        println!();
-        for (i, (sc, _)) in streams.iter().enumerate() {
-            print!("{sc:>6}  ");
-            for j in 0..streams.len() {
-                print!("{:>7.2}", mesh.correlation[i][j]);
-            }
-            println!();
-        }
-        println!();
-    }
-
-    report_mesh(&mesh, &cfg, &ranked);
     Ok(())
 }
 
-/// Build the operator graph behind the mesh: shared head (read → annotate → bin),
-/// a 4-stage pipeline per stream (profile → normalize → residual → smooth) joined
-/// through a common-mode barrier, and the shared mesh tail (pearson → threshold →
-/// components → centrality). Acyclic by construction.
-fn build_operator_dag(streams: &[(String, Vec<f64>)]) -> Dag<&'static str> {
-    let mut dag: Dag<&'static str> = Dag::new();
-    let node = |d: &mut Dag<&'static str>, id: &str, kind: &'static str| {
-        d.add_node(id.to_string(), kind).ok();
-    };
-    let edge = |d: &mut Dag<&'static str>, a: &str, b: &str| {
-        d.add_edge(a.to_string(), b.to_string()).expect("acyclic by construction");
-    };
+/// Run the full mesh for one axis: annotate → bin → common-mode → streams → DAG →
+/// mesh → τ-sweep → named regions → hub.
+fn run_axis(conn: &ix_duck::Connection, corpus: &str, params: &Params, axis: Axis) -> ix_duck::Result<()> {
+    let (bins, col) = (axis.bins(), axis.column());
+    println!("\n══════════════════════════════════════════════════════════════════════");
+    println!("AXIS: {}", axis.title());
+    println!("══════════════════════════════════════════════════════════════════════\n");
 
-    // Shared head + common-mode barrier + shared tail.
+    // ── annotate + bin: one pass → (set-class, bin) → count ──────────────────────
+    let sql = format!(
+        "WITH annotated AS (
+            SELECT ix_forte_number(midiNotes) AS sc, {col} AS bin
+            FROM read_json_auto('{corpus}')
+         )
+         SELECT sc, bin, count(*) AS n
+         FROM annotated
+         WHERE sc IS NOT NULL AND bin >= 0 AND bin < {bins}
+         GROUP BY sc, bin"
+    );
+    let mut profiles: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?, r.get::<_, i64>(2)?)))?;
+    for row in rows {
+        let (sc, bin, n) = row?;
+        profiles.entry(sc).or_insert_with(|| vec![0.0; bins])[bin as usize] = n as f64;
+    }
+
+    let total: f64 = profiles.values().flatten().sum();
+    println!("corpus: {corpus} → {} set-classes, {total:.0} classifiable voicings over {col} 0..{}\n", profiles.len(), bins - 1);
+
+    // ── qualifying population, then common-mode removal ──────────────────────────
+    // Raw profiles share one dominant trend (every set-class crowds the low frets /
+    // wide spans), so raw Pearson sees them as identical. We want each set-class's
+    // *distinctive* preference: normalize to a distribution, subtract the per-bin
+    // cross-set-class mean, and correlate the residual (the anomaly vs the typical).
+    let qualifying: Vec<(String, Vec<f64>, f64)> = profiles
+        .into_iter()
+        .map(|(sc, v)| { let s: f64 = v.iter().sum(); (sc, v, s) })
+        .filter(|(_, _, s)| *s >= params.min_support)
+        .collect();
+
+    let dists: Vec<Vec<f64>> = qualifying.iter().map(|(_, v, s)| v.iter().map(|n| n / s).collect()).collect();
+    let mut mean = vec![0.0f64; bins];
+    for d in &dists {
+        for (k, p) in d.iter().enumerate() {
+            mean[k] += p / dists.len() as f64;
+        }
+    }
+
+    // ── select streams: top-K by support, as residual profiles; keep the raw peak
+    //    bin for region naming. ──────────────────────────────────────────────────
+    let mut ranked: Vec<Stream> = qualifying
+        .iter()
+        .zip(&dists)
+        .map(|((sc, raw, support), dist)| Stream {
+            name: sc.clone(),
+            residual: dist.iter().zip(&mean).map(|(p, m)| p - m).collect(),
+            support: *support,
+            peak_bin: argmax(raw),
+        })
+        .collect();
+    ranked.sort_by(|a, b| b.support.partial_cmp(&a.support).unwrap());
+    ranked.truncate(params.top_k);
+
+    let streams: Vec<(String, Vec<f64>)> = ranked.iter().map(|s| (s.name.clone(), s.residual.clone())).collect();
+    println!("{} streams (top set-classes by support, ≥{:.0} voicings), common-mode removed.", streams.len(), params.min_support);
+
+    // ── reify the operator DAG (ADR-0004 "both layered") ─────────────────────────
+    let dag = build_operator_dag(&streams, col);
+    let levels = dag.parallel_levels();
+    let (crit, crit_len) = dag.critical_path(|_, _| 1.0);
+    println!(
+        "operator DAG (ix_pipeline::dag): {} operators, {} edges, depth {}, fan-out {}, critical path {} ops",
+        dag.node_count(), dag.edge_count(), levels.len(),
+        levels.iter().map(Vec::len).max().unwrap_or(0), crit_len as usize
+    );
+    println!("   critical chain: {}\n", crit.iter().take(7).map(|s| s.as_str()).collect::<Vec<_>>().join(" → "));
+
+    // ── run the mesh at the headline τ ───────────────────────────────────────────
+    let cfg = MeshConfig { threshold: THRESHOLD, ..MeshConfig::default() };
+    let mesh = correlate(conn, &streams, &cfg)?;
+
+    if streams.len() <= FULL_MATRIX_MAX {
+        print_matrix(&mesh, &streams);
+    }
+
+    // ── τ-sweep: region structure as the threshold tightens ──────────────────────
+    // Recount components in-process from the already-computed correlation matrix —
+    // no need to re-run the mesh per τ.
+    println!("τ-sweep (regions = connected components of the |r| ≥ τ graph):");
+    for tau in TAU_SWEEP {
+        let comps = components_at(&mesh.correlation, tau);
+        let non_singleton = comps.iter().filter(|c| c.len() > 1).count();
+        println!("   τ = {tau:.2} → {} regions ({} multi-member)", comps.len(), non_singleton);
+    }
+
+    // Name the regions at the τ that fractures the web into the most multi-member
+    // regions (on ties `max_by_key` keeps the tighter τ — the sharper split).
+    let split_tau = TAU_SWEEP
+        .iter()
+        .copied()
+        .max_by_key(|&t| components_at(&mesh.correlation, t).iter().filter(|c| c.len() > 1).count())
+        .unwrap_or(THRESHOLD);
+    println!("\nnamed fret-band regions at τ = {split_tau:.2}:");
+    let mut regions = components_at(&mesh.correlation, split_tau);
+    regions.sort_by_key(|c| std::cmp::Reverse(c.len()));
+    for region in regions.iter().filter(|c| c.len() >= 2).take(6) {
+        let band = dominant_band(region, &ranked, axis);
+        let mut members: Vec<&str> = region.iter().map(|&i| ranked[i].name.as_str()).collect();
+        members.truncate(10);
+        println!("   {band:>9}-band region ({} set-classes): {{ {} }}", region.len(), members.join(", "));
+    }
+
+    // ── hub at the headline τ ────────────────────────────────────────────────────
+    println!("\nix_centrality ({:?}) — top hub set-classes at τ = {THRESHOLD}:", cfg.centrality);
+    for &(i, score) in mesh.centrality.iter().take(6) {
+        let s = &ranked[i];
+        println!("   {:>6}: betweenness {score:>8.1}  ({:.0} voicings, peaks in {}-band)", s.name, s.support, axis.band(s.peak_bin));
+    }
+    println!("▶ structural hub on the {} axis: {}", col, mesh.lead_name().unwrap_or("?"));
+    Ok(())
+}
+
+/// A mesh stream: a set-class, its common-mode-removed profile, total support, and the
+/// raw peak bin (for region naming).
+struct Stream {
+    name: String,
+    residual: Vec<f64>,
+    support: f64,
+    peak_bin: usize,
+}
+
+fn argmax(v: &[f64]) -> usize {
+    v.iter().enumerate().max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).map(|(i, _)| i).unwrap_or(0)
+}
+
+/// Connected components of the graph `{ (i,j) : |correlation[i][j]| ≥ τ }`, via
+/// union-find. Used for the in-process τ-sweep (no mesh re-run).
+#[allow(clippy::needless_range_loop)] // triangular i<j scan over the matrix; indices feed union-find
+fn components_at(corr: &[Vec<f64>], tau: f64) -> Vec<Vec<usize>> {
+    let n = corr.len();
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(p: &mut [usize], x: usize) -> usize {
+        let mut r = x;
+        while p[r] != r { r = p[r]; }
+        let mut c = x;
+        while p[c] != c { let nx = p[c]; p[c] = r; c = nx; }
+        r
+    }
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if corr[i][j].abs() >= tau {
+                let (a, b) = (find(&mut parent, i), find(&mut parent, j));
+                if a != b { parent[a] = b; }
+            }
+        }
+    }
+    let mut by_root: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for i in 0..n {
+        let r = find(&mut parent, i);
+        by_root.entry(r).or_default().push(i);
+    }
+    by_root.into_values().collect()
+}
+
+/// The band a region is *distinctively* drawn to: the bin where the region's members
+/// most over-index versus the typical set-class (argmax of their mean residual). This
+/// is what the mesh actually clustered on — more telling than the raw peak, which is
+/// "open" for almost every set-class.
+fn dominant_band(region: &[usize], ranked: &[Stream], axis: Axis) -> &'static str {
+    let bins = ranked.first().map(|s| s.residual.len()).unwrap_or(0);
+    let mut mean = vec![0.0f64; bins];
+    for &i in region {
+        for (k, r) in ranked[i].residual.iter().enumerate() {
+            mean[k] += r / region.len() as f64;
+        }
+    }
+    axis.band(argmax(&mean))
+}
+
+fn print_matrix(mesh: &MeshResult, streams: &[(String, Vec<f64>)]) {
+    print!("ix_pearson residual-profile correlation\n        ");
+    for (sc, _) in streams { print!("{sc:>7}"); }
+    println!();
+    for (i, (sc, _)) in streams.iter().enumerate() {
+        print!("{sc:>6}  ");
+        for j in 0..streams.len() { print!("{:>7.2}", mesh.correlation[i][j]); }
+        println!();
+    }
+    println!();
+}
+
+/// Build the operator graph behind the mesh: shared head (read → annotate → bin), a
+/// 4-stage pipeline per stream (profile → normalize → residual → smooth) joined through
+/// a common-mode barrier, and the shared mesh tail. Acyclic by construction.
+fn build_operator_dag(streams: &[(String, Vec<f64>)], bin_col: &str) -> Dag<&'static str> {
+    let mut dag: Dag<&'static str> = Dag::new();
+    let node = |d: &mut Dag<&'static str>, id: &str, kind: &'static str| { d.add_node(id.to_string(), kind).ok(); };
+    let edge = |d: &mut Dag<&'static str>, a: &str, b: &str| { d.add_edge(a.to_string(), b.to_string()).expect("acyclic by construction"); };
+
+    let bin_label: &'static str = if bin_col == "fretSpan" { "GROUP BY fretSpan" } else { "GROUP BY minFret" };
     for (id, kind) in [
         ("src:read_json", "read_json_auto"),
         ("op:annotate", "ix_forte_number"),
-        ("op:bin", "GROUP BY minFret"),
+        ("op:bin", bin_label),
         ("op:common_mode", "cross-set-class mean"),
         ("mesh:pearson", "ix_pearson N×N"),
         ("mesh:threshold", "|r| ≥ τ"),
@@ -248,50 +343,20 @@ fn build_operator_dag(streams: &[(String, Vec<f64>)]) -> Dag<&'static str> {
     edge(&mut dag, "mesh:threshold", "mesh:components");
     edge(&mut dag, "mesh:components", "mesh:centrality");
 
-    // Per-stream 4-stage pipeline, joined through the common-mode barrier.
     for (i, _) in streams.iter().enumerate() {
         let (profile, norm, resid, smooth) =
             (format!("profile:{i}"), format!("norm:{i}"), format!("resid:{i}"), format!("smooth:{i}"));
-        node(&mut dag, &profile, "fret profile");
+        node(&mut dag, &profile, "profile");
         node(&mut dag, &norm, "normalize");
         node(&mut dag, &resid, "subtract common-mode");
         node(&mut dag, &smooth, "ix_wavelet_denoise");
         edge(&mut dag, "op:bin", &profile);
         edge(&mut dag, &profile, &norm);
-        edge(&mut dag, &norm, "op:common_mode"); // fan-in to the mean
+        edge(&mut dag, &norm, "op:common_mode");
         edge(&mut dag, &norm, &resid);
-        edge(&mut dag, "op:common_mode", &resid); // fan-out back to each residual
+        edge(&mut dag, "op:common_mode", &resid);
         edge(&mut dag, &resid, &smooth);
-        edge(&mut dag, &smooth, "mesh:pearson"); // fan-in to the correlation barrier
+        edge(&mut dag, &smooth, "mesh:pearson");
     }
     dag
-}
-
-/// Print the mesh verdict — region sizes (largest first) + the top hub ranking.
-fn report_mesh(mesh: &MeshResult, cfg: &MeshConfig, ranked: &[(String, Vec<f64>, f64)]) {
-    let mut sizes: Vec<&Vec<usize>> = mesh.clusters.iter().collect();
-    sizes.sort_by_key(|c| std::cmp::Reverse(c.len()));
-    println!(
-        "ix_connected_components (|r| ≥ {}) → {} fretboard region(s); sizes: {:?}",
-        cfg.threshold,
-        mesh.clusters.len(),
-        sizes.iter().map(|c| c.len()).collect::<Vec<_>>()
-    );
-    if let Some(largest) = sizes.first() {
-        let mut labels: Vec<&str> = largest.iter().map(|&i| mesh.names[i].as_str()).collect();
-        labels.truncate(16);
-        println!("   largest region (first {} of {}): {{ {} }}", labels.len(), sizes[0].len(), labels.join(", "));
-    }
-
-    println!("\nix_centrality ({:?}) — top hub set-classes:", cfg.centrality);
-    let support = |name: &str| ranked.iter().find(|(sc, _, _)| sc == name).map(|(_, _, s)| *s).unwrap_or(0.0);
-    for &(i, score) in mesh.centrality.iter().take(10) {
-        let name = mesh.names[i].as_str();
-        println!("   {name:>6}: betweenness {score:>10.1}  ({:.0} voicings)", support(name));
-    }
-    println!(
-        "\n▶ structural hub of the guitar's voicing geometry: {} \
-         (the set-class that most bridges distinct fretboard regions)",
-        mesh.lead_name().unwrap_or("?")
-    );
 }

--- a/docs/fr/pas-a-pas/maillage-voicings.md
+++ b/docs/fr/pas-a-pas/maillage-voicings.md
@@ -15,9 +15,14 @@ cargo run -p ix-duck --example ix_voicing_mesh --features duck
 
 ## La question
 
-> **Quelles classes d'ensembles (set-classes) d'accords occupent les mêmes régions du
-> manche, et quelle set-class est le pivot structurel de la géométrie des voicings de
-> la guitare ?**
+> **Quelles classes d'ensembles (set-classes) d'accords se comportent de la même façon
+> le long du manche, et quelle set-class est le pivot structurel de cette géométrie ?**
+
+La démo répond à cette question pour **deux axes**, un maillage chacun :
+
+- **Position** (`minFret`) — *où* sur le manche se situent les voicings d'une set-class.
+- **Écart** (`fretSpan`) — *à quel point* ses formes s'étirent (une lentille de
+  difficulté ergonomique).
 
 Le corpus (`state/voicings/raw/guitar.jsonl`, ~667 k doigtés, dont 558 k sont
 classables en 136 set-classes de Forte) est lu directement avec `read_json_auto` —
@@ -42,7 +47,7 @@ C'est la forme la plus complète d'ADR-0004 : un graphe de **~460 opérateurs** 
   affiché :
 
   ```text
-  read_json_auto ─▶ ix_forte_number (annoter) ─▶ GROUP BY minFret (regrouper)  [tête partagée]
+  read_json_auto ─▶ ix_forte_number (annoter) ─▶ GROUP BY <axe> (regrouper)    [tête partagée]
     ─▶ profile:k ─▶ normalize:k ─▶ residual:k ─▶ smooth:k                        [×120 flux]
                          └────────▶ mode-commun ────────┘                        [barrière]
     ─▶ ix_pearson (N×N) ─▶ |r| ≥ τ ─▶ ix_connected_components ─▶ ix_centrality   [queue partagée]
@@ -83,22 +88,39 @@ précisément ce que demande la question.
 > d'abord la tranche de bout en bout la plus fine, la laisser révéler l'inconnu, puis
 > passer à l'échelle.
 
-## Le résultat
+## Les résultats
 
-À `τ = 0,8` sur les 114 set-classes les mieux supportées (≥ 1000 voicings chacune,
-afin que chaque case de frette soit peuplée et qu'un profil clairsemé ne puisse pas
-simuler un pont) :
+Sur les set-classes les mieux supportées (≥ 1000 voicings chacune, afin que chaque
+case soit peuplée et qu'un profil clairsemé ne puisse pas simuler un pont), les deux
+axes donnent des **pivots différents** — la géométrie de *où* se situent les accords
+n'est pas celle de *à quel point* ils s'étirent :
 
-- Les set-classes forment **une seule toile connexe de géométrie du manche** — aucune
-  famille d'accords isolée ; elles sont toutes interreliées en position.
-- **5-29 est le pivot structurel** — betweenness **≈ 112**, soit environ 3,5× le
-  deuxième, et bien supportée (8 568 voicings) : ce n'est donc pas un artefact de
-  profil clairsemé. C'est la set-class dont le résidu de position sur le manche fait le
-  plus le pont entre les autres.
+| Axe | Flux | Pivot structurel (τ = 0,8) | Betweenness |
+|---|---|---|---|
+| **Position** (`minFret`) | 114 | **5-29** | ≈ 112 (3,5× le deuxième) |
+| **Écart** (`fretSpan`) | 120 | **2-3** | ≈ 185 (2,2× le deuxième) |
 
-Le levier de réglage est le seuil `|r|` noté `τ` (ADR-0004) : à `τ = 0,4`, le maillage
-détendancé reste une clique quasi complète avec des égalités de betweenness
-dégénérées ; augmenter `τ` affine le pivot.
+Les deux pivots sont bien supportés (5-29 : 8 568 voicings ; 2-3 : 2 024) : aucun
+n'est un artefact de profil clairsemé — chacun est la set-class dont le résidu fait le
+plus le pont entre les autres sur cet axe.
+
+### Le balayage de τ : une toile qui se fracture en régions nommées
+
+Le seuil `|r|` noté `τ` est le levier de réglage (ADR-0004). À `τ = 0,8`, chaque axe
+est une seule toile connexe ; augmenter `τ` la fracture, et la démo nomme chaque région
+survivante par la bande de frettes que ses membres *surreprésentent de façon distinctive*
+(l'argmax de leur résidu moyen — ce que le maillage a réellement regroupé, et non le
+pic brut, qui vaut « open » pour presque toutes les set-classes) :
+
+```text
+POSITION :  τ=0,80 → 1 région   τ=0,90 → 2   τ=0,95 → 3   τ=0,98 → 3
+ÉCART :     τ=0,80 → 1 région   τ=0,90 → 3   τ=0,95 → 3   τ=0,98 → 5
+```
+
+Sur l'axe de l'écart, la fracture est la plus parlante : une région **wide** (large)
+dominante détache de petites régions **moderate** (modérée) — p. ex.
+`{3-10, 4-9, 6-33, 6-32}` —, c.-à-d. des grappes de set-classes qui préfèrent un
+écart modéré là où la masse préfère un écart large.
 
 ## Portée et réserves
 

--- a/docs/walkthroughs/voicing-mesh.md
+++ b/docs/walkthroughs/voicing-mesh.md
@@ -15,8 +15,13 @@ cargo run -p ix-duck --example ix_voicing_mesh --features duck
 
 ## The question
 
-> **Which chord set-classes occupy the same fretboard regions, and which set-class
-> is the structural hub of the guitar's voicing geometry?**
+> **Which chord set-classes behave alike along the neck, and which set-class is the
+> structural hub of that geometry?**
+
+The demo answers this for **two axes**, one mesh each:
+
+- **Position** (`minFret`) — *where* on the neck a set-class's voicings sit.
+- **Stretch** (`fretSpan`) — *how ergonomically wide* its shapes are (a difficulty lens).
 
 The corpus (`state/voicings/raw/guitar.jsonl`, ~667 k fingerings, of which 558 k are
 classifiable into 136 Forte set-classes) is read directly with `read_json_auto` — no
@@ -39,7 +44,7 @@ This is the maximal-scope shape of ADR-0004: a graph of **~460 operators** whose
 - The **operator graph** is reified as an `ix_pipeline::dag::Dag` and printed:
 
   ```text
-  read_json_auto ─▶ ix_forte_number (annotate) ─▶ GROUP BY minFret (bin)   [shared head]
+  read_json_auto ─▶ ix_forte_number (annotate) ─▶ GROUP BY <axis> (bin)    [shared head]
     ─▶ profile:k ─▶ normalize:k ─▶ residual:k ─▶ smooth:k                    [×120 streams]
                          └────────▶ common-mode ────────┘                    [barrier]
     ─▶ ix_pearson (N×N) ─▶ |r| ≥ τ ─▶ ix_connected_components ─▶ ix_centrality [shared tail]
@@ -76,20 +81,37 @@ question actually asks.
 > This is the tracer-bullet discipline working as intended: build the thinnest
 > end-to-end slice first, let it surface the unknown, then scale.
 
-## The finding
+## The findings
 
-At `τ = 0.8` over the 114 best-supported set-classes (≥ 1000 voicings each, so every
-fret bin is populated and a sparse profile can't fake a bridge):
+Over the best-supported set-classes (≥ 1000 voicings each, so every bin is populated
+and a sparse profile can't fake a bridge), the two axes give **different hubs** — the
+geometry of *where* chords sit is not the geometry of *how wide* they stretch:
 
-- The set-classes form **one connected fretboard-geometry web** — no isolated chord
-  families; they are all positionally inter-related.
-- **5-29 is the structural hub** — betweenness **≈ 112**, about 3.5× the runner-up,
-  and well-supported (8 568 voicings), so it is not a sparse-profile artifact. It is
-  the set-class whose fretboard-position residual most bridges the others.
+| Axis | Streams | Structural hub (τ = 0.8) | Betweenness |
+|---|---|---|---|
+| **Position** (`minFret`) | 114 | **5-29** | ≈ 112 (3.5× runner-up) |
+| **Stretch** (`fretSpan`) | 120 | **2-3** | ≈ 185 (2.2× runner-up) |
 
-The operating lever is the `|r|` threshold `τ` (ADR-0004): at `τ = 0.4` the de-trended
-mesh is still one near-complete clique with degenerate betweenness ties; raising `τ`
-sharpens the hub.
+Both hubs are well-supported (5-29: 8 568 voicings; 2-3: 2 024), so neither is a
+sparse-profile artifact — each is the set-class whose residual most bridges the others
+on that axis.
+
+### The τ-sweep: one web fracturing into named regions
+
+The `|r|` threshold `τ` is the operating lever (ADR-0004). At `τ = 0.8` each axis is a
+single connected web; raising `τ` fractures it, and the demo names each surviving
+region by the fret-band its members *distinctively over-index on* (the argmax of their
+mean residual — what the mesh actually clustered on, not the raw peak, which is "open"
+for almost every set-class):
+
+```text
+POSITION:  τ=0.80 → 1 region   τ=0.90 → 2   τ=0.95 → 3   τ=0.98 → 3
+STRETCH:   τ=0.80 → 1 region   τ=0.90 → 3   τ=0.95 → 3   τ=0.98 → 5
+```
+
+On the stretch axis the split is the more interesting: a dominant **wide-band** region
+peels off small **moderate-band** regions (e.g. `{3-10, 4-9, 6-33, 6-32}`), i.e.
+clusters of set-classes that prefer a moderate stretch where the bulk prefer wide.
 
 ## Scope and caveats
 


### PR DESCRIPTION
## What

Extends the `ix_voicing_mesh` demo (landed in #171) to get more out of the mesh — the two optional follow-ups from that PR:

1. **Second axis — `fretSpan` (ergonomic stretch)** alongside `minFret` (position). The demo now runs one mesh per axis and reports both.
2. **τ-sweep with named regions** — shows the single web at τ = 0.8 fracturing as τ tightens, naming each surviving region by its distinctive fret-band.

## Findings (the payoff)

The two axes give **different hubs** — where chords sit is not how wide they stretch:

| Axis | Streams | Hub (τ = 0.8) | Betweenness |
|---|---|---|---|
| Position (`minFret`) | 114 | **5-29** | ≈ 112 (3.5×) |
| Stretch (`fretSpan`) | 120 | **2-3** | ≈ 185 (2.2×) |

τ-sweep (regions = connected components of the `|r| ≥ τ` graph):
```
POSITION:  τ=0.80 → 1   τ=0.90 → 2   τ=0.95 → 3   τ=0.98 → 3
STRETCH:   τ=0.80 → 1   τ=0.90 → 3   τ=0.95 → 3   τ=0.98 → 5
```
Regions are named by the band their members *distinctively over-index on* (argmax of mean residual — what the mesh actually clustered on, not the raw peak which is "open" for nearly every set-class). On the stretch axis a dominant **wide-band** region peels off small **moderate-band** clusters (e.g. `{3-10, 4-9, 6-33, 6-32}`).

## How

- `Axis` is a small enum (bin column + bin count + band-namer). Position = `minFret` 0..17; Stretch = `fretSpan` 0..4.
- The τ-sweep recounts components **in-process via union-find from the already-computed correlation matrix** — no re-running the mesh per τ.
- The operator-DAG reification, common-mode removal, and corpus-fallback (full → tracked sample) machinery are unchanged.

## Verification

- `cargo run -p ix-duck --example ix_voicing_mesh --features duck` → both axes run end-to-end (full corpus + the sample-fallback path).
- `cargo clippy -p ix-duck --features duck --all-targets` → clean.
- Docs (EN `docs/walkthroughs/voicing-mesh.md` + FR `docs/fr/pas-a-pas/maillage-voicings.md`) updated with both findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
