### PR TITLE
feat(ix-duck): ix_code_health — code-health map of the workspace, by IX over IX

### DIFF
--- a/crates/ix-duck/Cargo.toml
+++ b/crates/ix-duck/Cargo.toml
@@ -108,6 +108,10 @@ required-features = ["duck"]
 name = "ix_voicing_similarity"
 required-features = ["duck"]
 
+[[example]]
+name = "ix_code_health"
+required-features = ["duck"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 # For the ix_voicing_mesh example's operator-DAG reification (ADR-0004 "both layered").

--- a/crates/ix-duck/examples/ix_code_health.rs
+++ b/crates/ix-duck/examples/ix_code_health.rs
@@ -1,0 +1,183 @@
+//! `ix_code_health` — a code-health map of the IX workspace, computed by IX over IX.
+//!
+//! Pure dogfood: `read_text('crates/**/*.rs')` streams every Rust source file into the
+//! bench, the `ix_code_*` UDFs score each one (cyclomatic + cognitive complexity, SLOC,
+//! lexical smells), and a GROUP BY rolls them up per crate. No external data — the input
+//! is the repository itself, so it runs on any checkout.
+//!
+//! Three stages:
+//!   1. **Health table** — per-crate complexity + smell density.
+//!   2. **Map** — `ix_pca_project` the standardized per-crate feature vectors to 2-D and
+//!      report the multivariate outliers (crates unlike the rest).
+//!   3. **Validation** — *does code-health predict change-proneness?* Correlate each
+//!      health metric against per-crate git churn, with a permutation null so the answer
+//!      is a measured p-value, not a just-so story. (An external-validity check, matched
+//!      to a *predictive* claim — the analog of the mesh's null model.)
+//!
+//! Run: `cargo run -p ix-duck --example ix_code_health --features duck`
+
+use std::process::Command;
+
+use ix_duck::open_bench;
+use ix_math::inference::pearson;
+
+const NULLS: usize = 2000;
+const SEED: u64 = 0xC0DE_11EA_17C0_DE11;
+
+fn main() -> ix_duck::Result<()> {
+    let conn = open_bench()?;
+
+    // ── 1. per-file scores → per-crate roll-up ───────────────────────────────────
+    let sql = "
+        WITH files AS (
+            SELECT
+                regexp_extract(replace(filename, chr(92), '/'), 'crates/([^/]+)/', 1) AS crate,
+                ix_code_complexity(content, filename) AS cc,
+                CAST(json_extract(ix_code_metrics(content, filename), '$.file_scope.cognitive') AS DOUBLE) AS cog,
+                CAST(json_extract(ix_code_metrics(content, filename), '$.file_scope.sloc') AS DOUBLE) AS sloc,
+                json_array_length(ix_code_smells(content, filename)) AS smells
+            FROM read_text('crates/**/*.rs')
+        )
+        SELECT crate, count(*) AS files, sum(sloc) AS sloc, avg(cc) AS mean_cc,
+               max(cc) AS max_cc, avg(cog) AS mean_cog, sum(smells) AS smells,
+               1000.0 * sum(smells) / nullif(sum(sloc),0) AS smell_density
+        FROM files WHERE crate <> '' GROUP BY crate
+        ORDER BY smell_density DESC NULLS LAST";
+    let mut stmt = conn.prepare(sql)?;
+    let crates: Vec<CrateHealth> = stmt
+        .query_map([], |r| {
+            Ok(CrateHealth {
+                name: r.get(0)?,
+                files: r.get(1)?,
+                sloc: r.get::<_, f64>(2)?,
+                mean_cc: r.get(3)?,
+                max_cc: r.get(4)?,
+                mean_cog: r.get(5)?,
+                smells: r.get(6)?,
+                smell_density: r.get::<_, Option<f64>>(7)?.unwrap_or(0.0),
+            })
+        })?
+        .collect::<Result<_, _>>()?;
+
+    println!(
+        "ix over ix: {} crates, {} files, {:.0} SLOC, {} lexical smells\n",
+        crates.len(),
+        crates.iter().map(|c| c.files).sum::<i64>(),
+        crates.iter().map(|c| c.sloc).sum::<f64>(),
+        crates.iter().map(|c| c.smells).sum::<i64>()
+    );
+    println!("highest smell-density crates (lexical smells per KLOC):");
+    println!("   {:<20} {:>6} {:>7} {:>7} {:>7} {:>11}", "crate", "files", "SLOC", "mean_cc", "mean_cog", "smells/KLOC");
+    for c in crates.iter().take(10) {
+        println!("   {:<20} {:>6} {:>7.0} {:>7.1} {:>7.1} {:>11.1}", c.name, c.files, c.sloc, c.mean_cc, c.mean_cog, c.smell_density);
+    }
+
+    // ── 2. map: ix_pca_project the standardized feature vectors → 2-D ─────────────
+    // Features: complexity (mean/max), cognitive load, smell density, log size.
+    let feats: Vec<Vec<f64>> = crates
+        .iter()
+        .map(|c| vec![c.mean_cc, c.max_cc, c.mean_cog, c.smell_density, (1.0 + c.sloc).ln()])
+        .collect();
+    let z = standardize(&feats);
+    let json = matrix_json(&z);
+    let mut pca = conn.prepare("SELECT row, coords[1], coords[2] FROM ix_pca_project(?, 2) ORDER BY row")?;
+    let coords: Vec<(usize, f64, f64)> = pca
+        .query_map([json], |r| Ok((r.get::<_, i64>(0)? as usize, r.get::<_, f64>(1)?, r.get::<_, f64>(2)?)))?
+        .collect::<Result<_, _>>()?;
+    let mut outliers: Vec<(usize, f64)> = coords.iter().map(|&(i, x, y)| (i, x * x + y * y)).collect();
+    outliers.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    println!("\nix_pca_project health-space map — most multivariate-outlier crates (PC1²+PC2²):");
+    for &(i, d2) in outliers.iter().take(8) {
+        println!("   {:<20} dist {:.2}  (mean_cc {:.1}, smells/KLOC {:.1})", crates[i].name, d2.sqrt(), crates[i].mean_cc, crates[i].smell_density);
+    }
+
+    // ── 3. validation: does code-health predict churn? ───────────────────────────
+    // churn = commits touching crates/<name>/; normalize by size (per KLOC) so the test
+    // isn't just "bigger crates change more".
+    let churn_per_kloc: Vec<f64> = crates
+        .iter()
+        .map(|c| churn(&c.name) as f64 / (c.sloc / 1000.0).max(0.1))
+        .collect();
+    println!("\nvalidation — does code-health predict git churn (commits/KLOC)? [{NULLS} permutation nulls]");
+    for (label, pred) in [
+        ("mean cyclomatic", crates.iter().map(|c| c.mean_cc).collect::<Vec<_>>()),
+        ("smell density", crates.iter().map(|c| c.smell_density).collect::<Vec<_>>()),
+    ] {
+        let r = pearson(&pred, &churn_per_kloc).unwrap_or(0.0);
+        let p = perm_p(&pred, &churn_per_kloc, r, SEED ^ label.len() as u64);
+        let verdict = if p < 0.05 { "predictive" } else { "NOT predictive (within null)" };
+        println!("   {label:<16}: r = {r:+.3}  p = {p:.4}  → {verdict}");
+    }
+
+    Ok(())
+}
+
+struct CrateHealth {
+    name: String,
+    files: i64,
+    sloc: f64,
+    mean_cc: f64,
+    max_cc: f64,
+    mean_cog: f64,
+    smells: i64,
+    smell_density: f64,
+}
+
+/// Commits in history touching `crates/<crate>/`.
+fn churn(crate_name: &str) -> i64 {
+    Command::new("git")
+        .args(["rev-list", "--count", "HEAD", "--", &format!("crates/{crate_name}/")])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Column-wise z-score standardization (mean 0, unit variance; constant column → 0).
+fn standardize(m: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let (n, d) = (m.len(), m[0].len());
+    let mut out = vec![vec![0.0; d]; n];
+    for j in 0..d {
+        let col: Vec<f64> = m.iter().map(|r| r[j]).collect();
+        let mean = col.iter().sum::<f64>() / n as f64;
+        let var = col.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64;
+        let sd = var.sqrt();
+        for i in 0..n {
+            out[i][j] = if sd > 0.0 { (m[i][j] - mean) / sd } else { 0.0 };
+        }
+    }
+    out
+}
+
+fn matrix_json(m: &[Vec<f64>]) -> String {
+    let rows: Vec<String> = m
+        .iter()
+        .map(|r| format!("[{}]", r.iter().map(|x| format!("{x:.6}")).collect::<Vec<_>>().join(",")))
+        .collect();
+    format!("[{}]", rows.join(","))
+}
+
+/// Two-sided permutation p-value: fraction of label-shuffled correlations with
+/// |r_null| ≥ |r_real|. Deterministic (seeded xorshift), so the p is reproducible.
+fn perm_p(x: &[f64], y: &[f64], r_real: f64, seed: u64) -> f64 {
+    let mut rng = seed | 1;
+    let mut next = || {
+        rng ^= rng << 13;
+        rng ^= rng >> 7;
+        rng ^= rng << 17;
+        rng
+    };
+    let mut yp = y.to_vec();
+    let mut ge = 0usize;
+    for _ in 0..NULLS {
+        for i in (1..yp.len()).rev() {
+            let j = (next() % (i as u64 + 1)) as usize;
+            yp.swap(i, j);
+        }
+        if pearson(x, &yp).map(|r| r.abs() >= r_real.abs()).unwrap_or(false) {
+            ge += 1;
+        }
+    }
+    (1 + ge) as f64 / (NULLS + 1) as f64
+}

--- a/docs/fr/pas-a-pas/sante-code.md
+++ b/docs/fr/pas-a-pas/sante-code.md
@@ -1,0 +1,76 @@
+# `ix_code_health` — une carte de santé du code de l'espace de travail IX, par IX sur IX
+
+Une démo exécutable qui transforme l'arbre source d'IX lui-même en un jeu de données de
+santé du code interrogeable sur le banc DuckDB — **pur dogfood**, sans données externes,
+exécutable sur n'importe quel dépôt cloné.
+
+> _English version: [`docs/walkthroughs/code-health.md`](../../walkthroughs/code-health.md)._
+
+```bash
+cargo run -p ix-duck --example ix_code_health --features duck
+```
+
+## La question
+
+> **Quelles crates sont des aberrations de santé — et la santé du code prédit-elle la
+> propension au changement (churn git) ?**
+
+`read_text('crates/**/*.rs')` diffuse chaque fichier Rust dans le banc ; les UDF
+`ix_code_*` notent chacun (complexité cyclomatique + cognitive, SLOC, smells lexicaux) ;
+un `GROUP BY` agrège par crate. 79 crates, 632 fichiers, ~154 k SLOC — le tout analysé
+en une seule requête.
+
+## Trois étapes
+
+**1. Table de santé.** Complexité et densité de smells par crate. Les têtes de densité
+de smells (`ix-net`, `ix-bracelet`, `ix-manifold`, `ix-dynamics`, `ix-fractal`) sont
+toutes des **crates mathématiques** — un indice que la densité de smells lexicaux mesure
+en partie la *densité de littéraux numériques*, pas la « mauvaise santé ». C'est
+précisément ce biais que l'étape 3 teste.
+
+**2. Carte.** `ix_pca_project` réduit les vecteurs de caractéristiques standardisés par
+crate `[mean_cc, max_cc, mean_cog, smell_density, ln SLOC]` en 2-D ; les crates les plus
+éloignées du centroïde sont les aberrations multivariées :
+
+```text
+ix-duck-ext  dist 9,74  (mean_cc 65,9 — l'extension C-API riche en macros)
+ix-agent     dist 5,64
+ix-net       dist 4,26  (smells/KLOC 468)
+```
+
+**3. Validation — la santé prédit-elle le churn ?** Le churn git par crate (commits
+touchant `crates/<name>/`, normalisé en commits/KLOC pour que le test ne soit pas
+simplement « les grandes crates changent plus ») est corrélé à chaque métrique de santé,
+avec **2 000 permutations nulles** pour la significativité (l'analogue du modèle nul du
+maillage — un contrôle de validité externe adapté à une affirmation *prédictive*) :
+
+| Prédicteur | r vs churn/KLOC | p (permutation) | Verdict |
+|---|---|---|---|
+| cyclomatique moyen | −0,15 | 0,18 | **non prédictif** |
+| densité de smells | −0,12 | 0,30 | **non prédictif** |
+
+## Le résultat (un négatif honnête)
+
+**Ni la complexité ni la densité de smells lexicaux ne prédisent le churn dans cet espace
+de travail** — les deux corrélations sont dans la plage du modèle nul, et même légèrement
+*négatives*. Le signe négatif colle à l'indice de l'étape 1 : la densité de smells suit
+surtout la lourdeur mathématique, et ces crates de noyaux numériques (`ix-bracelet`,
+`ix-manifold`, …) sont *matures et stables*, pas churny. Le résultat actionnable est donc :
+**n'utilisez pas ces smells lexicaux comme proxy de risque de changement ici** — ils n'ont
+aucune validité externe mesurée pour le churn.
+
+Un négatif qui survit à un modèle nul vaut plus qu'un positif qui n'en a jamais affronté.
+
+## Portée et réserves
+
+- **Consultatif uniquement** — une *lentille* de santé, pas une barrière.
+- `ix_code_smells` est **lexical** (heuristique : TODO, nombres magiques, lignes
+  longues, …), donc la densité est bruitée et biaisée par le domaine (le code
+  mathématique en déclenche davantage). Le palier B (`code-semantic`, tree-sitter)
+  l'affinerait.
+- Le churn est aussi déterminé par l'**âge de la crate**, non contrôlé ici — une crate
+  récente a peu de commits quelle que soit sa santé. Avec n = 79 crates, le test est peu
+  puissant ; lire le négatif comme « aucun signal *détectable* », pas « indépendance
+  prouvée ».
+- Les données sont le dépôt lui-même : pas de repli sur échantillon — la démo tourne
+  partout où `git` et l'arbre source sont présents.

--- a/docs/walkthroughs/code-health.md
+++ b/docs/walkthroughs/code-health.md
@@ -1,0 +1,70 @@
+# `ix_code_health` — a code-health map of the IX workspace, computed by IX over IX
+
+A runnable demo that turns IX's own source tree into a queryable code-health dataset on
+the DuckDB bench — **pure dogfood**, no external data, runs on any checkout.
+
+> _Version française : [`docs/fr/pas-a-pas/sante-code.md`](../fr/pas-a-pas/sante-code.md)._
+
+```bash
+cargo run -p ix-duck --example ix_code_health --features duck
+```
+
+## The question
+
+> **Which crates are health outliers — and does code-health predict change-proneness
+> (git churn)?**
+
+`read_text('crates/**/*.rs')` streams every Rust file into the bench; the `ix_code_*`
+UDFs score each (cyclomatic + cognitive complexity, SLOC, lexical smells); a `GROUP BY`
+rolls them up per crate. 79 crates, 632 files, ~154 k SLOC — all analysed in one query.
+
+## Three stages
+
+**1. Health table.** Per-crate complexity and smell density. The smell-density leaders
+(`ix-net`, `ix-bracelet`, `ix-manifold`, `ix-dynamics`, `ix-fractal`) are all **math
+crates** — a hint that lexical smell density partly measures *numeric-literal density*,
+not "unhealthiness". That confound is exactly what stage 3 tests.
+
+**2. Map.** `ix_pca_project` reduces the standardized per-crate feature vectors
+`[mean_cc, max_cc, mean_cog, smell_density, ln SLOC]` to 2-D; the crates farthest from
+the centroid are the multivariate outliers:
+
+```text
+ix-duck-ext  dist 9.74  (mean_cc 65.9 — the macro-heavy C-API extension)
+ix-agent     dist 5.64
+ix-net       dist 4.26  (smells/KLOC 468)
+```
+
+**3. Validation — does health predict churn?** Per-crate git churn (commits touching
+`crates/<name>/`, normalized to commits/KLOC so the test isn't just "bigger crates change
+more") is correlated against each health metric, with **2 000 permutation nulls** for
+significance (the analog of the mesh's null model — an external-validity check matched to
+a *predictive* claim):
+
+| Predictor | r vs churn/KLOC | p (permutation) | Verdict |
+|---|---|---|---|
+| mean cyclomatic | −0.15 | 0.18 | **not predictive** |
+| smell density | −0.12 | 0.30 | **not predictive** |
+
+## The finding (an honest negative)
+
+**Neither complexity nor lexical smell density predicts churn in this workspace** — both
+correlations are within the null range, and even slightly *negative*. The negative sign
+fits the stage-1 hint: smell density mostly tracks math-heaviness, and those numeric-kernel
+crates (`ix-bracelet`, `ix-manifold`, …) are *mature and stable*, not churny. So the
+actionable result is: **don't use these lexical smells as a change-risk proxy here** — they
+have no measured external validity for churn.
+
+A negative that survives a null model is worth more than a positive that never faced one.
+
+## Scope and caveats
+
+- **Advisory only** — a health *lens*, not a gate.
+- `ix_code_smells` is **lexical** (heuristic: TODOs, magic numbers, long lines, …), so
+  density is noisy and confounded by domain (math code trips more). Tier B
+  (`code-semantic`, tree-sitter) would sharpen it.
+- Churn is also driven by **crate age**, which this doesn't control for — a newer crate
+  has few commits regardless of health. With n = 79 crates the test is low-powered; read
+  the negative as "no *detectable* signal", not "proven independence".
+- The data is the repo itself, so there's no corpus fallback — it runs anywhere `git` +
+  the source tree are present.


### PR DESCRIPTION
## What

A third demo (the "code-health map" candidate) — and the most operationally useful, because it ends in an **actionable negative**. Pure dogfood: IX analyzes its own 77-crate source tree on the DuckDB bench. No external data, runs on any checkout.

```bash
cargo run -p ix-duck --example ix_code_health --features duck
```

## Pipeline

`read_text('crates/**/*.rs')` → `ix_code_complexity` / `ix_code_metrics` / `ix_code_smells` per file → `GROUP BY` per crate (79 crates, 632 files, ~154k SLOC, all in one query).

1. **Health table** — per-crate complexity + smell density. Leaders are all math crates (`ix-net`, `ix-bracelet`, `ix-manifold`…) — a confound: lexical smell density tracks numeric-literal density, not "unhealthiness".
2. **Map** — `ix_pca_project` reduces standardized per-crate feature vectors to 2-D; top outliers are `ix-duck-ext` (macro-heavy C-API ext), `ix-agent`, `ix-net`.
3. **Validation** — does health predict churn? Per-crate git churn (commits/KLOC) vs each metric, with **2000 permutation nulls**.

## Finding (honest negative)

| Predictor | r vs churn/KLOC | p (perm) | Verdict |
|---|---|---|---|
| mean cyclomatic | −0.15 | 0.18 | not predictive |
| smell density | −0.12 | 0.30 | not predictive |

**Neither complexity nor lexical smell density predicts churn here** — both within the null, even slightly negative (math crates are smell-dense but stable). The actionable result: **don't use these lexical smells as a change-risk proxy.** A negative that survives a null model beats a positive that never faced one.

## Validation philosophy (the throughline)

Match the validation to the claim type: the mesh's *discovery* claim got a null model; the similarity demo's *retrieval* claim got a correctness oracle; this *predictive* claim gets an **external-validity** test (does it predict an independent signal — churn?). All three ship with their check.

## Caveats (in the docs)

Lexical smells are noisy/domain-confounded (Tier B tree-sitter would sharpen); churn is also age-driven (uncontrolled); n=79 is low-powered → read as "no *detectable* signal".

## Verification

- `cargo run -p ix-duck --example ix_code_health --features duck` → runs on the repo.
- `cargo clippy -p ix-duck --features duck --all-targets` → clean.
- Docs: EN `docs/walkthroughs/code-health.md` + FR `docs/fr/pas-a-pas/sante-code.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
