### PR TITLE
fix(ix-duck): guard dev-rhythm + code-health demos for degenerate environments

### DIFF
--- a/crates/ix-duck/examples/ix_code_health.rs
+++ b/crates/ix-duck/examples/ix_code_health.rs
@@ -98,6 +98,16 @@ fn main() -> ix_duck::Result<()> {
         .iter()
         .map(|c| churn(&c.name) as f64 / (c.sloc / 1000.0).max(0.1))
         .collect();
+    // Without a usable git checkout (no `git`, or a shallow clone), `churn()` returns 0
+    // for every crate → a constant vector, on which Pearson is undefined and the
+    // permutation test is meaningless. Skip the validation with a clear note (Codex P2).
+    if churn_per_kloc.iter().all(|&c| c == churn_per_kloc[0]) {
+        println!(
+            "\nvalidation skipped — churn is constant across crates (no usable git history; \
+             run from a full clone with `git` on PATH)."
+        );
+        return Ok(());
+    }
     println!("\nvalidation — does code-health predict git churn (commits/KLOC)? [{NULLS} permutation nulls]");
     for (label, pred) in [
         ("mean cyclomatic", crates.iter().map(|c| c.mean_cc).collect::<Vec<_>>()),

--- a/crates/ix-duck/examples/ix_dev_rhythm.rs
+++ b/crates/ix-duck/examples/ix_dev_rhythm.rs
@@ -44,6 +44,18 @@ fn main() -> ix_duck::Result<()> {
     println!("IX dev rhythm — {} commits over {} types", seq.len(), m);
     println!("   commit-type counts: {}", fmt_counts(&marg));
 
+    // A shallow / single-commit checkout has no transitions: `seq.windows(2)` is empty,
+    // so the accuracy divisor is zero and every downstream statistic is NaN. Bail with a
+    // clear note rather than print garbage (Codex P2).
+    if seq.len() < 30 {
+        println!(
+            "\ninsufficient git history ({} commits) — this demo needs a full checkout. \
+             Run from a complete clone (not a shallow / `--depth 1` one).",
+            seq.len()
+        );
+        return Ok(());
+    }
+
     // ── 1. Markov chain + stationary distribution ────────────────────────────────
     let trans = transition_matrix(&seq, m);
     let chain = MarkovChain::new(trans.clone()).expect("row-stochastic");


### PR DESCRIPTION
## What

Addresses both Codex **P2**s from #175 (code-health) and #176 (dev-rhythm): in a shallow / no-git checkout, the demos computed statistics on degenerate inputs and printed misleading results. Now they bail with a clear note.

| Demo | Degenerate case | Before | After |
|---|---|---|---|
| `ix_dev_rhythm` | <30-commit / `--depth 1` checkout | `seq.windows(2)` empty → divisor 0 → NaN p-values | "insufficient git history — needs a full checkout" |
| `ix_code_health` | no `git` on PATH / shallow | churn = 0 for all crates → constant vector → Pearson undefined | "validation skipped — churn is constant (no usable git history)" |

## Verification

- Normal runs **unchanged**: `ix_dev_rhythm` → p=0.0005 (real structure); `ix_code_health` → still NOT predictive.
- `cargo clippy -p ix-duck --features duck --all-targets` → clean.

The demos are correct in their actual run environment (full clone); these guards just make the degenerate case honest instead of NaN/garbage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
