### PR TITLE
feat(ix-duck): ix_voicing_similarity — harmonic kNN with a Z-relation oracle

### DIFF
--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -100,6 +100,10 @@ required-features = ["duck"]
 name = "ix_voicing_mesh"
 required-features = ["duck"]
 
+[[example]]
+name = "ix_voicing_similarity"
+required-features = ["duck"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 # For the ix_voicing_mesh example's operator-DAG reification (ADR-0004 "both layered").

--- a/crates/ix-duck/examples/ix_voicing_similarity.rs
+++ b/crates/ix-duck/examples/ix_voicing_similarity.rs
@@ -1,0 +1,144 @@
+//! `ix_voicing_similarity` — harmonic nearest-neighbours over the GA voicing corpus,
+//! with a built-in correctness oracle.
+//!
+//! Question: *given a chord's set-class, what are its harmonically-nearest neighbours by
+//! interval content — and which set-classes in the real repertoire are harmonically
+//! isolated (no close neighbour)?*
+//!
+//! The metric is `ix_icv_l1(a, b)` — the L1 distance between two PC-sets' **interval-class
+//! vectors** (the Grothendieck harmonic cost). Each set-class present in the corpus is one
+//! point; a self-join computes the full N×N distance table on the DuckDB bench.
+//!
+//! **Validation (the analog of the mesh's null model, matched to a *retrieval* demo).**
+//! By music theory, two *distinct* set-classes share an identical ICV iff they are
+//! **Z-related** — so every pair at harmonic distance 0 must satisfy `ix_z_related`. The
+//! demo asserts exactly this against the corpus: if any distance-0 pair were *not*
+//! Z-related, the metric would be unfaithful. The Z-relation is a ground-truth oracle,
+//! not a significance test — the right validation for a similarity/retrieval claim.
+//!
+//! Run: `cargo run -p ix-duck --example ix_voicing_similarity --features duck`
+
+use std::collections::BTreeMap;
+
+use ix_duck::open_bench;
+
+const CORPUS_FULL: &str = "state/voicings/raw/guitar.jsonl";
+const CORPUS_SAMPLE: &str = "state/voicings/guitar-corpus.json";
+
+/// Set-classes to showcase nearest-neighbours for (skipped if absent from the corpus).
+/// 4-Z15 is included on purpose: its nearest neighbour is its Z-partner 4-Z29 at
+/// distance 0 — the Z-relation made visible.
+const QUERIES: [&str; 4] = ["3-11", "4-27", "4-Z15", "5-35"];
+const K: usize = 5;
+
+fn main() -> ix_duck::Result<()> {
+    let conn = open_bench()?;
+    let (corpus, full) = if std::path::Path::new(CORPUS_FULL).exists() {
+        (CORPUS_FULL, true)
+    } else {
+        (CORPUS_SAMPLE, false)
+    };
+    if !full {
+        println!("note: full corpus absent (gitignored, 110 MB) — using the tracked sample.\n");
+    }
+    // Rank isolation only among set-classes common enough to be "really used" — scaled
+    // to the corpus so the sample still surfaces something.
+    let isolation_min_freq: i64 = if full { 500 } else { 5 };
+
+    // Each set-class present in the corpus → a representative PC-set (any voicing's
+    // midiNotes; ICV is a set-class invariant) + its voicing frequency.
+    // The self-join then computes the full harmonic-distance table + Z-relation flags.
+    let sql = format!(
+        "WITH sc AS (
+            SELECT ix_forte_number(midiNotes) AS forte,
+                   any_value(midiNotes)        AS rep,
+                   count(*)                     AS freq
+            FROM read_json_auto('{corpus}')
+            WHERE ix_forte_number(midiNotes) IS NOT NULL
+            GROUP BY ix_forte_number(midiNotes)
+         )
+         SELECT a.forte, a.freq, b.forte, ix_icv_l1(a.rep, b.rep), ix_z_related(a.rep, b.rep)
+         FROM sc a JOIN sc b ON a.forte <> b.forte"
+    );
+
+    let mut freq: BTreeMap<String, i64> = BTreeMap::new();
+    // dist[(a,b)] for a<b (symmetric); pairs with dist==0 carry their z_related flag.
+    let mut neighbours: BTreeMap<String, Vec<(i64, String)>> = BTreeMap::new();
+    let mut zero_pairs: Vec<(String, String, bool)> = Vec::new();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, i64>(1)?,
+            r.get::<_, String>(2)?,
+            r.get::<_, i64>(3)?,
+            r.get::<_, bool>(4)?,
+        ))
+    })?;
+    for row in rows {
+        let (a, fa, b, dist, zrel) = row?;
+        freq.insert(a.clone(), fa);
+        neighbours.entry(a.clone()).or_default().push((dist, b.clone()));
+        if dist == 0 && a < b {
+            zero_pairs.push((a, b, zrel));
+        }
+    }
+    for v in neighbours.values_mut() {
+        v.sort();
+    }
+
+    println!("corpus: {corpus} → {} distinct set-classes\n", freq.len());
+
+    // ── harmonic nearest-neighbours for the showcase queries ─────────────────────
+    println!("harmonic nearest-neighbours (ix_icv_l1 = L1 on the interval-class vector):");
+    for q in QUERIES {
+        let Some(nbrs) = neighbours.get(q) else {
+            println!("   {q:>6}: (absent from this corpus)");
+            continue;
+        };
+        let shown: Vec<String> = nbrs
+            .iter()
+            .take(K)
+            .map(|(d, name)| format!("{name} (d={d})"))
+            .collect();
+        println!("   {q:>6} → {}", shown.join(", "));
+    }
+
+    // ── validation oracle: every distance-0 pair must be Z-related ────────────────
+    let violations: Vec<&(String, String, bool)> = zero_pairs.iter().filter(|(_, _, z)| !z).collect();
+    println!(
+        "\nvalidation — {} distinct-set-class pairs at harmonic distance 0:",
+        zero_pairs.len()
+    );
+    for (a, b, _) in zero_pairs.iter().take(6) {
+        println!("   {a} ≡ {b}  (identical ICV — Z-related)");
+    }
+    if violations.is_empty() {
+        println!("   ✅ ORACLE PASS: every distance-0 pair is ix_z_related (the metric respects the Z-relation ground truth)");
+    } else {
+        println!("   ❌ ORACLE FAIL: {} distance-0 pair(s) are NOT Z-related — the metric is unfaithful:", violations.len());
+        for (a, b, _) in &violations {
+            println!("      {a} ≡ {b} but ix_z_related = false");
+        }
+    }
+
+    // ── harmonic isolation: set-classes whose nearest neighbour is farthest ───────
+    let mut isolation: Vec<(String, i64, i64)> = neighbours
+        .iter()
+        .filter(|(name, _)| freq.get(*name).copied().unwrap_or(0) >= isolation_min_freq)
+        .map(|(name, nbrs)| {
+            let nn = nbrs.first().map(|(d, _)| *d).unwrap_or(i64::MAX);
+            (name.clone(), nn, freq[name])
+        })
+        .collect();
+    isolation.sort_by(|a, b| b.1.cmp(&a.1).then(b.2.cmp(&a.2)));
+    println!(
+        "\nmost harmonically-isolated set-classes (≥{isolation_min_freq} voicings; nn = nearest-neighbour distance):"
+    );
+    for (name, nn, f) in isolation.iter().take(8) {
+        println!("   {name:>6}: nn = {nn}  ({f} voicings)");
+    }
+
+    Ok(())
+}

