### PR TITLE
fix(ix-skill): bump skill-count oracle to 66 (mesh_correlate, #178)

### DIFF
--- a/crates/ix-skill/tests/cli.rs
+++ b/crates/ix-skill/tests/cli.rs
@@ -25,15 +25,15 @@ fn list_skills_returns_all_entries() {
     let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
     let value: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     let count = value["count"].as_u64().expect("count is number");
-    // 65 = batch1 (6 + pca + dbscan + eigen + silhouette + feature_importances +
+    // 66 = batch1 (6 + pca + dbscan + eigen + silhouette + feature_importances +
     // svd + gmm + wavelet_denoise + fir_filter + spectrogram + autocorrelation,
     // 2026-06-07 dogfood catalog-breadth + remaining-gap + gap-audit fixes) +
     // batch2 (28) + batch3 (10 + context.walk + session.flywheel_export +
     // fuzzy.eval) + prime_radiant (2) + assumption_graph (4: assumption.query +
     // .belief_at + .drift + .claims) + acoustic_tune (2: analyze_reference +
-    // spectral_distance, 2026-06-07).
+    // spectral_distance, 2026-06-07) + mesh_correlate (1, #178 2026-06-23).
     // If this drifts, update the assertion alongside the batch changes.
-    assert_eq!(count, 65, "expected 65 registry skills, got {count}");
+    assert_eq!(count, 66, "expected 66 registry skills, got {count}");
 }
 
 #[test]


### PR DESCRIPTION
## What

`main` is red on `build-and-test` (all combos): `crates/ix-skill/tests/cli.rs::list_skills_returns_all_entries` asserts **65** registry skills but the registry now has **66**.

```
assertion `left == right` failed: expected 65 registry skills, got 66
```

## Why

PR #178 (`mesh_correlate` skill) added a 66th registry skill but didn't bump this count oracle. This is the known count-oracle pattern — the assertion must move with registry additions.

## Fix

Bump the assertion `65 → 66` and note `mesh_correlate` in the breakdown comment. Verified locally: `cargo test -p ix-skill --test cli list_skills_returns_all_entries` passes.

Unblocks `main` and any branch cut from it (e.g. #180).

🤖 Generated with [Claude Code](https://claude.com/claude-code)