### PR TITLE
feat(ix-agent): mesh_correlate skill — in-pipeline correlation-mesh fan-in

### DIFF
--- a/crates/ix-agent/examples/ix_pipeline_mesh_hub.rs
+++ b/crates/ix-agent/examples/ix_pipeline_mesh_hub.rs
@@ -1,0 +1,116 @@
+//! `ix_pipeline_mesh_hub` — correlation + centrality computed **inside** an executable
+//! pipeline, via the `mesh_correlate` fan-in skill.
+//!
+//! Companion to `ix_pipeline_mesh` (the pairwise tier, Option C of the plan): there the
+//! hub was read back in the harness, because a spec can't threshold edges at build time.
+//! `mesh_correlate` does the |Pearson| ≥ τ thresholding + betweenness centrality at run
+//! time inside one executor node (Option A), so the hub is computed *by the pipeline*.
+//!
+//!   mesh    = mesh_correlate(streams, τ)          → {correlation, centrality, hub, …}
+//!   summary = stats({from: mesh.centrality})      → spread of the centrality scores
+//!
+//! Validation: a planted hub-and-spoke — one hub correlated with K orthogonal spokes
+//! (so spokes are mutually uncorrelated); the executed mesh must return the hub.
+//!
+//! (Why streams are passed to `mesh_correlate` directly rather than through N per-stream
+//! stages: the obvious cond, `autocorrelation`, distorts correlation structure — every
+//! ACF shares the lag-0 = 1 spike, so unrelated streams correlate. A correlation-preserving
+//! identity cond skill would restore the N-per-stream-pipeline shape; see the plan.)
+//!
+//! Run: `cargo run -p ix-agent --example ix_pipeline_mesh_hub`
+
+use std::collections::{BTreeMap, HashMap};
+
+use ix_agent as _; // force-link the skill registry
+use ix_pipeline::executor::{execute, NoCache};
+use ix_pipeline::lower::lower;
+use ix_pipeline::spec::{PipelineSpec, StageSpec};
+use serde_json::{json, Value};
+
+const N: usize = 40;
+const SPOKES: usize = 3; // indices 1..=SPOKES; HUB = 0; the rest are distractors
+const HUB: usize = 0;
+const THRESHOLD: f64 = 0.4;
+
+fn main() {
+    let streams = planted_hub_and_spoke();
+
+    // Stage 1: mesh_correlate (the fan-in). Stage 2: stats over its centrality vector —
+    // a downstream consumer, proving the mesh output flows on through the pipeline.
+    let mut stages: BTreeMap<String, StageSpec> = BTreeMap::new();
+    stages.insert(
+        "mesh".into(),
+        stage("mesh_correlate", json!({ "series": streams, "threshold": THRESHOLD })),
+    );
+    stages.insert(
+        "summary".into(),
+        stage("stats", json!({ "data": { "from": "mesh.centrality" } })),
+    );
+    let spec = PipelineSpec { version: "1".into(), params: BTreeMap::new(), stages, x_editor: Value::Null };
+
+    let dag = lower(&spec).expect("lower");
+    println!(
+        "executable mesh (in-pipeline centrality) — {} streams → {} nodes, {} levels",
+        N,
+        dag.node_count(),
+        dag.parallel_levels().len()
+    );
+
+    let result = execute(&dag, &HashMap::new(), &NoCache).expect("execute");
+    println!("✓ executed {} nodes through ix_pipeline::executor\n", result.node_results.len());
+
+    let mesh = result.output("mesh").expect("mesh output");
+    let hub = mesh.get("hub").and_then(Value::as_u64).unwrap_or(0) as usize;
+    let centrality: Vec<f64> = mesh
+        .get("centrality")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().map(|v| v.as_f64().unwrap_or(0.0)).collect())
+        .unwrap_or_default();
+    let mut ranked: Vec<(usize, f64)> = centrality.iter().copied().enumerate().collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+
+    println!("mesh_correlate betweenness (top 5), computed in-pipeline:");
+    for (i, c) in ranked.iter().take(5) {
+        let tag = if *i == HUB { "  ← planted hub" } else if (1..=SPOKES).contains(i) { "  (spoke)" } else { "" };
+        println!("   stream {i:>3}: {c:.2}{tag}");
+    }
+    // The downstream stage saw the same vector.
+    if let Some(s) = result.output("summary") {
+        println!("\ndownstream `stats` over the centrality vector: mean={}, max={}", s.get("mean").unwrap_or(&Value::Null), s.get("max").unwrap_or(&Value::Null));
+    }
+    println!(
+        "\nvalidation — mesh node returned hub = {hub}; planted hub = {HUB}  →  {}",
+        if hub == HUB { "✓ RECOVERED (centrality computed inside the executed pipeline)" } else { "✗ not recovered" }
+    );
+}
+
+/// HUB = mean of SPOKES orthogonal tones (correlates ~1/√K with each); the rest are
+/// independent pure-noise distractors (uncorrelated → isolated, betweenness 0).
+fn planted_hub_and_spoke() -> Vec<Vec<f64>> {
+    let len = 256;
+    let tone = |freq: f64, seed: u64| -> Vec<f64> {
+        (0..len)
+            .map(|t| (2.0 * std::f64::consts::PI * freq * t as f64 / len as f64).sin() + noise(t, seed))
+            .collect()
+    };
+    let spokes: Vec<Vec<f64>> = (0..SPOKES).map(|k| tone(2.0 + k as f64, 100 + k as u64)).collect();
+    let mut streams: Vec<Vec<f64>> = Vec::with_capacity(N);
+    streams.push((0..len).map(|t| spokes.iter().map(|s| s[t]).sum::<f64>() / SPOKES as f64).collect());
+    streams.extend(spokes);
+    for i in (SPOKES + 1)..N {
+        streams.push((0..len).map(|t| noise(t, 9000 + i as u64)).collect());
+    }
+    streams
+}
+
+fn noise(t: usize, seed: u64) -> f64 {
+    let mut x = (t as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ seed.wrapping_mul(0xD1B5_4A32_D192_ED03);
+    x ^= x >> 33;
+    x = x.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    x ^= x >> 33;
+    (x as f64 / u64::MAX as f64 - 0.5) * 0.6
+}
+
+fn stage(skill: &str, args: Value) -> StageSpec {
+    StageSpec { skill: skill.into(), args, deps: vec![], cache: None }
+}

--- a/crates/ix-agent/src/handlers.rs
+++ b/crates/ix-agent/src/handlers.rs
@@ -902,6 +902,50 @@ pub fn autocorrelation(params: Value) -> Result<Value, String> {
     }))
 }
 