--- a/docs/fr/pas-a-pas/similarite-voicings.md
+++ b/docs/fr/pas-a-pas/similarite-voicings.md
@@ -1,0 +1,92 @@
+# `ix_voicing_similarity` — plus proches voisins harmoniques sur le corpus de voicings
+
+Une démo exécutable de **recherche par similarité** sur le banc d'analyse DuckDB, dotée
+d'un **oracle de correction** intégré. Compagnon de
+[`maillage-voicings.md`](maillage-voicings.md) (qui fait de la *corrélation/du
+regroupement*) ; celle-ci fait de la *recherche du plus proche voisin + détection
+d'aberrants*.
+
+> _English version: [`docs/walkthroughs/voicing-similarity.md`](../../walkthroughs/voicing-similarity.md)._
+
+```bash
+cargo run -p ix-duck --example ix_voicing_similarity --features duck
+```
+
+## La question
+
+> **Étant donné la set-class d'un accord, quels sont ses plus proches voisins
+> harmoniques par contenu intervallique — et quelles set-classes du répertoire réel sont
+> harmoniquement isolées (sans voisin proche) ?**
+
+Chaque set-class de Forte présente dans le corpus est un point. La distance est
+**`ix_icv_l1(a, b)`** — la distance L1 entre les **vecteurs de classes d'intervalles**
+(ICV) des deux PC-sets (le coût harmonique de Grothendieck). Une seule auto-jointure
+calcule la table N×N complète des distances harmoniques sur le banc ; `ix_forte_number`
+annote et `any_value(midiNotes)` choisit un représentant (l'ICV est un invariant de la
+set-class : n'importe quel voicing d'une set-class donne le même vecteur).
+
+## Plus proches voisins
+
+```text
+ 3-11 → 2-3 (d=2), 2-4 (d=2), 2-5 (d=2), 3-3 (d=2), 3-4 (d=2)
+ 4-27 → 4-12 (d=2), 4-13 (d=2), 4-18 (d=2), 4-26 (d=2), 4-Z15 (d=2)
+4-Z15 → 4-Z29 (d=0), 4-11 (d=2), 4-12 (d=2), 4-13 (d=2), 4-14 (d=2)
+```
+
+Le point fort est `4-Z15` : son **plus proche voisin est `4-Z29` à distance 0**. Ce sont
+les deux **tétracordes tous-intervalles** — des accords distincts au contenu
+intervallique *identique*. La recherche les fait remonter automatiquement, ce que la
+validation formalise précisément.
+
+## Validation — l'oracle de la relation Z
+
+C'est l'analogue du modèle nul du maillage, mais adapté à une démo de *recherche* : au
+lieu d'un test de significativité, un **oracle de correction fondé sur une vérité
+terrain**.
+
+Deux set-classes *distinctes* ont un ICV identique **si et seulement si** elles sont
+**Z-reliées** (même cardinalité + même vecteur d'intervalles, forme première différente).
+Donc **toute paire à distance harmonique 0 doit vérifier `ix_z_related`** — sinon
+`ix_icv_l1` serait infidèle. La démo le vérifie contre le corpus :
+
+```text
+validation — 19 paires de set-classes distinctes à distance harmonique 0 :
+   4-Z15 ≡ 4-Z29,  5-Z12 ≡ 5-Z36,  6-Z29 ≡ 6-Z50,  … (toutes les paires Z hexacordales)
+   ✅ ORACLE PASS : toute paire à distance 0 est ix_z_related
+```
+
+Le compte est lui-même une **correspondance avec la théorie** : le 12-TET compte
+exactement **19 paires Z-reliées** (1 tétracorde + 3 pentacordes + 15 hexacordes). La
+démo récupère l'ensemble *complet* depuis le corpus de guitare — donc chaque set-class
+Z-reliée apparaît bel et bien dans de vrais doigtés — et confirme que `ix_icv_l1` et
+`ix_z_related` concordent sur toutes. C'est à la fois un contrôle externe (les 19, et la
+fameuse `4-Z15/4-Z29`) et un contrôle de cohérence inter-UDF.
+
+## Isolation harmonique
+
+Parmi les set-classes assez courantes pour être « vraiment utilisées » (≥ 500 voicings),
+les plus harmoniquement **isolées** — plus grande distance au plus proche voisin — sont :
+
+```text
+ 5-7 : nn = 4  (10 546 voicings)      5-33 : nn = 4  (4 241 voicings)
+5-31 : nn = 4  ( 7 994 voicings)      4-28 : nn = 3  (1 749 voicings)
+5-15 : nn = 4  ( 4 952 voicings)
+```
+
+Les pentacordes `5-7`, `5-31`, `5-15`, `5-33` sont les plus éloignés de tout le reste par
+contenu intervallique tout en apparaissant des milliers de fois — des accords
+harmoniquement distinctifs que les guitaristes emploient malgré tout.
+
+## Portée et réserves
+
+- **Consultatif uniquement** (comme toutes les lentilles `ix_duck` ; cf. ADR-0002 /
+  ADR-0004) — pas une barrière.
+- L'espace ICV est **dense et quantifié** : les distances sont de petits entiers (nn ∈
+  {2, 3, 4} ici), donc « l'isolation » ne différencie que faiblement. L'oracle (distance
+  0) est exact ; le classement par isolation est un signal doux, pas une partition nette.
+- La métrique est purement harmonique (contenu intervallique) ; elle ignore le
+  voicing/registre/jouabilité. À combiner avec les axes position/écart de
+  `ix_voicing_mesh` pour la vue manche.
+- Le corpus complet est exclu de git (110 Mo) ; sur un dépôt fraîchement cloné, la démo
+  bascule sur l'échantillon suivi de 500 voicings (moins de set-classes, donc moins de
+  paires Z — l'oracle tient toujours).

--- a/docs/walkthroughs/voicing-similarity.md
+++ b/docs/walkthroughs/voicing-similarity.md
@@ -1,0 +1,83 @@
+# `ix_voicing_similarity` — harmonic nearest-neighbours over the voicing corpus
+
+A runnable demo of **similarity retrieval** on the DuckDB analyst bench, with a built-in
+**correctness oracle**. Companion to [`voicing-mesh.md`](voicing-mesh.md) (which does
+*correlation/clustering*); this one does *nearest-neighbour retrieval + outlier scoring*.
+
+> _Version française : [`docs/fr/pas-a-pas/similarite-voicings.md`](../fr/pas-a-pas/similarite-voicings.md)._
+
+```bash
+cargo run -p ix-duck --example ix_voicing_similarity --features duck
+```
+
+## The question
+
+> **Given a chord's set-class, what are its harmonically-nearest neighbours by interval
+> content — and which set-classes in the real repertoire are harmonically isolated (no
+> close neighbour)?**
+
+Each Forte set-class present in the corpus is one point. The distance is **`ix_icv_l1(a, b)`**
+— the L1 distance between the two PC-sets' **interval-class vectors** (the Grothendieck
+harmonic cost). A single self-join computes the full N×N harmonic-distance table on the
+bench; `ix_forte_number` annotates and `any_value(midiNotes)` picks a representative
+(the ICV is a set-class invariant, so any voicing of a set-class gives the same vector).
+
+## Nearest neighbours
+
+```text
+ 3-11 → 2-3 (d=2), 2-4 (d=2), 2-5 (d=2), 3-3 (d=2), 3-4 (d=2)
+ 4-27 → 4-12 (d=2), 4-13 (d=2), 4-18 (d=2), 4-26 (d=2), 4-Z15 (d=2)
+4-Z15 → 4-Z29 (d=0), 4-11 (d=2), 4-12 (d=2), 4-13 (d=2), 4-14 (d=2)
+```
+
+The highlight is `4-Z15`: its **nearest neighbour is `4-Z29` at distance 0**. These are the
+two **all-interval tetrachords** — distinct chord shapes with *identical* interval content.
+The retrieval surfaces that automatically, which is exactly what the validation formalises.
+
+## Validation — the Z-relation oracle
+
+This is the analog of the mesh's null model, but matched to a *retrieval* demo: instead of
+a significance test, a **ground-truth correctness oracle**.
+
+Two *distinct* set-classes have an identical ICV **iff** they are **Z-related** (same
+cardinality + same interval vector, different prime form). So **every pair at harmonic
+distance 0 must be `ix_z_related`** — if any weren't, `ix_icv_l1` would be unfaithful.
+The demo checks this against the corpus:
+
+```text
+validation — 19 distinct-set-class pairs at harmonic distance 0:
+   4-Z15 ≡ 4-Z29,  5-Z12 ≡ 5-Z36,  6-Z29 ≡ 6-Z50,  … (all hexachordal Z-pairs)
+   ✅ ORACLE PASS: every distance-0 pair is ix_z_related
+```
+
+The count is itself a **textbook match**: 12-TET has exactly **19 Z-related pairs** (1
+tetrachord + 3 pentachord + 15 hexachord). The demo recovers the *complete* set from the
+guitar corpus — so every Z-related set-class actually occurs in real fingerings — and
+confirms `ix_icv_l1` and `ix_z_related` agree on all of them. That is both an external
+ground-truth check (the 19, and the famous `4-Z15/4-Z29`) and a cross-UDF consistency check.
+
+## Harmonic isolation
+
+Among set-classes common enough to be "really used" (≥ 500 voicings), the most
+harmonically **isolated** — largest nearest-neighbour distance — are:
+
+```text
+ 5-7: nn = 4  (10 546 voicings)      5-33: nn = 4  (4 241 voicings)
+5-31: nn = 4  ( 7 994 voicings)      4-28: nn = 3  (1 749 voicings)
+5-15: nn = 4  ( 4 952 voicings)
+```
+
+The pentachords `5-7`, `5-31`, `5-15`, `5-33` sit farthest from everything else by
+interval content while still appearing thousands of times — harmonically distinctive
+chords guitarists nonetheless reach for.
+
+## Scope and caveats
+
+- **Advisory only** (like all `ix_duck` lenses; see ADR-0002 / ADR-0004) — not a gate.
+- The ICV space is **dense and quantised**: distances are small integers (nn ∈ {2, 3, 4}
+  here), so "isolation" differentiates only weakly. The oracle (distance 0) is exact; the
+  isolation ranking is a soft signal, not a sharp partition.
+- The metric is harmonic (interval content) only — it ignores voicing/register/playability.
+  Pair it with the position/stretch axes of `ix_voicing_mesh` for the fretboard view.
+- Full corpus is gitignored (110 MB); on a fresh checkout the demo falls back to the
+  tracked 500-voicing sample (fewer set-classes, so fewer Z-pairs — the oracle still holds).