+// @ai:invariant mesh_correlate builds the |Pearson| >= threshold graph over N equal-length series and returns betweenness centrality + connected components; a hub-and-spoke input (one stream correlated with several mutually-uncorrelated others) ranks the hub highest [T:test conf:0.85 src:skills::batch2::tests::mesh_correlate_finds_hub]
+pub fn mesh_correlate(params: Value) -> Result<Value, String> {
+    use ix_graph::graph::Graph;
+    let series = parse_f64_matrix(&params, "series")?;
+    let threshold = parse_f64_opt(&params, "threshold", 0.5);
+    let n = series.len();
+    if n < 2 {
+        return Err("mesh_correlate: need at least 2 series".into());
+    }
+    // Pairwise Pearson → threshold edges → graph. The thresholding happens here at run
+    // time (a pipeline spec can't threshold edges at build time), which is exactly why
+    // this fan-in is a skill: it turns N stream features into one correlation graph.
+    let mut corr = vec![vec![0.0f64; n]; n];
+    let mut g = Graph::with_nodes(n);
+    for i in 0..n {
+        corr[i][i] = 1.0;
+        for j in (i + 1)..n {
+            // A constant series makes Pearson undefined → treat as r = 0 (no edge).
+            let r = ix_math::inference::pearson(&series[i], &series[j]).unwrap_or(0.0);
+            corr[i][j] = r;
+            corr[j][i] = r;
+            if r.abs() >= threshold {
+                g.add_undirected_edge(i, j, 1.0);
+            }
+        }
+    }
+    let centrality = g.betweenness_centrality();
+    let components = g.connected_components();
+    let hub = centrality
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    Ok(json!({
+        "correlation": corr,
+        "centrality": centrality,
+        "components": components,
+        "hub": hub,
+        "threshold": threshold,
+        "n_streams": n,
+    }))
+}
+
 // ── ix_tsne ────────────────────────────────────────────────
 
 pub fn tsne(params: Value) -> Result<Value, String> {

--- a/crates/ix-agent/src/skills/batch2.rs
+++ b/crates/ix-agent/src/skills/batch2.rs
@@ -697,6 +697,29 @@ pub fn graph(p: Value) -> Result<Value, String> {
     handlers::graph_ops(p)
 }
 
+// ---- mesh_correlate ------------------------------------------------------
+fn mesh_correlate_schema() -> Value {
+    object(
+        vec![
+            ("series", Prop::num_matrix().desc("N equal-length real series (one row each)")),
+            ("threshold", Prop::number().desc("|Pearson r| edge threshold (default 0.5)")),
+        ],
+        &["series"],
+    )
+}
+/// Correlation-mesh fan-in: |Pearson| ≥ threshold graph over N series → betweenness
+/// centrality + connected components + the hub. The pipeline-mesh aggregation as a single
+/// node (the thresholding a spec can't do at build time).
+#[ix_skill(
+    domain = "graph",
+    name = "mesh_correlate",
+    governance = "deterministic",
+    schema_fn = "crate::skills::batch2::mesh_correlate_schema"
+)]
+pub fn mesh_correlate(p: Value) -> Result<Value, String> {
+    handlers::mesh_correlate(p)
+}
+
 // ---- hyperloglog ---------------------------------------------------------
 fn hyperloglog_schema() -> Value {
     object(
@@ -787,4 +810,28 @@ fn governance_policy_schema() -> Value {
 )]
 pub fn governance_policy(p: Value) -> Result<Value, String> {
     handlers::governance_policy(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn mesh_correlate_finds_hub() {
+        // Hub-and-spoke: orthogonal spokes p,q,r (mutually uncorrelated) + a hub
+        // h = p+q+r correlated with each. Under |r| >= 0.4, h connects to all three
+        // spokes while the spokes don't connect to each other → h is the betweenness hub.
+        let p = [2.0, -2.0, 0.0, 0.0, 0.0, 0.0];
+        let q = [0.0, 0.0, 2.0, -2.0, 0.0, 0.0];
+        let r = [0.0, 0.0, 0.0, 0.0, 2.0, -2.0];
+        let h: Vec<f64> = (0..6).map(|i| p[i] + q[i] + r[i]).collect();
+        let out = mesh_correlate(json!({
+            "series": [h, p, q, r],   // hub at index 0
+            "threshold": 0.4
+        }))
+        .expect("mesh_correlate");
+        assert_eq!(out["hub"], json!(0), "the hub (index 0) must rank highest by betweenness");
+        assert_eq!(out["n_streams"], json!(4));
+    }
 }

--- a/crates/ix-agent/tests/parity.rs
+++ b/crates/ix-agent/tests/parity.rs
@@ -82,6 +82,7 @@ const EXPECTED: &[&str] = &[
     "ix_pca",
     "ix_silhouette",
     "ix_markov",
+    "ix_mesh_correlate",
     "ix_ml_pipeline",
     "ix_ml_predict",
     "ix_nl_to_pipeline",
@@ -201,9 +202,11 @@ fn parity_expected_count() {
     //   agent-native parity with the sentrux_gate_writer binary) = 92.
     // + ix_annotations_scan (2026-05-24, @ai annotation extract+reconcile scan,
     //   agent-native parity with the ix-ai-annotations reconcile binary) = 93.
+    // + mesh_correlate (2026-06-23, correlation-mesh fan-in for executable pipeline
+    //   meshes — |Pearson|≥τ graph → betweenness + components) = 94.
     // If this drifts, update both EXPECTED and this assertion in the
     // same commit.
-    assert_eq!(EXPECTED.len(), 93);
+    assert_eq!(EXPECTED.len(), 94);
 }
 
 #[test]
@@ -314,6 +317,7 @@ fn parity_batch2_tools_are_registry_backed() {
         "gradient_boosting",
         "supervised",
         "graph",
+        "mesh_correlate",
         "hyperloglog",
         "governance.check",
         "governance.persona",
@@ -343,8 +347,8 @@ fn parity_all_43_registry_backed() {
     //   analysis skills) = 65.
     let registry_count = ix_registry::count();
     assert_eq!(
-        registry_count, 65,
-        "expected 65 registry skills, got {registry_count}"
+        registry_count, 66,
+        "expected 66 registry skills, got {registry_count}"
     );
 }
 

--- a/docs/fr/pas-a-pas/mesh-correlate-skill.md
+++ b/docs/fr/pas-a-pas/mesh-correlate-skill.md
@@ -1,0 +1,61 @@
+# `mesh_correlate` — le skill de réduction (fan-in) maillage-corrélation dans le pipeline
+
+Un skill `ix-agent` enregistré (`#[ix_skill] name = "mesh_correlate"`) qui transforme N
+séries en un graphe de corrélation **à l'intérieur d'un pipeline exécutable**, calculant la
+centralité là où un spec ne le pourrait pas autrement.
+
+> _English version: [`docs/walkthroughs/mesh-correlate-skill.md`](../../walkthroughs/mesh-correlate-skill.md)._
+
+## Pourquoi il existe
+
+La démo de maillage exécutable ([`ix_pipeline_mesh`](maillage-pipeline-executable.md), plan
+`docs/plans/2026-06-23-executable-pipeline-mesh.md`) a révélé une vraie limite : un
+`PipelineSpec` **ne peut pas seuiller les arêtes au moment de la construction** (les poids
+sont des valeurs d'exécution), donc le regroupement/la centralité du maillage devaient être
+calculés dans le harnais. `mesh_correlate` comble cet écart — il fait le seuillage
+`|Pearson| ≥ τ` **et** la centralité d'intermédiarité à l'exécution, dans un seul nœud de
+réduction (Option A du plan).
+
+```
+mesh_correlate({ series: [[…],[…],…], threshold: τ })
+  → { correlation: N×N, centrality: [betweenness…], components: […], hub, n_streams }
+```
+
+Il enveloppe `ix_math::inference::pearson` + `ix_graph::graph::Graph`
+(`betweenness_centrality`, `connected_components`) — pas de nouvel algorithme, juste la
+forme de réduction en tant que skill.
+
+## Dans un pipeline
+
+`crates/ix-agent/examples/ix_pipeline_mesh_hub.rs` :
+
+```text
+mesh    = mesh_correlate(streams, τ=0.4)   → {centrality, hub, …}
+summary = stats({from: mesh.centrality})   → dispersion des scores
+✓ executed 2 nodes through ix_pipeline::executor
+```
+
+Validation — un **moyeu-et-rayons** (hub-and-spoke) planté (un moyeu = moyenne de 3 rayons
+orthogonaux, plus des distracteurs de bruit pur). Le maillage exécuté retourne le moyeu :
+
+```text
+stream 0: 3.00  ← planted hub        stream 1: 0.00 (spoke)   …distractors: 0.00
+hub = 0; planted hub = 0  →  ✓ RECOVERED (centralité calculée dans le pipeline exécuté)
+```
+
+L'étape `stats` en aval consomme `mesh.centrality`, donc le résultat du maillage circule
+dans le pipeline comme toute autre sortie d'étape.
+
+## Portée et réserves
+
+- C'est la réduction **Option A** (maillage dans un nœud), complémentaire de l'Option C de
+  `ix_pipeline_mesh` (le maillage par paires explicite à 100+ nœuds). Ensemble, elles
+  montrent le compromis : un DAG de maillage explicite vs. la centralité dans le pipeline.
+- L'exemple passe les séries directement à `mesh_correlate` plutôt que par N étapes de
+  conditionnement par flux, car le cond évident (`autocorrelation`) déforme la corrélation
+  (chaque ACF partage le pic au lag 0 = 1). Un skill de conditionnement *identité*
+  préservant la corrélation restaurerait la forme N-pipelines-par-flux — un suivi.
+- Un moyeu de betweenness nécessite une structure **moyeu-et-rayons** ; un ensemble de flux
+  mutuellement corrélés est une clique sans moyeu (la même leçon que le maillage de
+  voicings).
+- Consultatif/illustratif, comme les autres démos de maillage.

--- a/docs/walkthroughs/mesh-correlate-skill.md
+++ b/docs/walkthroughs/mesh-correlate-skill.md
@@ -1,0 +1,58 @@
+# `mesh_correlate` — the in-pipeline correlation-mesh fan-in skill
+
+A registered `ix-agent` skill (`#[ix_skill] name = "mesh_correlate"`) that turns N series
+into a correlation graph **inside an executable pipeline**, computing centrality where a
+spec otherwise couldn't.
+
+> _Version française : [`docs/fr/pas-a-pas/mesh-correlate-skill.md`](../fr/pas-a-pas/mesh-correlate-skill.md)._
+
+## Why it exists
+
+The executable-mesh demo ([`ix_pipeline_mesh`](executable-pipeline-mesh.md), plan
+`docs/plans/2026-06-23-executable-pipeline-mesh.md`) found a real limit: a `PipelineSpec`
+**can't threshold edges at build time** (the weights are run-time values), so the mesh's
+clustering/centrality had to be computed back in the harness. `mesh_correlate` closes that
+gap — it does the `|Pearson| ≥ τ` thresholding **and** betweenness centrality at run time,
+in one fan-in node (Option A of the plan).
+
+```
+mesh_correlate({ series: [[…],[…],…], threshold: τ })
+  → { correlation: N×N, centrality: [betweenness…], components: […], hub, n_streams }
+```
+
+It wraps `ix_math::inference::pearson` + `ix_graph::graph::Graph` (`betweenness_centrality`,
+`connected_components`) — no new algorithm, just the fan-in shape as a skill.
+
+## In a pipeline
+
+`crates/ix-agent/examples/ix_pipeline_mesh_hub.rs`:
+
+```text
+mesh    = mesh_correlate(streams, τ=0.4)   → {centrality, hub, …}
+summary = stats({from: mesh.centrality})   → spread of the scores
+✓ executed 2 nodes through ix_pipeline::executor
+```
+
+Validation — a planted **hub-and-spoke** (one hub = mean of 3 orthogonal spokes, plus pure
+-noise distractors). The executed mesh returns the hub:
+
+```text
+stream 0: 3.00  ← planted hub        stream 1: 0.00 (spoke)   …distractors: 0.00
+hub = 0; planted hub = 0  →  ✓ RECOVERED (centrality computed inside the executed pipeline)
+```
+
+The downstream `stats` stage consumes `mesh.centrality`, so the mesh result flows on
+through the pipeline like any other stage output.
+
+## Scope and caveats
+
+- This is the **Option A** fan-in (mesh in one node), complementing `ix_pipeline_mesh`'s
+  Option C (the explicit 100+ node pairwise mesh). Together they show the tradeoff: an
+  explicit mesh DAG vs. in-pipeline centrality.
+- The example passes streams to `mesh_correlate` directly rather than through N per-stream
+  cond stages, because the obvious cond (`autocorrelation`) distorts correlation (every ACF
+  shares the lag-0 = 1 spike). A correlation-preserving *identity* cond skill would restore
+  the N-per-stream-pipeline shape — a follow-up.
+- A betweenness hub needs **hub-and-spoke** structure; a set of mutually-correlated streams
+  is a clique with no hub (the same lesson as the voicing mesh).
+- Advisory/illustrative, like the other mesh demos.


### PR DESCRIPTION
## What

The `mesh_correlate` fan-in skill — the follow-up from #177's plan. It makes the executable mesh's **centrality computable inside the pipeline**, closing the limitation #177 surfaced (a `PipelineSpec` can't threshold edges at build time).

```
mesh_correlate({ series: [[…],…], threshold: τ })
  → { correlation, centrality (betweenness), components, hub, n_streams }
```

Wraps `ix_math::inference::pearson` + `ix_graph` (`betweenness_centrality`, `connected_components`) — no new algorithm, just the fan-in shape as a registered skill (Option A of the plan).

## In a pipeline

`examples/ix_pipeline_mesh_hub.rs` — `mesh_correlate` + a downstream `stats` stage, executed via `ix_pipeline::executor`:

```text
hub = 0; planted hub = 0  →  ✓ RECOVERED (centrality computed inside the executed pipeline)
```

Validated against a planted hub-and-spoke (hub bridges 3 orthogonal spokes; distractors isolated). The downstream `stats` stage consumes `mesh.centrality`, proving the mesh output flows on.

## Plumbing

- `#[ix_skill name="mesh_correlate"]` in batch2 + schema.
- **Parity bumped** (the cross-cutting bit): `ix_mesh_correlate` added to `EXPECTED`; counts 93→94 and 65→66. All 9 parity tests pass.
- Unit test `mesh_correlate_finds_hub` (planted hub-and-spoke → hub ranks highest).
- Docs EN + FR.

## Honest notes (in the docs)

- Streams are passed to `mesh_correlate` directly, not through N per-stream cond stages: the obvious cond (`autocorrelation`) **distorts** correlation — every ACF shares the lag-0 = 1 spike, so unrelated streams correlate (found while building). A correlation-preserving *identity* cond skill would restore the N-pipeline shape — a follow-up.
- This is **Option A** (mesh in one node), complementing #177's **Option C** (explicit 100+ node pairwise mesh). Together they show the tradeoff.

## Verification

- `cargo test -p ix-agent --test parity` → 9/9. `cargo test -p ix-agent --lib mesh_correlate` → pass.
- `cargo run -p ix-agent --example ix_pipeline_mesh_hub` → recovers the hub.
- `cargo clippy -p ix-agent` (lib + example) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