### PR DESCRIPTION
## What

A second voicing-corpus demo (you asked for more "similarly useful" demos) — complementary to `ix_voicing_mesh`: where the mesh does *correlation/clustering*, this does **similarity retrieval + outlier scoring**, and it ships with a built-in **correctness oracle**.

```bash
cargo run -p ix-duck --example ix_voicing_similarity --features duck
```

## Question

> Given a chord's set-class, what are its harmonically-nearest neighbours by interval content — and which set-classes in the real repertoire are harmonically isolated?

Metric: **`ix_icv_l1(a,b)`** — L1 distance on the interval-class vector (Grothendieck harmonic cost). A self-join computes the full N×N harmonic-distance table over set-classes present in the corpus.

## Nearest neighbours

```
4-Z15 → 4-Z29 (d=0), 4-11 (d=2), 4-12 (d=2), ...
```
`4-Z15`'s nearest neighbour is its Z-partner `4-Z29` at distance 0 — the two all-interval tetrachords, surfaced automatically.

## Validation — Z-relation oracle (the key part)

Matched to a *retrieval* demo, the validation is a **ground-truth correctness oracle**, not a significance test. Distinct set-classes share an ICV **iff** Z-related, so every distance-0 pair must be `ix_z_related`:

```
validation — 19 distinct-set-class pairs at harmonic distance 0:
   ✅ ORACLE PASS: every distance-0 pair is ix_z_related
```

The count **19** is a textbook match — 12-TET has exactly 19 Z-related pairs (1 tetrachord + 3 pentachord + 15 hexachord). The demo recovers the *complete* set from the corpus and confirms `ix_icv_l1` ↔ `ix_z_related` agree on all of them (external ground truth + cross-UDF consistency). It **passes** — a satisfying counterpoint to the mesh's stretch axis, which the null model **failed**.

## Isolation finding

Pentachords `5-7`, `5-31`, `5-15`, `5-33` are the most harmonically isolated *common* set-classes (nn=4, thousands of voicings each). Honest caveat: the ICV space is dense (distances are small integers), so isolation is a soft signal, not a sharp partition.

## Verification

- `cargo run -p ix-duck --example ix_voicing_similarity --features duck` → full corpus + sample-fallback both run; oracle passes.
- `cargo clippy -p ix-duck --features duck --all-targets` → clean.
- Docs: EN `docs/walkthroughs/voicing-similarity.md` + FR `docs/fr/pas-a-pas/similarite-voicings.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
